### PR TITLE
Apply design system across pages

### DIFF
--- a/src/__tests__/components/ui/LinkButton.test.tsx
+++ b/src/__tests__/components/ui/LinkButton.test.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import LinkButton from "@/view/ui/LinkButton";
+
+describe("LinkButton", () => {
+  it("renders link", () => {
+    render(<LinkButton href="/test">Test</LinkButton>);
+    const link = screen.getByRole("link", { name: /test/i });
+    expect(link).toBeInTheDocument();
+  });
+});

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import MainLayout from '@/components/layout/MainLayout';
-import Link from 'next/link';
+import { LinkButton } from '@/view/ui';
 
 export default function NotFound() {
   return (
@@ -15,12 +15,10 @@ export default function NotFound() {
           or is temporarily unavailable.
         </p>
         <div className="flex justify-center gap-2">
-          <Link href="/" className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700">
-            Go to Homepage
-          </Link>
-          <Link href="/modules" className="rounded border border-blue-600 px-4 py-2 text-blue-600 hover:bg-blue-50">
+          <LinkButton href="/">Go to Homepage</LinkButton>
+          <LinkButton href="/modules" variant="secondary">
             Browse Tools
-          </Link>
+          </LinkButton>
         </div>
       </div>
     </MainLayout>

--- a/src/components/layout/ErrorBoundary.tsx
+++ b/src/components/layout/ErrorBoundary.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { Component, ErrorInfo, ReactNode } from 'react';
-import Link from 'next/link';
-import { Button } from '@/view/ui';
+import { Button, LinkButton } from '@/view/ui';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -66,9 +65,9 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
           </pre>
           <div className="flex justify-center gap-2">
             <Button onClick={this.handleReset}>Try Again</Button>
-            <Link href="/" className="rounded border border-blue-600 px-3 py-1 text-blue-600 hover:bg-blue-50">
+            <LinkButton href="/" variant="secondary">
               Go to Homepage
-            </Link>
+            </LinkButton>
           </div>
         </div>
       );

--- a/src/view/ui/Button.tsx
+++ b/src/view/ui/Button.tsx
@@ -17,6 +17,34 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   loading?: boolean;
 }
 
+export const buttonBase =
+  "inline-flex items-center justify-center rounded font-medium focus:outline-none focus:ring transition-colors";
+
+export const buttonVariants: Record<ButtonVariant, string> = {
+  primary:
+    "bg-blue-600 text-white hover:bg-blue-700 disabled:bg-blue-400 dark:bg-blue-500 hc:bg-black hc:text-white",
+  secondary:
+    "bg-gray-200 text-gray-900 hover:bg-gray-300 dark:bg-gray-700 dark:text-white hc:bg-black hc:text-white",
+  ghost:
+    "bg-transparent hover:bg-gray-100 dark:hover:bg-gray-800 hc:bg-black hc:text-white",
+  danger:
+    "bg-red-600 text-white hover:bg-red-700 disabled:bg-red-400 hc:bg-black hc:text-white",
+};
+
+export const buttonSizes: Record<ButtonSize, string> = {
+  sm: "px-2 py-1 text-sm",
+  md: "px-3 py-1.5 text-base",
+  lg: "px-4 py-2 text-lg",
+};
+
+export function getButtonClasses(
+  variant: ButtonVariant = "primary",
+  size: ButtonSize = "md",
+  className?: string,
+) {
+  return clsx(buttonBase, buttonVariants[variant], buttonSizes[size], className);
+}
+
 export default function Button({
   children,
   variant = "primary",
@@ -26,27 +54,9 @@ export default function Button({
   className,
   ...rest
 }: ButtonProps) {
-  const base =
-    "inline-flex items-center justify-center rounded font-medium focus:outline-none focus:ring transition-colors";
-  const variants: Record<ButtonVariant, string> = {
-    primary:
-      "bg-blue-600 text-white hover:bg-blue-700 disabled:bg-blue-400 dark:bg-blue-500 hc:bg-black hc:text-white",
-    secondary:
-      "bg-gray-200 text-gray-900 hover:bg-gray-300 dark:bg-gray-700 dark:text-white hc:bg-black hc:text-white",
-    ghost:
-      "bg-transparent hover:bg-gray-100 dark:hover:bg-gray-800 hc:bg-black hc:text-white",
-    danger:
-      "bg-red-600 text-white hover:bg-red-700 disabled:bg-red-400 hc:bg-black hc:text-white",
-  };
-  const sizes: Record<ButtonSize, string> = {
-    sm: "px-2 py-1 text-sm",
-    md: "px-3 py-1.5 text-base",
-    lg: "px-4 py-2 text-lg",
-  };
-
   return (
     <button
-      className={clsx(base, variants[variant], sizes[size], className)}
+      className={getButtonClasses(variant, size, className)}
       disabled={disabled || loading}
       aria-disabled={disabled || loading}
       aria-busy={loading}

--- a/src/view/ui/LinkButton.tsx
+++ b/src/view/ui/LinkButton.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+import Link, { LinkProps } from "next/link";
+import { ReactNode } from "react";
+import clsx from "clsx";
+import {
+  getButtonClasses,
+  ButtonVariant,
+  ButtonSize,
+} from "./Button";
+
+interface LinkButtonProps extends LinkProps {
+  children?: ReactNode;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  className?: string;
+}
+
+export default function LinkButton({
+  children,
+  variant = "primary",
+  size = "md",
+  className,
+  ...rest
+}: LinkButtonProps) {
+  return (
+    <Link {...rest} className={clsx(getButtonClasses(variant, size), className)}>
+      {children}
+    </Link>
+  );
+}

--- a/src/view/ui/index.ts
+++ b/src/view/ui/index.ts
@@ -1,3 +1,4 @@
 export { default as Button } from './Button';
 export { default as Textbox } from './Textbox';
 export { default as ToolsCard } from './ToolsCard';
+export { default as LinkButton } from './LinkButton';


### PR DESCRIPTION
## Summary
- export `getButtonClasses` helper for design system buttons
- add `LinkButton` component
- use `LinkButton` on NotFound page and in ErrorBoundary
- test `LinkButton`

## Testing
- `npm run lint` *(fails: Cannot find module '../languages/js/source-code')*
- `npm run typecheck`
- `npm test -- -w 1` *(fails: Cannot find module './util')*

------
https://chatgpt.com/codex/tasks/task_e_684336ae2a1c83298408495b2d4aa918