### PR TITLE
Add Cookie Inspector tool

### DIFF
--- a/__tests__/cookies.test.ts
+++ b/__tests__/cookies.test.ts
@@ -1,0 +1,54 @@
+import {
+  parseCookieString,
+  mergeCookies,
+  formatExportFilename,
+} from '../model/cookies';
+
+describe('parseCookieString', () => {
+  it('parses name=value pairs', () => {
+    const res = parseCookieString('a=1; b=2');
+    expect(res).toEqual([
+      { name: 'a', value: '1' },
+      { name: 'b', value: '2' },
+    ]);
+  });
+
+  it('handles empty string', () => {
+    expect(parseCookieString('')).toEqual([]);
+  });
+});
+
+describe('mergeCookies', () => {
+  it('marks cookies as httpOnly when missing from client list', () => {
+    const server = [ { name: 'sid', value: '123' } ];
+    const client: any[] = [];
+    const merged = mergeCookies(server, client);
+    expect(merged[0].httpOnly).toBe(true);
+    expect(merged[0].accessible).toBe(false);
+  });
+
+  it('combines client details', () => {
+    const server = [ { name: 'a', value: '1' } ];
+    const client = [ { name: 'a', value: '1', secure: true } ];
+    const merged = mergeCookies(server, client);
+    expect(merged[0].secure).toBe(true);
+    expect(merged[0].httpOnly).toBe(false);
+  });
+
+  it('merges multiple cookies', () => {
+    const server = [ { name: 'a', value: '1' }, { name: 'b', value: '2' } ];
+    const client = [ { name: 'b', value: '2', path: '/' } ];
+    const merged = mergeCookies(server, client);
+    expect(merged).toHaveLength(2);
+    expect(merged[0].accessible).toBe(false);
+    expect(merged[1].path).toBe('/');
+  });
+});
+
+describe('formatExportFilename', () => {
+  it('generates a timestamped filename', () => {
+    const date = new Date('2025-06-11T12:34:56Z');
+    const name = formatExportFilename('example.com', date);
+    expect(name).toBe('example.com_2025-06-11-12-34-56.json');
+  });
+});

