### PR TITLE
Add robust URL auto-encoding & fix deep link runner

### DIFF
--- a/__tests__/url.test.ts
+++ b/__tests__/url.test.ts
@@ -1,0 +1,31 @@
+import { encodeUrlQueryParams } from "../model/url";
+
+describe("encodeUrlQueryParams", () => {
+  it("encodes query values", () => {
+    const url = "https://example.com/path?name=John Doe&city=New York";
+    expect(encodeUrlQueryParams(url)).toBe(
+      "https://example.com/path?name=John%20Doe&city=New%20York",
+    );
+  });
+
+  it("handles custom schemes", () => {
+    const url = "trueapp://host/path?foo=bar baz";
+    expect(encodeUrlQueryParams(url)).toBe("trueapp://host/path?foo=bar%20baz");
+  });
+
+  it("preserves already encoded values", () => {
+    const url = "https://example.com/path?name=John%20Doe";
+    expect(encodeUrlQueryParams(url)).toBe("https://example.com/path?name=John%20Doe");
+  });
+
+  it("encodes URLs without scheme", () => {
+    const url = "example.com/path?term=hello world#frag";
+    expect(encodeUrlQueryParams(url)).toBe("example.com/path?term=hello%20world#frag");
+  });
+
+  it("handles plus signs and empty params", () => {
+    const url = "https://ex.com/?a=1%2B2&a=&b";
+    expect(encodeUrlQueryParams(url)).toBe("https://ex.com/?a=1%2B2&a=&b=");
+  });
+});
+

--- a/model/url.ts
+++ b/model/url.ts
@@ -1,0 +1,53 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+/**
+ * Encode all query parameter values in a URL while preserving the base path.
+ * Existing encodings are normalized to avoid double encoding.
+ *
+ * @param url - The URL which may contain unencoded query parameters.
+ * @returns The URL with each query parameter percent-encoded.
+ */
+export const encodeUrlQueryParams = (url: string): string => {
+  try {
+    const urlObj = new URL(url);
+    const base = `${urlObj.protocol}//${urlObj.host}${urlObj.pathname}`;
+    const params = Array.from(urlObj.searchParams.entries())
+      .map(([k, v]) => {
+        try {
+          const decoded = decodeURIComponent(v);
+          return `${encodeURIComponent(k)}=${encodeURIComponent(decoded)}`;
+        } catch {
+          return `${encodeURIComponent(k)}=${encodeURIComponent(v)}`;
+        }
+      })
+      .join("&");
+    return params ? `${base}?${params}${urlObj.hash}` : `${base}${urlObj.hash}`;
+  } catch {
+    // Fallback for URLs without scheme or other parsing issues
+    try {
+      const [base, rest] = url.split("?");
+      if (!rest) return url;
+      const [query, fragment] = rest.split("#");
+      const encodedQuery = query
+        .split("&")
+        .filter(Boolean)
+        .map((part) => {
+          const [k, v = ""] = part.split("=");
+          try {
+            const decodedVal = decodeURIComponent(v);
+            return `${encodeURIComponent(k)}=${encodeURIComponent(decodedVal)}`;
+          } catch {
+            return `${encodeURIComponent(k)}=${encodeURIComponent(v)}`;
+          }
+        })
+        .join("&");
+      return `${base}?${encodedQuery}${fragment ? `#${fragment}` : ""}`;
+    } catch {
+      return url;
+    }
+  }
+};
+
+export default encodeUrlQueryParams;


### PR DESCRIPTION
## Summary
- implement `encodeUrlQueryParams` helper for robust query param encoding
- allow toggling auto-encoding in QR Generator
- enable running all schemes on current device
- add unit tests for URL encoding logic

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68496f8f191c832985d505d9173c6c28