### PR TITLE
Improve spacing in grid layouts

### DIFF
--- a/src/design-system/components/layout/Grid.tsx
+++ b/src/design-system/components/layout/Grid.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 
 export type GridColumns = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 'none';
-export type GridGap = 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+export type GridGap = 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
 export type GridResponsiveColumns = {
   base?: GridColumns;
   sm?: GridColumns;
@@ -45,7 +45,7 @@ export interface GridProps {
 export const Grid: React.FC<GridProps> = ({
   children,
   columns = { base: 1, md: 3 },
-  gap = 'md',
+  gap = 'lg',
   rowGap,
   justify = 'start',
   align = 'stretch',
@@ -72,6 +72,7 @@ export const Grid: React.FC<GridProps> = ({
     md: '4',
     lg: '6',
     xl: '8',
+    '2xl': '12',
   };
 
   const getGapClass = (gap?: GridGap) => {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -209,7 +209,7 @@ const Home: React.FC = () => {
             </div>
             
             {/* Quick Stats */}
-            <div className="mt-8 grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="mt-8 grid grid-cols-2 md:grid-cols-4 gap-6">
               <div className="stats-card bg-white dark:bg-gray-700 rounded-lg shadow-sm p-4 text-center">
                 <div className="text-2xl font-bold text-primary-500">{allTools.length}</div>
                 <div className="text-sm text-gray-600 dark:text-gray-300">Total Tools</div>
@@ -402,7 +402,7 @@ const Home: React.FC = () => {
                 View All
               </Button>
             </div>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
               {recentTools.map(tool => (
                 <Link
                   key={`recent-${tool.id}`}
@@ -448,7 +448,7 @@ const Home: React.FC = () => {
           {isLoading ? (
             // Skeleton loading state
             <div className={viewMode === 'grid' ? 
-              "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4" : 
+              "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6" :
               "space-y-3"
             }>
               {Array.from({ length: 6 }).map((_, i) => (
@@ -474,7 +474,7 @@ const Home: React.FC = () => {
             </div>
           ) : visibleTools.length > 0 ? (
             viewMode === 'grid' ? (
-              <Grid columns={{ base: 1, sm: 2, md: 3 }} gap="md">
+              <Grid columns={{ base: 1, sm: 2, md: 3 }} gap="lg">
                 {visibleTools.map(tool => (
                   <Link
                     key={tool.id}
@@ -596,7 +596,7 @@ const Home: React.FC = () => {
           {/* Categories Navigation */}
         <section className="mb-12">
           <h2 className="text-xl font-semibold text-gray-800 dark:text-white mb-5">Browse by Category</h2>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
             {categories.map(category => (
               <div 
                 key={`cat-${category}`}
@@ -632,7 +632,7 @@ const Home: React.FC = () => {
                 Suggest new features, report bugs, or contribute directly to our GitHub repository.
               </p>
               
-              <div className="flex flex-wrap gap-4">
+              <div className="flex flex-wrap gap-6">
                 <a
                   href="https://github.com/HydrogenB/mydebugger" 
                   target="_blank"


### PR DESCRIPTION
## Summary
- adjust `Grid` component to support larger spacing
- use larger spacing throughout the home page grids

## Testing
- `pnpm lint` *(fails: ESLint couldn't find configuration)*
- `pnpm typecheck` *(fails with TS errors, missing deps)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c62dfddc8329b0b030650bbef693