### PR TITLE
Restore available tools view

### DIFF
--- a/src/__tests__/components/ui/HeroSection.test.tsx
+++ b/src/__tests__/components/ui/HeroSection.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import HeroSection from '@/components/ui/HeroSection';
+import '@testing-library/jest-dom';
+
+describe('HeroSection', () => {
+  it('renders the hero title', () => {
+    render(
+      <HeroSection
+        searchQuery=""
+        onSearchChange={() => {}}
+      />
+    );
+    
+    const titleElement = screen.getByText(/MyDebugger/i);
+    expect(titleElement).toBeInTheDocument();
+  });
+
+  it('renders the search box with correct placeholder', () => {
+    render(
+      <HeroSection
+        searchQuery=""
+        onSearchChange={() => {}}
+      />
+    );
+    
+    const searchBox = screen.getByPlaceholderText(/Search tools.../i);
+    expect(searchBox).toBeInTheDocument();
+  });
+
+  it('calls the onSearchChange handler when typing in the search box', () => {
+    const mockOnSearchChange = jest.fn();
+    
+    render(
+      <HeroSection
+        searchQuery=""
+        onSearchChange={mockOnSearchChange}
+      />
+    );
+    
+    const searchBox = screen.getByPlaceholderText(/Search tools.../i);
+    searchBox.focus();
+    searchBox.value = 'jwt';
+    searchBox.dispatchEvent(new Event('input', { bubbles: true }));
+    
+    expect(mockOnSearchChange).toHaveBeenCalledWith('jwt');
+  });
+});

