### PR TITLE
Add key saving and GPG RSA support

### DIFF
--- a/__tests__/aes.test.ts
+++ b/__tests__/aes.test.ts
@@ -26,6 +26,18 @@ if (typeof global.crypto === 'undefined') {
   if (!global.crypto.subtle) global.crypto.subtle = webcrypto.subtle;
   if (!global.crypto.getRandomValues) global.crypto.getRandomValues = webcrypto.getRandomValues.bind(webcrypto);
 }
+if (typeof globalThis.crypto === 'undefined') {
+  (globalThis as any).crypto = global.crypto;
+}
+if (typeof (globalThis as any).self === 'undefined') {
+  (globalThis as any).self = global;
+}
+const webstreams = require('stream/web');
+if (typeof global.ReadableStream === 'undefined') {
+  global.ReadableStream = webstreams.ReadableStream;
+  global.WritableStream = webstreams.WritableStream;
+  global.TransformStream = webstreams.TransformStream;
+}
 
 test('encrypt and decrypt roundtrip with 32 byte key', async () => {
   const key = '12345678901234567890123456789012';
@@ -82,6 +94,15 @@ test('RSA-OAEP encrypt/decrypt', async () => {
   const msg = 'rsa message';
   const encrypted = await rsaOaepEncrypt(publicKey, msg);
   const decrypted = await rsaOaepDecrypt(privateKey, encrypted);
+  expect(decrypted).toBe(msg);
+});
+
+test.skip('GPG RSA-2048 encrypt/decrypt', async () => {
+  const { generateGpgKeyPair, gpgEncrypt, gpgDecrypt } = await import('../model/aes');
+  const { publicKey, privateKey } = await generateGpgKeyPair();
+  const msg = 'pgp message';
+  const encrypted = await gpgEncrypt(publicKey, msg);
+  const decrypted = await gpgDecrypt(privateKey, encrypted);
   expect(decrypted).toBe(msg);
 });
 

--- a/__tests__/gpg.test.ts
+++ b/__tests__/gpg.test.ts
@@ -1,0 +1,10 @@
+/** @jest-environment node */
+import { generateGpgKeyPair, gpgEncrypt, gpgDecrypt } from '../model/aes';
+
+test('GPG RSA-2048 roundtrip', async () => {
+  const { publicKey, privateKey } = await generateGpgKeyPair();
+  const msg = 'gpg message';
+  const enc = await gpgEncrypt(publicKey, msg);
+  const dec = await gpgDecrypt(privateKey, enc);
+  expect(dec).toBe(msg);
+});

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -12,6 +12,9 @@ import {
   generateRsaKeyPair,
   rsaOaepEncrypt,
   rsaOaepDecrypt,
+  generateGpgKeyPair,
+  gpgEncrypt,
+  gpgDecrypt,
 } from '../model/aes';
 
 const aesKey = generateAesKey();
@@ -21,6 +24,10 @@ const decrypted = await aes256CbcDecryptRandomIV(aesKey, encrypted);
 const { publicKey, privateKey } = await generateRsaKeyPair();
 const enc = await rsaOaepEncrypt(publicKey, 'secret');
 const dec = await rsaOaepDecrypt(privateKey, enc);
+
+const gpg = await generateGpgKeyPair();
+const encGpg = await gpgEncrypt(gpg.publicKey, 'secret');
+const decGpg = await gpgDecrypt(gpg.privateKey, encGpg);
 ```
 
-Use the Crypto Lab tool to experiment with AES-CBC, AES-GCM, and RSA-OAEP. You can generate keys and key pairs with a button and switch between encrypt and decrypt modes in real time.
+Use the Crypto Lab tool to experiment with AES-CBC, AES-GCM, RSA-OAEP, and GPG RSA‑2048. Keys can be generated and saved as reusable chips during your session for quick switching between algorithms.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,6 +55,7 @@ export default [
       'vercel.json',
       'pnpm-lock.yaml',
       'package-lock.json',
+      'coverage/**',
       'index.html',
       'eslint.config.js',
     ],

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lz-string": "^1.5.0",
     "next": "^14.0.4",
     "node-fetch": "^3.3.0",
+    "openpgp": "5",
     "p-queue": "^8.1.0",
     "puppeteer": "^24.8.2",
     "qrcode": "^1.5.3",
@@ -29,6 +30,7 @@
     "vite": "^4.5.2"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^2.1.4",
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "^0.5.10",
     "@testing-library/jest-dom": "^6.1.0",
@@ -42,7 +44,6 @@
     "@types/react-helmet": "^6.1.6",
     "@typescript-eslint/eslint-plugin": "^6.13.0",
     "@typescript-eslint/parser": "^6.13.0",
-    "@eslint/eslintrc": "^2.1.4",
     "autoprefixer": "^10.4.14",
     "eslint": "^8.53.0",
     "eslint-config-airbnb": "^19.0.4",
@@ -61,7 +62,8 @@
     "ts-jest": "^29.1.1",
     "typescript": "^5.0.2",
     "vite": "^4.5.2"
-  },  "scripts": {
+  },
+  "scripts": {
     "dev": "vite",
     "build": "vite build",
     "build:vercel": "node vercel-build.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       node-fetch:
         specifier: ^3.3.0
         version: 3.3.2
+      openpgp:
+        specifier: '5'
+        version: 5.11.3
       p-queue:
         specifier: ^8.1.0
         version: 8.1.0
@@ -1074,6 +1077,9 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -1175,6 +1181,9 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bn.js@4.12.2:
+    resolution: {integrity: sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==}
 
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -2516,6 +2525,9 @@ packages:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
 
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -2659,6 +2671,10 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  openpgp@5.11.3:
+    resolution: {integrity: sha512-jXOPfIteBUQ2zSmRG4+Y6PNntIIDEAvoM/lOYCnvpXAByJEruzrHQZWE/0CGOKHbubwUuty2HoPHsqBzyKHOpA==}
+    engines: {node: '>= 8.0.0'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -4679,6 +4695,13 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.2
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   ast-types-flow@0.0.8: {}
 
   ast-types@0.13.4:
@@ -4794,6 +4817,8 @@ snapshots:
   basic-ftp@5.0.5: {}
 
   binary-extensions@2.3.0: {}
+
+  bn.js@4.12.2: {}
 
   brace-expansion@1.1.11:
     dependencies:
@@ -6539,6 +6564,8 @@ snapshots:
 
   mini-svg-data-uri@1.4.4: {}
 
+  minimalistic-assert@1.0.1: {}
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -6691,6 +6718,10 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  openpgp@5.11.3:
+    dependencies:
+      asn1.js: 5.4.1
 
   optionator@0.9.4:
     dependencies:

--- a/src/tools/aes-cbc/README.md
+++ b/src/tools/aes-cbc/README.md
@@ -1,4 +1,4 @@
 # Crypto Lab
 
-This tool lets you experiment with AES (CBC and GCM) as well as RSA-OAEP encryption. Generate keys, toggle algorithms, and see results instantly.
+This tool lets you experiment with AES (CBC and GCM), RSA-OAEP, and GPG RSA‑2048 encryption. You can generate keys, save them for reuse within the session, and toggle algorithms in real time.
 

--- a/src/tools/aes-cbc/page.tsx
+++ b/src/tools/aes-cbc/page.tsx
@@ -27,6 +27,11 @@ const AesCbcPage: React.FC = () => {
       setExampleIndex={vm.setExampleIndex}
       setAlgorithm={vm.setAlgorithm}
       generateKeyPair={vm.generateKeyPair}
+      saveCurrentKey={vm.saveCurrentKey}
+      selectSavedKey={vm.selectSavedKey}
+      discardSavedKey={vm.discardSavedKey}
+      savedKeys={vm.savedKeys}
+      savedKeyPairs={vm.savedKeyPairs}
 
       toggleMode={vm.toggleMode}
       clear={vm.clear}

--- a/view/AesCbcView.tsx
+++ b/view/AesCbcView.tsx
@@ -23,6 +23,11 @@ interface Props {
   setExampleIndex: (i: number | null) => void;
   setAlgorithm: (a: CryptoAlgorithm) => void;
   generateKeyPair: () => Promise<void>;
+  saveCurrentKey: () => void;
+  selectSavedKey: (index: number) => void;
+  discardSavedKey: (index: number) => void;
+  savedKeys: string[];
+  savedKeyPairs: { publicKey: string; privateKey: string }[];
 
   toggleMode: () => void;
   clear: () => void;
@@ -47,6 +52,11 @@ export function AesCbcView({
   setExampleIndex,
   setAlgorithm,
   generateKeyPair,
+  saveCurrentKey,
+  selectSavedKey,
+  discardSavedKey,
+  savedKeys,
+  savedKeyPairs,
 
   toggleMode,
   clear,
@@ -66,9 +76,10 @@ export function AesCbcView({
           <option value="aes-cbc">AES-256-CBC</option>
           <option value="aes-gcm">AES-256-GCM</option>
           <option value="rsa-oaep">RSA-OAEP</option>
+          <option value="gpg-rsa-2048">GPG RSA-2048</option>
         </select>
       </div>
-      {algorithm === 'rsa-oaep' ? (
+      {algorithm === 'rsa-oaep' || algorithm === 'gpg-rsa-2048' ? (
         <>
           <div className="mb-4 flex flex-col gap-2">
             {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
@@ -90,6 +101,29 @@ export function AesCbcView({
               onChange={e => setPrivateKey(e.target.value)}
             />
           </div>
+          {savedKeyPairs.length > 0 && (
+            <div className="mb-4 flex flex-wrap gap-2">
+              {/* eslint-disable react/no-array-index-key */}
+              {savedKeyPairs.map((_, idx) => (
+                <span
+                  key={`kp-${idx}`}
+                  className="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded flex items-center gap-1 text-sm"
+                >
+                  <button type="button" onClick={() => selectSavedKey(idx)} className="focus:outline-none">
+                    Key {idx + 1}
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Remove"
+                    onClick={() => discardSavedKey(idx)}
+                    className="text-red-600"
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
         </>
       ) : (
         <>
@@ -123,6 +157,29 @@ export function AesCbcView({
               ))}
             </select>
           </div>
+          {savedKeys.length > 0 && (
+            <div className="mb-4 flex flex-wrap gap-2">
+              {/* eslint-disable react/no-array-index-key */}
+              {savedKeys.map((k, idx) => (
+                <span
+                  key={`k-${idx}`}
+                  className="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded flex items-center gap-1 text-sm"
+                >
+                  <button type="button" onClick={() => selectSavedKey(idx)} className="focus:outline-none">
+                    {k.slice(0, 8)}...
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Remove"
+                    onClick={() => discardSavedKey(idx)}
+                    className="text-red-600"
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
         </>
       )}
 
@@ -166,7 +223,16 @@ export function AesCbcView({
           className="px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600"
           onClick={generateKeyPair}
         >
-          {algorithm === 'rsa-oaep' ? 'Generate Keys' : 'Generate Key'}
+          {algorithm === 'aes-cbc' || algorithm === 'aes-gcm'
+            ? 'Generate Key'
+            : 'Generate Keys'}
+        </button>
+        <button
+          type="button"
+          className="px-4 py-2 bg-purple-500 text-white rounded hover:bg-purple-600"
+          onClick={saveCurrentKey}
+        >
+          Save Key
         </button>
         <button
           type="button"


### PR DESCRIPTION
## Summary
- support GPG RSA-2048 in Crypto Lab
- allow saving current key/pair for reuse via chips
- document new usage
- ignore coverage folder in ESLint
- add gpg node test

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684879078bac83299be7b7aab4f98528