### PR TITLE
Fix loading loop on Home page

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,7 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import { 
@@ -30,9 +33,9 @@ const Home: React.FC = () => {
   const [isFeaturedExpanded, setIsFeaturedExpanded] = useState<boolean>(false);
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
   
-  const allTools = getTools();
-  const categories = getAllCategories();
-  const popularTools = getPopularTools();
+  const allTools = useMemo(() => getTools(), []);
+  const categories = useMemo(() => getAllCategories(), []);
+  const popularTools = useMemo(() => getPopularTools(), []);
   const observerRef = useRef<IntersectionObserver | null>(null);
   const toolsContainerRef = useRef<HTMLDivElement>(null);
   


### PR DESCRIPTION
## Summary
- stabilize Home page by memoizing data arrays
- add missing license header

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config)*
- `pnpm typecheck` *(fails: script not found)*
- `pnpm test --coverage` *(fails: unknown option)*

------
https://chatgpt.com/codex/tasks/task_e_68456a5010d48329be57de6b562011e1