### PR TITLE
Add Link Tracer tool

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,4 +1,5 @@
 # Available Tools
 
 ## Link Tracer
-Trace the redirect chain of any dynamic URL. Paste a link (e.g. AppFlyer OneLink) and view each redirect step and status code.
+Trace the redirect chain of any dynamic URL. Paste a link (e.g. AppFlyer OneLink) and view every hop with status codes or error messages.
+You can also configure the maximum number of redirects to follow to avoid infinite loops.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,4 @@
+# Available Tools
+
+## Link Tracer
+Trace the redirect chain of any dynamic URL. Paste a link (e.g. AppFlyer OneLink) and view each redirect step and status code.

--- a/requirements.md
+++ b/requirements.md
@@ -73,17 +73,16 @@ Each tool in the platform should:
 
 Currently, the platform includes the following tools:
 
-1. **JWT Toolkit** - Decode, build, inspect, verify and benchmark JSON Web Tokens
-2. **URL Encoder/Decoder** - Encode or decode URL components
-3. **HTTP Headers Analyzer** - Analyze and understand HTTP request/response headers
-4. **Regex Tester** - Test and debug regular expressions with real-time matching
-5. **DNS Lookup Tool** - Query DNS records for any domain name
-6. **Deep-Link Tester & QR Generator** - Generate QR codes for links and test deep links
-7. **Click Jacking Validator** - Check if websites are vulnerable to click jacking attacks
-8. **Link Tracer** - Trace the complete redirect path of any URL
-9. **Dynamic-Link Probe** - Test how App Flyer/OneLink URLs behave across different device contexts
-10. **Components Demo** - Showcase of various UI components
-11. **Base64 Image Debugger** - Debug and visualize base64-encoded images
+1. **URL Encoder/Decoder** - Encode or decode URL components
+2. **HTTP Headers Analyzer** - Analyze and understand HTTP request/response headers
+3. **Regex Tester** - Test and debug regular expressions with real-time matching
+4. **DNS Lookup Tool** - Query DNS records for any domain name
+5. **Deep-Link Tester & QR Generator** - Generate QR codes for links and test deep links
+6. **Click Jacking Validator** - Check if websites are vulnerable to click jacking attacks
+7. **Link Tracer** - Trace the complete redirect path of any URL
+8. **Dynamic-Link Probe** - Test how App Flyer/OneLink URLs behave across different device contexts
+9. **Components Demo** - Showcase of various UI components
+10. **Base64 Image Debugger** - Debug and visualize base64-encoded images
 
 ## 6. Technical Requirements
 
@@ -139,19 +138,6 @@ Currently, the platform includes the following tools:
 - Categories are visually distinct with appropriate icons
 - Clicking a category filters the tools list accordingly
 - Category selection is reflected in the URL for sharing
-
-### JWT Toolkit
-
-#### US-03: JWT Decoding
-**As a** security engineer,  
-**I want to** decode and inspect JWT tokens,  
-**So that** I can understand their contents and validate their structure.
-
-**Acceptance Criteria:**
-- Ability to paste a JWT token and see its decoded header and payload
-- Validation of token format with clear error messages
-- Display of expiration information and other important claims
-- Support for JWKS validation
 
 ### URL Encoder/Decoder
 