--- a/api/cookies.js
+++ b/api/cookies.js
@@ -1,0 +1,22 @@
+// Serverless function to expose request cookies
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  const cookieHeader = req.headers.cookie || '';
+  const cookies = cookieHeader
+    .split(';')
+    .map((c) => {
+      const [name, ...rest] = c.trim().split('=');
+      return { name, value: rest.join('=') };
+    })
+    .filter((c) => c.name);
+
+  res.status(200).json({ cookies });
+}

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -31,3 +31,12 @@ const decGpg = await gpgDecrypt(gpg.privateKey, encGpg);
 ```
 
 Use the Crypto Lab tool to experiment with AES-CBC, AES-GCM, RSA-OAEP, and GPG RSA‑2048. Keys can be generated and saved as reusable chips during your session for quick switching between algorithms.
+
+## Cookie Inspector
+
+```tsx
+import CookieInspectorPage from '../src/tools/cookie-inspector';
+```
+
+Use the Cookie Inspector to quickly view and filter cookies available to your session. You can export the visible cookies to a JSON file for debugging or QA reports.
+Click any cookie name or value to copy it. Long values can be expanded inline, and exports are named using the current hostname and timestamp.

--- a/model/cookies.ts
+++ b/model/cookies.ts
@@ -1,0 +1,55 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+export interface BasicCookie {
+  name: string;
+  value: string;
+}
+
+export interface ClientCookie extends BasicCookie {
+  domain?: string;
+  path?: string;
+  expires?: number;
+  secure?: boolean;
+  sameSite?: string;
+}
+
+export interface CookieInfo extends ClientCookie {
+  size: number;
+  httpOnly: boolean;
+  accessible: boolean;
+}
+
+export const parseCookieString = (cookieString: string): BasicCookie[] =>
+  !cookieString
+    ? []
+    : cookieString.split(';').map((part) => {
+        const [name, ...rest] = part.trim().split('=');
+        return { name, value: rest.join('=') };
+      });
+
+export const mergeCookies = (
+  serverCookies: BasicCookie[],
+  clientCookies: ClientCookie[],
+): CookieInfo[] =>
+  serverCookies.map((sc) => {
+    const client = clientCookies.find((cc) => cc.name === sc.name);
+    const base = client ?? { name: sc.name, value: sc.value };
+    return {
+      ...base,
+      value: client ? client.value : sc.value,
+      size: base.name.length + base.value.length,
+      httpOnly: !client,
+      accessible: !!client,
+    };
+  });
+
+export const formatExportFilename = (
+  host: string,
+  date: Date = new Date(),
+): string => {
+  const safeHost = host || 'site';
+  const ts = date.toISOString().replace(/[:T]/g, '-').split('.')[0];
+  return `${safeHost}_${ts}.json`;
+};

--- a/src/design-system/icons/tool-icons.tsx
+++ b/src/design-system/icons/tool-icons.tsx
@@ -102,3 +102,9 @@ export const Base64ImageIcon: React.FC<IconProps> = ({ className }) => (
     <polyline points="21 15 16 10 5 21" strokeWidth="2"></polyline>
   </svg>
 );
+export const CookieIcon: React.FC<IconProps> = ({ className }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-9-9 5 5 0 009 9z" />
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 15h.01M12 12h.01M12 18h.01M16 14h.01" />
+  </svg>
+);

--- a/src/tools/cookie-inspector/index.ts
+++ b/src/tools/cookie-inspector/index.ts
@@ -1,0 +1,5 @@
+// Auto-generated index file
+import CookieInspectorPage from './page';
+
+export { CookieInspectorPage };
+export default CookieInspectorPage;

--- a/src/tools/cookie-inspector/page.tsx
+++ b/src/tools/cookie-inspector/page.tsx
@@ -1,0 +1,13 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import useCookieInspector from '../../../viewmodel/useCookieInspector';
+import CookieInspectorView from '../../../view/CookieInspectorView';
+
+const CookieInspectorPage: React.FC = () => {
+  const vm = useCookieInspector();
+  return <CookieInspectorView {...vm} />;
+};
+
+export default CookieInspectorPage;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -60,7 +60,8 @@ import {
   QrCodeIcon,
   ClickJackingIcon,
   LinkTracerIcon,
-  Base64ImageIcon
+  Base64ImageIcon,
+  CookieIcon
 } from '../design-system/icons/tool-icons';
 
 // Category definitions with icons for consistent UI
@@ -286,6 +287,23 @@ const toolRegistry: Tool[] = [
     },
     uiOptions: {
       showExamples: true
+    }
+  },
+  {
+    id: 'cookie-inspector',
+    route: '/cookies',
+    title: 'Cookie Inspector',
+    description: 'View cookies for this session and export them.',
+    icon: CookieIcon,
+    component: lazy(() => import('./cookie-inspector/page')),
+    category: 'Testing',
+    isNew: true,
+    metadata: {
+      keywords: ['cookie', 'debug', 'browser', 'httpOnly', 'session'],
+      relatedTools: [],
+    },
+    uiOptions: {
+      showExamples: false
     }
   },
   {

--- a/view/CookieInspectorView.tsx
+++ b/view/CookieInspectorView.tsx
@@ -1,0 +1,127 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import { CookieInfo } from '../model/cookies';
+
+interface Props {
+  cookies: CookieInfo[];
+  filter: string;
+  setFilter: (v: string) => void;
+  exportJson: () => void;
+  expanded: Record<string, boolean>;
+  toggleExpand: (name: string) => void;
+  copy: (text: string, label: string) => void;
+  toastMessage: string;
+}
+
+export function CookieInspectorView({
+  cookies,
+  filter,
+  setFilter,
+  exportJson,
+  expanded,
+  toggleExpand,
+  copy,
+  toastMessage,
+}: Props) {
+  return (
+    <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md">
+      <h2 className="text-2xl font-bold mb-4 text-gray-800 dark:text-white">Cookie Inspector</h2>
+      <div className="mb-4 flex justify-between">
+        <input
+          type="text"
+          className="border px-3 py-2 rounded w-full mr-4 dark:bg-gray-700 dark:text-gray-200"
+          placeholder="Filter cookies"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+        <button
+          type="button"
+          className="px-4 py-2 bg-primary-500 text-white rounded hover:bg-primary-600"
+          onClick={exportJson}
+        >
+          Export JSON
+        </button>
+      </div>
+      {toastMessage && (
+        <div className="fixed top-20 right-4 z-50 bg-gray-800 text-white px-4 py-2 rounded-md shadow-lg animate-fade-in-out">
+          {toastMessage}
+        </div>
+      )}
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm text-left text-gray-700 dark:text-gray-200">
+          <thead>
+            <tr>
+              <th className="px-2 py-1">Name</th>
+              <th className="px-2 py-1">Value</th>
+              <th className="px-2 py-1">Domain</th>
+              <th className="px-2 py-1">Path</th>
+              <th className="px-2 py-1">Expiry</th>
+              <th className="px-2 py-1">Size</th>
+              <th className="px-2 py-1">Secure</th>
+              <th className="px-2 py-1">HttpOnly</th>
+              <th className="px-2 py-1">SameSite</th>
+            </tr>
+          </thead>
+          <tbody>
+            {cookies.map((c) => (
+              <tr key={c.name} className="border-b dark:border-gray-700">
+                <td className="px-2 py-1 font-medium">
+                  <button type="button" onClick={() => copy(c.name, 'Cookie name')} className="mr-2 hover:underline text-blue-600">
+                    {c.name}
+                  </button>
+                </td>
+                <td className="px-2 py-1 break-all">
+                  {c.accessible ? (
+                    (() => {
+                      const truncated = c.value.length > 40 ? `${c.value.slice(0, 40)}…` : c.value;
+                      const toShow = expanded[c.name] ? c.value : truncated;
+                      return (
+                        <>
+                          {toShow}
+                          {c.value.length > 40 && (
+                            <button
+                              type="button"
+                              className="ml-1 text-xs text-blue-600 hover:underline"
+                              onClick={() => toggleExpand(c.name)}
+                            >
+                              {expanded[c.name] ? 'Collapse' : 'Expand'}
+                            </button>
+                          )}
+                          <button
+                            type="button"
+                            className="ml-2 text-xs text-blue-600 hover:underline"
+                            onClick={() => copy(c.value, 'Cookie value')}
+                          >
+                            Copy
+                          </button>
+                        </>
+                      );
+                    })()
+                  ) : (
+                    'Inaccessible'
+                  )}
+                </td>
+                <td className="px-2 py-1">{c.domain ?? '-'}</td>
+                <td className="px-2 py-1">{c.path ?? '-'}</td>
+                <td className="px-2 py-1">{c.expires ? new Date(c.expires).toLocaleString() : '-'}</td>
+                <td className="px-2 py-1">{c.size}</td>
+                <td className="px-2 py-1">{c.secure ? 'Yes' : 'No'}</td>
+                <td className="px-2 py-1">{c.httpOnly ? 'Yes' : 'No'}</td>
+                <td className="px-2 py-1">{c.sameSite ?? '-'}</td>
+              </tr>
+            ))}
+            {cookies.length === 0 && (
+              <tr>
+                <td className="px-2 py-4" colSpan={9}>No cookies found.</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default CookieInspectorView;

--- a/viewmodel/useCookieInspector.ts
+++ b/viewmodel/useCookieInspector.ts
@@ -1,0 +1,114 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { useEffect, useState } from 'react';
+import {
+  BasicCookie,
+  ClientCookie,
+  CookieInfo,
+  parseCookieString,
+  mergeCookies,
+  formatExportFilename,
+} from '../model/cookies';
+
+interface StoreCookie extends ClientCookie {}
+
+declare global {
+  interface Window {
+    cookieStore?: {
+      getAll: () => Promise<StoreCookie[]>;
+    };
+  }
+}
+
+const fetchServerCookies = async (): Promise<BasicCookie[]> => {
+  try {
+    const res = await fetch('/api/cookies');
+    if (!res.ok) throw new Error('Failed to fetch cookies');
+    const data = await res.json();
+    return Array.isArray(data.cookies) ? data.cookies : [];
+  } catch {
+    return [];
+  }
+};
+
+const getClientCookies = async (): Promise<ClientCookie[]> => {
+  if (window.cookieStore && window.cookieStore.getAll) {
+    const cs = await window.cookieStore.getAll();
+    return cs.map((c) => ({
+      name: c.name,
+      value: c.value,
+      domain: c.domain,
+      path: c.path,
+      expires: c.expires,
+      secure: c.secure,
+      sameSite: c.sameSite,
+    }));
+  }
+  return parseCookieString(document.cookie).map((c) => ({ ...c }));
+};
+
+export const useCookieInspector = () => {
+  const [cookies, setCookies] = useState<CookieInfo[]>([]);
+  const [filter, setFilter] = useState('');
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [toastMessage, setToastMessage] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      const [server, client] = await Promise.all([
+        fetchServerCookies(),
+        getClientCookies(),
+      ]);
+      setCookies(mergeCookies(server, client));
+    })();
+  }, []);
+
+  const filtered = cookies.filter((c) => c.name.toLowerCase().includes(filter.toLowerCase()));
+
+  const toggleExpand = (name: string) => {
+    setExpanded((prev) => ({ ...prev, [name]: !prev[name] }));
+  };
+
+  const copy = (text: string, label: string) => {
+    try {
+      navigator.clipboard.writeText(text);
+      setToastMessage(`${label} copied!`);
+    } catch {
+      setToastMessage('Clipboard access denied');
+    }
+  };
+
+  useEffect(() => {
+    if (!toastMessage) {
+      return undefined;
+    }
+    const timer = setTimeout(() => setToastMessage(''), 2000);
+    return () => clearTimeout(timer);
+  }, [toastMessage]);
+
+  const exportJson = () => {
+    const blob = new Blob([JSON.stringify(filtered, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = formatExportFilename(window.location.hostname);
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return {
+    cookies: filtered,
+    filter,
+    setFilter,
+    exportJson,
+    expanded,
+    toggleExpand,
+    copy,
+    toastMessage,
+  };
+};
+
+export default useCookieInspector;

--- a/viewmodel/useCookieInspector.ts
+++ b/viewmodel/useCookieInspector.ts
@@ -70,9 +70,9 @@ export const useCookieInspector = () => {
     setExpanded((prev) => ({ ...prev, [name]: !prev[name] }));
   };
 
-  const copy = (text: string, label: string) => {
+  const copy = async (text: string, label: string) => {
     try {
-      navigator.clipboard.writeText(text);
+      await navigator.clipboard.writeText(text);
       setToastMessage(`${label} copied!`);
     } catch {
       setToastMessage('Clipboard access denied');


### PR DESCRIPTION
## Summary
- add CookieInspector model and API
- add CookieInspector view model and view
- register Cookie Inspector route
- add Cookie icon
- document new Cookie Inspector tool
- test cookie utilities

------
https://chatgpt.com/codex/tasks/task_e_6848f8562df48329b4cf7c0bd38fd240