### PR TITLE
Implement pinned tools and improve SEO

### DIFF
--- a/src/design-system/components/layout/ToolLayout.tsx
+++ b/src/design-system/components/layout/ToolLayout.tsx
@@ -66,6 +66,8 @@ export const ToolLayout: React.FC<ToolLayoutProps> = ({
         <meta property="og:description" content={pageDescription} />
         <meta property="og:type" content="website" />
         <meta property="og:url" content={`https://mydebugger.vercel.app${tool.route}`} />
+        <meta property="og:site_name" content="MyDebugger" />
+        <meta property="og:image" content="https://mydebugger.vercel.app/favicon.svg" />
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:title" content={pageTitle} />
         <meta name="twitter:description" content={pageDescription} />
@@ -83,9 +85,6 @@ export const ToolLayout: React.FC<ToolLayoutProps> = ({
               <h1 className="text-3xl font-bold text-gray-900 dark:text-white mr-2">{finalTitle}</h1>
               {tool.isBeta && (
                 <Tag variant="warning" size="sm" className="ml-1">BETA</Tag>
-              )}
-              {tool.isNew && (
-                <Tag variant="success" size="sm" className="ml-1">NEW</Tag>
               )}
             </div>
           </div>

--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -6,11 +6,6 @@ import { getAllCategories } from '../tools';
 const getIconHelper = (name: string) => {
   const icons: Record<string, React.ReactNode> = {
     code: <span>💻</span>,
-    twitter: (
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
-        <path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z" />
-      </svg>
-    ),
     linkedin: (
       <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
         <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/>
@@ -67,15 +62,6 @@ const Footer: React.FC = () => {
               >
                 {getIconHelper('linkedin')}
               </button>
-              <a
-                href="https://twitter.com"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Twitter"
-                className="text-gray-500 hover:text-gray-900 dark:hover:text-white transition"
-              >
-                {getIconHelper('twitter')}
-              </a>
             </div>
           </div>
           

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -105,7 +105,6 @@ const toolRegistry: Tool[] = [
     component: lazy(() => import('./jwt/JwtToolkit')),
     category: 'Security',
     isPopular: true,
-    isNew: true,
     metadata: {
       keywords: ['jwt', 'token', 'generator', 'decoder', 'verification', 'json web token', 'authentication', 'verify', 'jwks', 'security analysis', 'jwt inspector', 'jwt benchmark'],
       learnMoreUrl: 'https://jwt.io/introduction',
@@ -207,7 +206,6 @@ const toolRegistry: Tool[] = [
     icon: ClickJackingIcon,
     component: lazy(() => import('./clickjacking/ClickJackingValidator')),
     category: 'Security',
-    isNew: true,
     metadata: {
       keywords: ['clickjacking', 'security', 'x-frame-options', 'csp', 'iframe', 'vulnerability', 'content-security-policy', 'frame-ancestors'],
       learnMoreUrl: 'https://owasp.org/www-community/attacks/Clickjacking',
@@ -225,7 +223,6 @@ const toolRegistry: Tool[] = [
     icon: LinkTracerIcon,
     component: lazy(() => import('./linktracer/LinkTracer')),
     category: 'Testing',
-    isNew: true,
     metadata: {
       keywords: ['redirect', 'trace', 'url', 'link', 'shortened url', 'redirect chain', 'http status', 'redirect checker'],
       learnMoreUrl: 'https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections',
@@ -243,7 +240,6 @@ const toolRegistry: Tool[] = [
     icon: LinkTracerIcon, // Reusing the same icon for now
     component: lazy(() => import('./linktracer/DeviceTrace')),
     category: 'Testing',
-    isNew: true,
     metadata: {
       keywords: ['app flyer', 'one link', 'dynamic link', 'deep link', 'device probe', 'app store', 'play store', 'universal link'],
       learnMoreUrl: 'https://support.appsflyer.com/hc/en-us/articles/207032366-OneLink-overview',
@@ -261,7 +257,6 @@ const toolRegistry: Tool[] = [
     icon: UtilitiesIcon,
     component: lazy(() => import('./components-demo/ComponentsDemo')),
     category: 'Utilities',
-    isNew: true,
     metadata: {
       keywords: ['components', 'demo', 'ui', 'showcase'],
       learnMoreUrl: 'https://reactjs.org/docs/components-and-props.html',
@@ -280,7 +275,6 @@ const toolRegistry: Tool[] = [
     icon: Base64ImageIcon,
     component: lazy(() => import('./base64-image/page')),
     category: 'Utilities',
-    isNew: true,
     metadata: {
       keywords: ['base64', 'image', 'encoder', 'decoder', 'preview', 'debug', 'visualize', 'png', 'jpg', 'jpeg', 'gif', 'svg'],
       relatedTools: ['url-encoder'],
@@ -297,7 +291,6 @@ const toolRegistry: Tool[] = [
     icon: CookieIcon,
     component: lazy(() => import('./cookie-inspector/page')),
     category: 'Testing',
-    isNew: true,
     metadata: {
       keywords: ['cookie', 'debug', 'browser', 'httpOnly', 'session'],
       relatedTools: [],
@@ -315,7 +308,6 @@ const toolRegistry: Tool[] = [
     icon: SecurityIcon,
     component: lazy(() => import('./aes-cbc/page')),
     category: 'Security',
-    isNew: true,
     metadata: {
       keywords: ['aes', 'gcm', 'rsa', 'encryption', 'decryption', 'crypto', 'cbc', 'security'],
 


### PR DESCRIPTION
## Summary
- remove Twitter icon from footer
- add pinned tools feature with drag & drop reorder
- drop hero section, keep search bar
- remove "NEW" labels from tool cards and tool pages
- enhance metadata for better SEO

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849905b72108329808f7ffb8e43add9