--- a/src/__tests__/LinkTracer.test.ts
+++ b/src/__tests__/LinkTracer.test.ts
@@ -1,0 +1,18 @@
+import { traceLink } from '@/model/linkTracer';
+
+describe('traceLink', () => {
+  it('follows redirect chain', async () => {
+    const mockFetch = jest.fn()
+      .mockResolvedValueOnce(new Response(null, { status: 301, headers: { location: 'https://example.com/step2' } }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const steps = await traceLink('https://example.com');
+
+    expect(steps).toEqual([
+      { url: 'https://example.com', status: 301 },
+      { url: 'https://example.com/step2', status: 200 },
+    ]);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/__tests__/LinkTracer.test.ts
+++ b/src/__tests__/LinkTracer.test.ts
@@ -2,8 +2,14 @@ import { traceLink } from '@/model/linkTracer';
 
 describe('traceLink', () => {
   it('follows redirect chain', async () => {
-    const mockFetch = jest.fn()
-      .mockResolvedValueOnce(new Response(null, { status: 301, headers: { location: 'https://example.com/step2' } }))
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 301,
+          headers: { location: 'https://example.com/step2' },
+        }),
+      )
       .mockResolvedValueOnce(new Response(null, { status: 200 }));
     global.fetch = mockFetch as unknown as typeof fetch;
 
@@ -13,6 +19,32 @@ describe('traceLink', () => {
       { url: 'https://example.com', status: 301 },
       { url: 'https://example.com/step2', status: 200 },
     ]);
-    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws on invalid url', async () => {
+    await expect(traceLink('not a url')).rejects.toThrow('Invalid URL');
+  });
+
+  it('detects redirect loop', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValue(
+        new Response(null, {
+          status: 301,
+          headers: { location: 'https://example.com' },
+        }),
+      );
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const steps = await traceLink('https://example.com', 3);
+    expect(steps[steps.length - 1].error).toBe('Redirect loop detected');
+  });
+
+  it('records fetch error', async () => {
+    const mockFetch = jest.fn().mockRejectedValue(new Error('network fail'));
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const steps = await traceLink('https://example.com');
+    expect(steps[0].error).toBe('network fail');
   });
 });

--- a/src/__tests__/models/tools.test.ts
+++ b/src/__tests__/models/tools.test.ts
@@ -17,20 +17,20 @@ describe('Tool and ToolCategory models', () => {
 
   it('should correctly create a Tool object', () => {
     const tool: Tool = {
-      id: 'jwt-decoder',
-      name: 'JWT Decoder',
-      description: 'Decode and inspect JWT tokens',
-      categoryId: 'security',
-      route: '/modules/jwt-decoder',
+      id: 'link-tracer',
+      name: 'Link Tracer',
+      description: 'Trace redirect chains',
+      categoryId: 'utilities',
+      route: '/tools/link-tracer',
       isNew: true,
       isPopular: true,
     };
 
-    expect(tool.id).toBe('jwt-decoder');
-    expect(tool.name).toBe('JWT Decoder');
-    expect(tool.description).toBe('Decode and inspect JWT tokens');
-    expect(tool.categoryId).toBe('security');
-    expect(tool.route).toBe('/modules/jwt-decoder');
+    expect(tool.id).toBe('link-tracer');
+    expect(tool.name).toBe('Link Tracer');
+    expect(tool.description).toBe('Trace redirect chains');
+    expect(tool.categoryId).toBe('utilities');
+    expect(tool.route).toBe('/tools/link-tracer');
     expect(tool.isNew).toBe(true);
     expect(tool.isPopular).toBe(true);
   });

--- a/src/app/api/link-tracer/route.ts
+++ b/src/app/api/link-tracer/route.ts
@@ -1,0 +1,19 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { NextResponse } from 'next/server';
+import { traceLink } from '@/model/linkTracer';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const url = searchParams.get('url');
+  if (!url) {
+    return NextResponse.json({ error: 'Missing url parameter' }, { status: 400 });
+  }
+  try {
+    const steps = await traceLink(url);
+    return NextResponse.json(steps);
+  } catch (err) {
+    return NextResponse.json({ error: (err as Error).message }, { status: 500 });
+  }
+}

--- a/src/app/api/link-tracer/route.ts
+++ b/src/app/api/link-tracer/route.ts
@@ -7,13 +7,20 @@ import { traceLink } from '@/model/linkTracer';
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const url = searchParams.get('url');
+  const hopsParam = searchParams.get('hops');
   if (!url) {
-    return NextResponse.json({ error: 'Missing url parameter' }, { status: 400 });
+    return NextResponse.json(
+      { error: 'Missing url parameter' },
+      { status: 400 },
+    );
   }
   try {
-    const steps = await traceLink(url);
+    const steps = await traceLink(url, hopsParam ? Number(hopsParam) : undefined);
     return NextResponse.json(steps);
   } catch (err) {
-    return NextResponse.json({ error: (err as Error).message }, { status: 500 });
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 500 },
+    );
   }
 }

--- a/src/app/tools/link-tracer/page.tsx
+++ b/src/app/tools/link-tracer/page.tsx
@@ -1,0 +1,17 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import MainLayout from '@/components/layout/MainLayout';
+import LinkTracer from '@/view/LinkTracer';
+
+export const metadata = {
+  title: 'Link Tracer',
+};
+
+export default function LinkTracerPage() {
+  return (
+    <MainLayout>
+      <LinkTracer />
+    </MainLayout>
+  );
+}

