### PR TITLE
Improve home UI showcase

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,5 +1,22 @@
 # Available Tools
 
 ## Link Tracer
+
 Trace the redirect chain of any dynamic URL. Paste a link (e.g. AppFlyer OneLink) and view every hop with status codes or error messages.
 You can also configure the maximum number of redirects to follow to avoid infinite loops.
+
+## URL Encoder/Decoder
+
+Quickly encode or decode URL components without leaving the page.
+
+## HTTP Headers Analyzer
+
+Inspect HTTP response headers and understand their meaning.
+
+## Regex Tester
+
+Experiment with regular expressions using instant feedback.
+
+## Base64 Image Debugger
+
+Paste a base64 string and immediately preview the decoded image.

--- a/src/__tests__/components/ui/HeroSection.test.tsx
+++ b/src/__tests__/components/ui/HeroSection.test.tsx
@@ -1,48 +1,35 @@
-import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
-import HeroSection from '@/components/ui/HeroSection';
-import '@testing-library/jest-dom';
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import HeroSection from "@/components/ui/HeroSection";
+import "@testing-library/jest-dom";
 
-describe('HeroSection', () => {
-  it('renders the hero title', () => {
-    render(
-      <HeroSection
-        searchQuery=""
-        onSearchChange={() => {}}
-      />
-    );
-    
+describe("HeroSection", () => {
+  it("renders the hero title", () => {
+    render(<HeroSection searchQuery="" onSearchChange={() => {}} />);
+
     const titleElement = screen.getByText(/MyDebugger/i);
     expect(titleElement).toBeInTheDocument();
+    expect(
+      screen.getByText(/open-source toolbox for web & mobile developers/i),
+    ).toBeInTheDocument();
   });
 
-  it('renders the search box with correct placeholder', () => {
-    render(
-      <HeroSection
-        searchQuery=""
-        onSearchChange={() => {}}
-      />
-    );
-    
+  it("renders the search box with correct placeholder", () => {
+    render(<HeroSection searchQuery="" onSearchChange={() => {}} />);
+
     const searchBox = screen.getByPlaceholderText(/Search tools.../i);
     expect(searchBox).toBeInTheDocument();
   });
 
-  it('calls the onSearchChange handler when typing in the search box', () => {
+  it("calls the onSearchChange handler when typing in the search box", () => {
     const mockOnSearchChange = jest.fn();
-    
-    render(
-      <HeroSection
-        searchQuery=""
-        onSearchChange={mockOnSearchChange}
-      />
-    );
-    
-    const searchBox = screen.getByPlaceholderText<HTMLInputElement>(
-      /Search tools.../i,
-    );
-    fireEvent.change(searchBox, { target: { value: 'jwt' } });
-    
-    expect(mockOnSearchChange).toHaveBeenCalledWith('jwt');
+
+    render(<HeroSection searchQuery="" onSearchChange={mockOnSearchChange} />);
+
+    const searchBox =
+      screen.getByPlaceholderText<HTMLInputElement>(/Search tools.../i);
+    fireEvent.change(searchBox, { target: { value: "jwt" } });
+
+    expect(mockOnSearchChange).toHaveBeenCalledWith("jwt");
   });
 });

--- a/src/__tests__/components/ui/ToolCard.test.tsx
+++ b/src/__tests__/components/ui/ToolCard.test.tsx
@@ -1,23 +1,26 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
-import ToolCard from '@/components/ui/ToolCard';
-import { Tool } from '@/models';
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import ToolCard from "@/components/ui/ToolCard";
+import { Tool } from "@/models";
 
-describe('ToolCard', () => {
+describe("ToolCard", () => {
   const tool: Tool = {
-    id: 'link-tracer',
-    name: 'Link Tracer',
-    description: 'Trace the complete redirect path of any URL.',
-    categoryId: 'utilities',
-    route: '/tools/link-tracer',
+    id: "link-tracer",
+    name: "Link Tracer",
+    description: "Trace the complete redirect path of any URL.",
+    categoryId: "utilities",
+    route: "/tools/link-tracer",
+    icon: "🔗",
+    isNew: true,
   };
 
-  it('renders tool name and description', () => {
+  it("renders tool name and description", () => {
     render(<ToolCard tool={tool} />);
     expect(screen.getByText(/Link Tracer/i)).toBeInTheDocument();
     expect(
       screen.getByText(/Trace the complete redirect path of any URL./i),
     ).toBeInTheDocument();
+    expect(screen.getByText("New")).toBeInTheDocument();
   });
 });

--- a/src/__tests__/models/tools.test.ts
+++ b/src/__tests__/models/tools.test.ts
@@ -1,36 +1,38 @@
-import { ToolCategory, Tool } from '@/models';
+import { ToolCategory, Tool } from "@/models";
 
-describe('Tool and ToolCategory models', () => {
-  it('should correctly create a ToolCategory object', () => {
+describe("Tool and ToolCategory models", () => {
+  it("should correctly create a ToolCategory object", () => {
     const category: ToolCategory = {
-      id: 'encoding',
-      name: 'Encoding Tools',
-      description: 'Tools for encoding and decoding data',
-      icon: 'encode',
+      id: "encoding",
+      name: "Encoding Tools",
+      description: "Tools for encoding and decoding data",
+      icon: "encode",
     };
 
-    expect(category.id).toBe('encoding');
-    expect(category.name).toBe('Encoding Tools');
-    expect(category.description).toBe('Tools for encoding and decoding data');
-    expect(category.icon).toBe('encode');
+    expect(category.id).toBe("encoding");
+    expect(category.name).toBe("Encoding Tools");
+    expect(category.description).toBe("Tools for encoding and decoding data");
+    expect(category.icon).toBe("encode");
   });
 
-  it('should correctly create a Tool object', () => {
+  it("should correctly create a Tool object", () => {
     const tool: Tool = {
-      id: 'jwt-decoder',
-      name: 'JWT Decoder',
-      description: 'Decode and inspect JWT tokens',
-      categoryId: 'security',
-      route: '/modules/jwt-decoder',
+      id: "jwt-decoder",
+      name: "JWT Decoder",
+      description: "Decode and inspect JWT tokens",
+      categoryId: "security",
+      route: "/modules/jwt-decoder",
+      icon: "🔐",
       isNew: true,
       isPopular: true,
     };
 
-    expect(tool.id).toBe('jwt-decoder');
-    expect(tool.name).toBe('JWT Decoder');
-    expect(tool.description).toBe('Decode and inspect JWT tokens');
-    expect(tool.categoryId).toBe('security');
-    expect(tool.route).toBe('/modules/jwt-decoder');
+    expect(tool.id).toBe("jwt-decoder");
+    expect(tool.name).toBe("JWT Decoder");
+    expect(tool.description).toBe("Decode and inspect JWT tokens");
+    expect(tool.categoryId).toBe("security");
+    expect(tool.route).toBe("/modules/jwt-decoder");
+    expect(tool.icon).toBe("🔐");
     expect(tool.isNew).toBe(true);
     expect(tool.isPopular).toBe(true);
   });

--- a/src/components/ui/HeroSection.tsx
+++ b/src/components/ui/HeroSection.tsx
@@ -1,40 +1,56 @@
-'use client';
+"use client";
 
 /**
  * © 2025 MyDebugger Contributors – MIT License
  */
 
-import { ChangeEvent } from 'react';
+import { ChangeEvent, FormEvent } from "react";
 
 interface HeroSectionProps {
   searchQuery: string;
   onSearchChange: (query: string) => void;
 }
 
-export default function HeroSection({ searchQuery, onSearchChange }: HeroSectionProps) {
+export default function HeroSection({
+  searchQuery,
+  onSearchChange,
+}: HeroSectionProps) {
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     onSearchChange(e.target.value);
   };
 
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+  };
+
   return (
-    <section className="bg-white py-6 dark:bg-gray-800">
+    <section className="bg-gradient-to-r from-blue-50 to-blue-100 py-10 dark:from-gray-800 dark:to-gray-900">
       <div className="mx-auto max-w-6xl px-4 text-center">
-        <h1 className="text-4xl font-bold text-blue-600">MyDebugger</h1>
-        <p className="mb-4 mt-2 text-lg text-gray-600 dark:text-gray-300">
-          Your comprehensive toolkit for web and app debugging
+        <h1 className="text-5xl font-extrabold text-blue-700 dark:text-blue-400">
+          MyDebugger
+        </h1>
+        <p className="mb-6 mt-3 text-lg text-gray-700 dark:text-gray-300">
+          A modern, open-source toolbox for web & mobile developers
         </p>
-        <div className="mx-auto flex max-w-xl flex-col gap-2 sm:flex-row">
+        <form
+          onSubmit={handleSubmit}
+          className="mx-auto flex max-w-xl flex-col gap-3 sm:flex-row"
+        >
           <input
             type="text"
             value={searchQuery}
             onChange={handleChange}
             placeholder="Search tools..."
-            className="flex-grow rounded border border-gray-300 px-3 py-2 dark:bg-gray-700 dark:text-white"
+            className="flex-grow rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring dark:bg-gray-700 dark:text-white"
+            aria-label="search tools"
           />
-          <button className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700">
+          <button
+            type="submit"
+            className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:outline-none focus:ring"
+          >
             Search
           </button>
-        </div>
+        </form>
       </div>
     </section>
   );

--- a/src/components/ui/ToolCard.tsx
+++ b/src/components/ui/ToolCard.tsx
@@ -1,11 +1,11 @@
-'use client';
+"use client";
 
 /**
  * © 2025 MyDebugger Contributors – MIT License
  */
 
-import Link from 'next/link';
-import { Tool } from '@/models';
+import Link from "next/link";
+import { Tool } from "@/models";
 
 interface ToolCardProps {
   tool: Tool;
@@ -13,15 +13,34 @@ interface ToolCardProps {
 
 export default function ToolCard({ tool }: ToolCardProps) {
   return (
-    <div className="flex h-full flex-col rounded-md border border-gray-300 p-4">
+    <div className="flex h-full flex-col rounded-md border border-gray-300 p-4 shadow-sm hover:shadow-md transition-shadow">
       <div className="flex-grow">
-        <h3 className="mb-2 text-lg font-semibold">{tool.name}</h3>
-        <p className="text-sm text-gray-600">{tool.description}</p>
+        <div className="flex items-center gap-2">
+          {tool.icon && (
+            <span aria-hidden className="text-2xl">
+              {tool.icon}
+            </span>
+          )}
+          <h3 className="text-lg font-semibold">{tool.name}</h3>
+          {tool.isNew && (
+            <span className="rounded bg-green-600 px-1.5 py-0.5 text-xs text-white">
+              New
+            </span>
+          )}
+          {tool.isPopular && (
+            <span className="rounded bg-purple-600 px-1.5 py-0.5 text-xs text-white">
+              Popular
+            </span>
+          )}
+        </div>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+          {tool.description}
+        </p>
       </div>
       <div className="mt-4">
         <Link
           href={tool.route}
-          className="rounded bg-blue-600 px-3 py-1 text-white hover:bg-blue-700"
+          className="rounded bg-blue-600 px-3 py-1 text-white hover:bg-blue-700 focus:outline-none focus:ring"
         >
           Open
         </Link>

--- a/src/components/ui/ToolsSection.tsx
+++ b/src/components/ui/ToolsSection.tsx
@@ -16,11 +16,17 @@ export default function ToolsSection({ tools }: ToolsSectionProps) {
     <section id="tools" className="py-6">
       <div className="mx-auto max-w-6xl px-4">
         <h2 className="text-center text-2xl font-semibold">Available Tools</h2>
-        <div className="mt-4 grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-          {tools.map((tool) => (
-            <ToolCard key={tool.id} tool={tool} />
-          ))}
-        </div>
+        {tools.length === 0 ? (
+          <p className="mt-4 text-center text-gray-600 dark:text-gray-300">
+            No tools found.
+          </p>
+        ) : (
+          <div className="mt-4 grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+            {tools.map((tool) => (
+              <ToolCard key={tool.id} tool={tool} />
+            ))}
+          </div>
+        )}
       </div>
     </section>
   );

--- a/src/models/tools.ts
+++ b/src/models/tools.ts
@@ -21,6 +21,8 @@ export interface Tool {
   description: string;
   categoryId: string;
   route: string;
+  /** optional emoji or icon name */
+  icon?: string;
   isNew?: boolean;
   isPopular?: boolean;
 }
@@ -30,11 +32,44 @@ export interface Tool {
  */
 export const availableTools: Tool[] = [
   {
-    id: 'link-tracer',
-    name: 'Link Tracer',
-    description: 'Trace the complete redirect path of any URL.',
-    categoryId: 'utilities',
-    route: '/tools/link-tracer',
+    id: "link-tracer",
+    name: "Link Tracer",
+    description: "Trace the complete redirect path of any URL.",
+    categoryId: "utilities",
+    route: "/tools/link-tracer",
     isNew: true,
+  },
+  {
+    id: "url-encoder",
+    name: "URL Encoder/Decoder",
+    description: "Encode or decode URL components easily.",
+    categoryId: "utilities",
+    route: "/tools/url-encoder",
+    icon: "🔗",
+    isPopular: true,
+  },
+  {
+    id: "headers-analyzer",
+    name: "HTTP Headers Analyzer",
+    description: "Inspect and validate HTTP response headers.",
+    categoryId: "security",
+    route: "/tools/headers-analyzer",
+    icon: "📊",
+  },
+  {
+    id: "regex-tester",
+    name: "Regex Tester",
+    description: "Test regular expressions in real time.",
+    categoryId: "testing",
+    route: "/tools/regex-tester",
+    icon: "🔍",
+  },
+  {
+    id: "base64-image-debugger",
+    name: "Base64 Image Debugger",
+    description: "Decode and preview base64 encoded images.",
+    categoryId: "formatters",
+    route: "/tools/base64-image-debugger",
+    icon: "🖼️",
   },
 ];


### PR DESCRIPTION
## Summary
- show gradient hero with tagline and search form
- add icons and badges for ToolCard
- show `No tools found` message if search yields none
- list more tools in docs
- update tests for components and models

## Testing
- `npm run lint` *(fails: Cannot find module './dom.asynciterable')*
- `npm run typecheck`
- `npm test` *(fails: Cannot find module './util')*

------
https://chatgpt.com/codex/tasks/task_e_68432238bcb883298b07c3bbedba06a6