--- a/src/__tests__/components/ui/ToolCard.test.tsx
+++ b/src/__tests__/components/ui/ToolCard.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ToolCard from '@/components/ui/ToolCard';
+import { Tool } from '@/models';
+
+describe('ToolCard', () => {
+  const tool: Tool = {
+    id: 'link-tracer',
+    name: 'Link Tracer',
+    description: 'Trace the complete redirect path of any URL.',
+    categoryId: 'utilities',
+    route: '/tools/link-tracer',
+  };
+
+  it('renders tool name and description', () => {
+    render(<ToolCard tool={tool} />);
+    expect(screen.getByText(/Link Tracer/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Trace the complete redirect path of any URL./i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/models/tools.test.ts
+++ b/src/__tests__/models/tools.test.ts
@@ -17,20 +17,20 @@ describe('Tool and ToolCategory models', () => {
 
   it('should correctly create a Tool object', () => {
     const tool: Tool = {
-      id: 'link-tracer',
-      name: 'Link Tracer',
-      description: 'Trace redirect chains',
-      categoryId: 'utilities',
-      route: '/tools/link-tracer',
+      id: 'jwt-decoder',
+      name: 'JWT Decoder',
+      description: 'Decode and inspect JWT tokens',
+      categoryId: 'security',
+      route: '/modules/jwt-decoder',
       isNew: true,
       isPopular: true,
     };
 
-    expect(tool.id).toBe('link-tracer');
-    expect(tool.name).toBe('Link Tracer');
-    expect(tool.description).toBe('Trace redirect chains');
-    expect(tool.categoryId).toBe('utilities');
-    expect(tool.route).toBe('/tools/link-tracer');
+    expect(tool.id).toBe('jwt-decoder');
+    expect(tool.name).toBe('JWT Decoder');
+    expect(tool.description).toBe('Decode and inspect JWT tokens');
+    expect(tool.categoryId).toBe('security');
+    expect(tool.route).toBe('/modules/jwt-decoder');
     expect(tool.isNew).toBe(true);
     expect(tool.isPopular).toBe(true);
   });

--- a/src/__tests__/viewmodels/useHomeViewModel.test.ts
+++ b/src/__tests__/viewmodels/useHomeViewModel.test.ts
@@ -1,0 +1,26 @@
+import { renderHook, act } from '@testing-library/react';
+import { useHomeViewModel } from '@/viewmodel';
+
+describe('useHomeViewModel', () => {
+  it('should initialize with empty search query and all tools', () => {
+    const { result } = renderHook(() => useHomeViewModel());
+
+    expect(result.current.searchQuery).toBe('');
+    expect(result.current.filteredTools.length).toBeGreaterThan(0);
+  });
+
+  it('should update search query and filter tools', () => {
+    const { result } = renderHook(() => useHomeViewModel());
+
+    act(() => {
+      result.current.setSearchQuery('link');
+    });
+
+    expect(result.current.searchQuery).toBe('link');
+    expect(
+      result.current.filteredTools.every((tool) =>
+        tool.name.toLowerCase().includes('link'),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,22 +4,24 @@
  * © 2025 MyDebugger Contributors – MIT License
  */
 
-import { Box, Typography, Container } from '@mui/material';
+import { Box } from '@mui/material';
+import HeroSection from '@/components/ui/HeroSection';
+import ToolsSection from '@/components/ui/ToolsSection';
 import MainLayout from '@/components/layout/MainLayout';
+import { useHomeViewModel } from '@/viewmodel';
 
 export default function HomePage() {
+  const { searchQuery, setSearchQuery, filteredTools } = useHomeViewModel();
+
   return (
     <MainLayout>
-      <Container maxWidth="md">
-        <Box sx={{ my: 8, textAlign: 'center' }}>
-          <Typography variant="h3" component="h1" gutterBottom>
-            MyDebugger
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Developer tools coming soon.
-          </Typography>
-        </Box>
-      </Container>
+      <Box>
+        <HeroSection
+          searchQuery={searchQuery}
+          onSearchChange={setSearchQuery}
+        />
+        <ToolsSection tools={filteredTools} />
+      </Box>
     </MainLayout>
   );
 }

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
 import { useState } from 'react';
 import {
   AppBar,
@@ -19,6 +23,7 @@ import {
 } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import HomeIcon from '@mui/icons-material/Home';
+import InfoIcon from '@mui/icons-material/Info';
 import BugReportIcon from '@mui/icons-material/BugReport';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
@@ -61,6 +66,9 @@ export default function NavBar() {
               {mode === 'light' ? <Brightness4Icon /> : <Brightness7Icon />}
             </IconButton>
           </Tooltip>
+          <Button color="inherit" component={Link} href="/modules" sx={{ mr: 1 }}>
+            Tools
+          </Button>
           <Button color="inherit" component={Link} href="/about">
             About
           </Button>
@@ -91,6 +99,12 @@ export default function NavBar() {
               </ListItemButton>
             </ListItem>
             <ListItem disablePadding>
+              <ListItemButton component={Link} href="/about">
+                <ListItemIcon>
+                  <InfoIcon />
+                </ListItemIcon>
+                <ListItemText primary="About" />
+              </ListItemButton>
             </ListItem>
           </List>
           <Divider />
@@ -98,14 +112,30 @@ export default function NavBar() {
               variant="subtitle2"
               sx={{ px: 2, pt: 2, pb: 1, fontWeight: 'bold' }}
             >
-              Tool Categories
+              Tool Categories (Coming Soon)
             </Typography>
             <ListItem disablePadding>
-                <ListItemText 
-                  primary="More categories coming soon." 
-                  sx={{ px:2, py:1 }} 
-                  primaryTypographyProps={{variant: 'caption', color: 'textSecondary'}}
-                />
+              <ListItemButton disabled>
+                <ListItemIcon>
+                  <BugReportIcon />
+                </ListItemIcon>
+                <ListItemText primary="Encoding" />
+              </ListItemButton>
+            </ListItem>
+            <ListItem disablePadding>
+              <ListItemButton disabled>
+                <ListItemIcon>
+                  <BugReportIcon />
+                </ListItemIcon>
+                <ListItemText primary="Security" />
+              </ListItemButton>
+            </ListItem>
+            <ListItem disablePadding>              <ListItemButton disabled>
+                <ListItemIcon>
+                  <BugReportIcon />
+                </ListItemIcon>
+                <ListItemText primary="Testing" />
+              </ListItemButton>
             </ListItem>
           </List>
         </Box>

--- a/src/components/ui/HeroSection.tsx
+++ b/src/components/ui/HeroSection.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+import {
+  Box,
+  Typography,
+  TextField,
+  InputAdornment,
+  Container,
+  Paper,
+  Button,
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+
+interface HeroSectionProps {
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+}
+
+export default function HeroSection({ searchQuery, onSearchChange }: HeroSectionProps) {
+  return (
+    <Box
+      sx={{
+        bgcolor: 'background.paper',
+        pt: 6,
+        pb: 6,
+      }}
+    >
+      <Container maxWidth="lg">
+        <Paper
+          elevation={0}
+          sx={{
+            p: 4,
+            borderRadius: 2,
+            textAlign: 'center',
+            backgroundColor: 'transparent',
+          }}
+        >
+          <Typography
+            component="h1"
+            variant="h2"
+            align="center"
+            color="primary"
+            fontWeight="bold"
+            gutterBottom
+          >
+            MyDebugger
+          </Typography>
+          <Typography
+            variant="h5"
+            align="center"
+            color="text.secondary"
+            sx={{ mb: 4 }}
+          >
+            Your comprehensive toolkit for web and app debugging
+          </Typography>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: { xs: 'column', sm: 'row' },
+              justifyContent: 'center',
+              gap: 2,
+              maxWidth: 600,
+              mx: 'auto',
+            }}
+          >
+            <TextField
+              fullWidth
+              placeholder="Search tools..."
+              value={searchQuery}
+              onChange={(e) => onSearchChange(e.target.value)}
+              sx={{ flexGrow: 1 }}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon />
+                  </InputAdornment>
+                ),
+              }}
+            />
+            <Button variant="contained" color="primary" sx={{ px: 4 }}>
+              Search
+            </Button>
+          </Box>
+        </Paper>
+      </Container>
+    </Box>
+  );
+}

--- a/src/components/ui/ToolCard.tsx
+++ b/src/components/ui/ToolCard.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+import Link from 'next/link';
+import {
+  Card,
+  CardContent,
+  CardActions,
+  Button,
+  Typography,
+} from '@mui/material';
+import { Tool } from '@/models';
+
+interface ToolCardProps {
+  tool: Tool;
+}
+
+export default function ToolCard({ tool }: ToolCardProps) {
+  return (
+    <Card
+      variant="outlined"
+      sx={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <CardContent sx={{ flexGrow: 1 }}>
+        <Typography component="h3" variant="h6" gutterBottom>
+          {tool.name}
+        </Typography>
+        <Typography color="text.secondary">{tool.description}</Typography>
+      </CardContent>
+      <CardActions>
+        <Button
+          component={Link}
+          href={tool.route}
+          size="small"
+          variant="contained"
+          color="primary"
+        >
+          Open
+        </Button>
+      </CardActions>
+    </Card>
+  );
+}

--- a/src/components/ui/ToolsSection.tsx
+++ b/src/components/ui/ToolsSection.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+import { Box, Container, Grid, Typography } from '@mui/material';
+import ToolCard from './ToolCard';
+import { Tool } from '@/models';
+
+interface ToolsSectionProps {
+  tools: Tool[];
+}
+
+export default function ToolsSection({ tools }: ToolsSectionProps) {
+  return (
+    <Box sx={{ py: 6 }}>
+      <Container maxWidth="lg">
+        <Typography component="h2" variant="h4" align="center" gutterBottom>
+          Available Tools
+        </Typography>
+        <Grid container spacing={4} sx={{ mt: 2 }}>
+          {tools.map((tool) => (
+            <Grid key={tool.id} item xs={12} sm={6} md={4}>
+              <ToolCard tool={tool} />
+            </Grid>
+          ))}
+        </Grid>
+      </Container>
+    </Box>
+  );
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,4 +1,8 @@
 /**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+/**
  * Export all models
  */
 export * from './tools';

--- a/src/models/tools.ts
+++ b/src/models/tools.ts
@@ -1,4 +1,8 @@
 /**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+/**
  * Model representing a tool category
  */
 export interface ToolCategory {
@@ -20,3 +24,17 @@ export interface Tool {
   isNew?: boolean;
   isPopular?: boolean;
 }
+
+/**
+ * List of currently available tools in the application
+ */
+export const availableTools: Tool[] = [
+  {
+    id: 'link-tracer',
+    name: 'Link Tracer',
+    description: 'Trace the complete redirect path of any URL.',
+    categoryId: 'utilities',
+    route: '/tools/link-tracer',
+    isNew: true,
+  },
+];

--- a/src/viewmodel/index.ts
+++ b/src/viewmodel/index.ts
@@ -1,0 +1,9 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+/**
+ * Export all viewmodels
+ */
+export * from './useHomeViewModel';
+export { default as useLinkTracer } from './useLinkTracer';

--- a/src/viewmodel/useHomeViewModel.ts
+++ b/src/viewmodel/useHomeViewModel.ts
@@ -1,0 +1,27 @@
+'use client';
+
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+import { useState, useMemo } from 'react';
+import { Tool, availableTools } from '@/models';
+
+export function useHomeViewModel() {
+  const [searchQuery, setSearchQuery] = useState('');
+  const filteredTools = useMemo(() => {
+    if (!searchQuery) return availableTools;
+    const query = searchQuery.toLowerCase();
+    return availableTools.filter(
+      (tool) =>
+        tool.name.toLowerCase().includes(query) ||
+        tool.description.toLowerCase().includes(query),
+    );
+  }, [searchQuery]);
+
+  return {
+    searchQuery,
+    setSearchQuery,
+    filteredTools,
+  };
+}


### PR DESCRIPTION
## Summary
- list actual tools on the home page via new ToolsSection component
- add ToolCard component for individual tool display
- store available tools in the models layer
- simplify Home view model with search filtering
- update unit tests for new components and view model
- remove ComingSoonSection

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing type declarations)*
- `npm test` *(fails: jest permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6842cf23eadc832984dbe4e77807345a