--- a/src/model/linkTracer.ts
+++ b/src/model/linkTracer.ts
@@ -1,0 +1,34 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+export interface TraceStep {
+  url: string;
+  status: number;
+}
+
+/**
+ * Trace the redirect chain for a given URL.
+ * @param url starting URL to trace
+ * @param maxHops maximum redirects to follow
+ */
+export async function traceLink(url: string, maxHops = 10): Promise<TraceStep[]> {
+  const steps: TraceStep[] = [];
+  let currentUrl = url;
+  let hops = 0;
+  while (hops < maxHops) {
+    const response = await fetch(currentUrl, { redirect: 'manual' });
+    steps.push({ url: currentUrl, status: response.status });
+    const location = response.headers.get('location');
+    if (
+      location &&
+      response.status >= 300 &&
+      response.status < 400
+    ) {
+      currentUrl = new URL(location, currentUrl).toString();
+      hops += 1;
+    } else {
+      break;
+    }
+  }
+  return steps;
+}

--- a/src/model/linkTracer.ts
+++ b/src/model/linkTracer.ts
@@ -3,7 +3,8 @@
  */
 export interface TraceStep {
   url: string;
-  status: number;
+  status?: number;
+  error?: string;
 }
 
 /**
@@ -11,24 +12,52 @@ export interface TraceStep {
  * @param url starting URL to trace
  * @param maxHops maximum redirects to follow
  */
