### PR TITLE
Add advanced clickjacking validator

### DIFF
--- a/__tests__/clickjacking.test.ts
+++ b/__tests__/clickjacking.test.ts
@@ -1,0 +1,22 @@
+import { formatReportFilename, generateReport, ClickjackingReport } from '../model/clickjacking';
+
+describe('formatReportFilename', () => {
+  it('creates filename with host and timestamp', () => {
+    const date = new Date('2025-06-11T12:34:56Z');
+    const name = formatReportFilename('example.com', date);
+    expect(name).toBe('example.com_clickjacking_2025-06-11-12-34-56.json');
+  });
+});
+
+describe('generateReport', () => {
+  it('stringifies the report data', () => {
+    const data: ClickjackingReport = {
+      url: 'https://a.com',
+      headers: { 'x-frame-options': 'DENY' },
+      protected: true,
+      timestamp: '2025-06-11T12:00:00Z',
+    };
+    const out = generateReport(data);
+    expect(JSON.parse(out)).toEqual(data);
+  });
+});

--- a/api/clickjacking-analysis.js
+++ b/api/clickjacking-analysis.js
@@ -20,7 +20,7 @@ export default async function handler(req, res) {
     return;
   }
   
-  const { url } = req.query;
+  const { url, ua, ref } = req.query;
   
   if (!url) {
     return res.status(400).json({ error: 'URL parameter is required' });
@@ -44,7 +44,8 @@ export default async function handler(req, res) {
         response = await fetch(targetUrl.toString(), {
           method,
           headers: {
-            'User-Agent': 'MyDebugger-ClickjackingValidator/1.0',
+            'User-Agent': ua || 'MyDebugger-ClickjackingValidator/1.0',
+            ...(ref ? { Referer: ref } : {}),
           },
           redirect: 'manual',
           signal: controller.signal,

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -40,3 +40,14 @@ import CookieInspectorPage from '../src/tools/cookie-inspector';
 
 Use the Cookie Inspector to quickly view and filter cookies available to your session. You can export the visible cookies to a JSON file for debugging or QA reports.
 Click any cookie name or value to copy it. Long values can be expanded inline, and exports are named using the current hostname and timestamp.
+
+## Clickjacking Validator
+
+```tsx
+import ClickJackingValidator from '../src/tools/clickjacking';
+```
+
+Check whether a page blocks framing by inspecting `X-Frame-Options` and
+`Content-Security-Policy` headers. The tool attempts to render the site in an
+iframe and shows raw HTTP headers. Results can be copied or exported as JSON for
+security reports.

--- a/model/clickjacking.ts
+++ b/model/clickjacking.ts
@@ -1,0 +1,25 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+export interface ClickjackingReport {
+  url: string;
+  headers: Record<string, string>;
+  protected: boolean;
+  message?: string;
+  userAgent?: string;
+  referrer?: string;
+  timestamp: string;
+}
+
+export const formatReportFilename = (
+  host: string,
+  date: Date = new Date(),
+): string => {
+  const safeHost = host.replace(/[^a-z0-9.-]/gi, '') || 'site';
+  const ts = date.toISOString().replace(/[:T]/g, '-').split('.')[0];
+  return `${safeHost}_clickjacking_${ts}.json`;
+};
+
+export const generateReport = (data: ClickjackingReport): string =>
+  JSON.stringify(data, null, 2);

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "preview": "vite preview",
     "lint": "eslint \"./**/*.{ts,tsx,js,jsx}\"",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "jest --coverage"
+    "test": "jest --coverage",
+    "check": "pnpm lint && pnpm typecheck && pnpm test --coverage"
   },
   "eslintConfig": {},
   "browserslist": {


### PR DESCRIPTION
## Summary
- support custom user-agent and referrer in clickjacking API
- record raw headers in the Clickjacking Validator UI
- allow copying headers and exporting results
- expose optional UA/referrer inputs and raw header viewer
- document the new Clickjacking Validator tool
- add utilities for generating clickjacking reports
- test report helpers

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6849b662291c8329baf2fe153b911640