### PR TITLE
Add Crypto Lab UX enhancements

### DIFF
--- a/src/tools/aes-cbc/page.tsx
+++ b/src/tools/aes-cbc/page.tsx
@@ -33,6 +33,11 @@ const AesCbcPage: React.FC = () => {
       savedKeys={vm.savedKeys}
       savedKeyPairs={vm.savedKeyPairs}
 
+      outputFormat={vm.outputFormat}
+      setOutputFormat={vm.setOutputFormat}
+      toastMessage={vm.toastMessage}
+      copyOutput={vm.copyOutput}
+
       toggleMode={vm.toggleMode}
       clear={vm.clear}
     />


### PR DESCRIPTION
## Summary
- enhance Crypto Lab UX with mode indicator and copy button
- validate inputs and support multiple output formats
- show toasts when copying or saving keys
- add accessibility and responsive layout tweaks

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849b42006a883299291280153b09bc5