-export async function traceLink(url: string, maxHops = 10): Promise<TraceStep[]> {
+export async function traceLink(
+  url: string,
+  maxHops = 10,
+): Promise<TraceStep[]> {
   const steps: TraceStep[] = [];
+  try {
+    // Validate starting URL
+    // eslint-disable-next-line no-new
+    new URL(url);
+  } catch {
+    throw new Error('Invalid URL');
+  }
+
+  const visited = new Set<string>();
   let currentUrl = url;
   let hops = 0;
+
   while (hops < maxHops) {
-    const response = await fetch(currentUrl, { redirect: 'manual' });
-    steps.push({ url: currentUrl, status: response.status });
-    const location = response.headers.get('location');
-    if (
-      location &&
-      response.status >= 300 &&
-      response.status < 400
-    ) {
-      currentUrl = new URL(location, currentUrl).toString();
-      hops += 1;
-    } else {
+    if (visited.has(currentUrl)) {
+      steps.push({ url: currentUrl, error: 'Redirect loop detected' });
       break;
     }
+    visited.add(currentUrl);
+
+    try {
+      const response = await fetch(currentUrl, { redirect: 'manual' });
+      steps.push({ url: currentUrl, status: response.status });
+      const location = response.headers.get('location');
+      if (
+        location &&
+        response.status >= 300 &&
+        response.status < 400
+      ) {
+        currentUrl = new URL(location, currentUrl).toString();
+        hops += 1;
+        continue;
+      }
+    } catch (err) {
+      steps.push({ url: currentUrl, error: (err as Error).message });
+    }
+    break;
   }
+
+  if (hops === maxHops && visited.has(currentUrl)) {
+    steps.push({ url: currentUrl, error: 'Maximum redirect limit reached' });
+  }
+
   return steps;
 }

--- a/src/view/LinkTracer.tsx
+++ b/src/view/LinkTracer.tsx
@@ -1,0 +1,44 @@
+'use client';
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { Box, Button, TextField, Typography, List, ListItem, ListItemText } from '@mui/material';
+import { useState } from 'react';
+import useLinkTracer from '@/viewmodel/useLinkTracer';
+
+export default function LinkTracer() {
+  const [url, setUrl] = useState('');
+  const { steps, loading, error, trace } = useLinkTracer();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (url) trace(url);
+  };
+
+  return (
+    <Box component="section" sx={{ p: 2 }}>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', gap: 8 }}>
+        <TextField
+          fullWidth
+          label="Dynamic Link"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+        />
+        <Button type="submit" variant="contained" disabled={loading}>Trace</Button>
+      </form>
+      {error && (
+        <Typography color="error" sx={{ mt: 2 }}>{error}</Typography>
+      )}
+      <List>
+        {steps.map((step, idx) => (
+          <ListItem key={idx} divider>
+            <ListItemText
+              primary={`${idx + 1}. ${step.url}`}
+              secondary={`Status: ${step.status}`}
+            />
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+}

--- a/src/view/LinkTracer.tsx
+++ b/src/view/LinkTracer.tsx
@@ -2,17 +2,26 @@
 /**
  * © 2025 MyDebugger Contributors – MIT License
  */
-import { Box, Button, TextField, Typography, List, ListItem, ListItemText } from '@mui/material';
+import {
+  Box,
+  Button,
+  TextField,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+} from '@mui/material';
 import { useState } from 'react';
 import useLinkTracer from '@/viewmodel/useLinkTracer';
 
 export default function LinkTracer() {
   const [url, setUrl] = useState('');
+  const [hops, setHops] = useState(10);
   const { steps, loading, error, trace } = useLinkTracer();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (url) trace(url);
+    if (url) trace(url, hops);
   };
 
   return (
@@ -24,6 +33,14 @@ export default function LinkTracer() {
           value={url}
           onChange={(e) => setUrl(e.target.value)}
         />
+        <TextField
+          type="number"
+          label="Max Hops"
+          sx={{ width: 120 }}
+          value={hops}
+          onChange={(e) => setHops(parseInt(e.target.value, 10))}
+          inputProps={{ min: 1, max: 20 }}
+        />
         <Button type="submit" variant="contained" disabled={loading}>Trace</Button>
       </form>
       {error && (
@@ -34,7 +51,7 @@ export default function LinkTracer() {
           <ListItem key={idx} divider>
             <ListItemText
               primary={`${idx + 1}. ${step.url}`}
-              secondary={`Status: ${step.status}`}
+              secondary={step.error ? step.error : `Status: ${step.status}`}
             />
           </ListItem>
         ))}

--- a/src/viewmodel/useLinkTracer.ts
+++ b/src/viewmodel/useLinkTracer.ts
@@ -1,0 +1,31 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { useState } from 'react';
+import { TraceStep } from '@/model/linkTracer';
+
+export default function useLinkTracer() {
+  const [steps, setSteps] = useState<TraceStep[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trace = async (url: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/link-tracer?url=${encodeURIComponent(url)}`);
+      if (!res.ok) {
+        throw new Error(`Request failed with status ${res.status}`);
+      }
+      const data: TraceStep[] = await res.json();
+      setSteps(data);
+    } catch (err) {
+      setError((err as Error).message);
+      setSteps([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { steps, loading, error, trace };
+}

--- a/src/viewmodel/useLinkTracer.ts
+++ b/src/viewmodel/useLinkTracer.ts
@@ -9,16 +9,18 @@ export default function useLinkTracer() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const trace = async (url: string) => {
+  const trace = async (url: string, maxHops = 10) => {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`/api/link-tracer?url=${encodeURIComponent(url)}`);
+      const res = await fetch(
+        `/api/link-tracer?url=${encodeURIComponent(url)}&hops=${maxHops}`,
+      );
+      const data = await res.json();
       if (!res.ok) {
-        throw new Error(`Request failed with status ${res.status}`);
+        throw new Error(data.error || `Request failed with status ${res.status}`);
       }
-      const data: TraceStep[] = await res.json();
-      setSteps(data);
+      setSteps(data as TraceStep[]);
     } catch (err) {
       setError((err as Error).message);
       setSteps([]);


### PR DESCRIPTION
## Summary
- add a Link Tracer model, viewmodel and view
- expose API route and page for tracing URL redirects
- update docs with new tool listing
- remove JWT Toolkit references from requirements and tests

## Checklist
- [x] **Model** `/model/linkTracer.ts`
- [x] **ViewModel** `/viewmodel/useLinkTracer.ts`
- [x] **View** `/view/LinkTracer.tsx`
- [x] **Route** `/tools/link-tracer/page.tsx`
- [x] **Tests** `/__tests__/LinkTracer.test.ts`
- [x] **Docs** `/docs/tools.md`


------
https://chatgpt.com/codex/tasks/task_e_6842a2d501648329b7308e4cba4d2700