### PR TITLE
Add Deep Link Chain tool

### DIFF
--- a/__tests__/deepLinkChain.test.ts
+++ b/__tests__/deepLinkChain.test.ts
@@ -1,0 +1,84 @@
+import { followRedirectChain, parseUtmParams, fetchOpenGraph } from '../model/deepLinkChain';
+
+describe('parseUtmParams', () => {
+  it('extracts utm parameters', () => {
+    const url = 'https://ex.com/?utm_source=google&utm_medium=cpc&foo=bar';
+    expect(parseUtmParams(url)).toEqual({ utm_source: 'google', utm_medium: 'cpc' });
+  });
+
+  it('returns empty object for invalid url', () => {
+    expect(parseUtmParams('not a url')).toEqual({});
+  });
+});
+
+describe('followRedirectChain', () => {
+  it('follows redirects', async () => {
+    (global.fetch as any) = jest.fn()
+      .mockResolvedValueOnce({
+        status: 301,
+        headers: new Headers({ location: 'https://b.com' })
+      })
+      .mockResolvedValueOnce({ status: 200, headers: new Headers() });
+
+    const hops = await followRedirectChain('https://a.com');
+    expect(hops).toHaveLength(2);
+    expect(hops[0].status).toBe(301);
+    expect(hops[1].status).toBe(200);
+  });
+
+  it('detects redirect loops', async () => {
+    (global.fetch as any) = jest.fn().mockResolvedValue({
+      status: 301,
+      headers: new Headers({ location: 'https://a.com' }),
+    });
+    const hops = await followRedirectChain('https://a.com');
+    expect(hops[hops.length - 1].error).toContain('loop');
+  });
+
+  it('uses fallback when fetch fails', async () => {
+    (global.fetch as any) = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('blocked'))
+      .mockResolvedValueOnce({ url: 'https://final.com' });
+
+    const hops = await followRedirectChain('https://a.com');
+    expect((global.fetch as any)).toHaveBeenCalledTimes(2);
+    expect(hops[hops.length - 1].url).toBe('https://final.com');
+  });
+
+  it('handles unreachable fallback', async () => {
+    (global.fetch as any) = jest.fn().mockRejectedValue(new Error('x'));
+    const hops = await followRedirectChain('https://a.com');
+    expect(hops).toHaveLength(1);
+    expect(hops[0].error).toBe('x');
+  });
+
+  it('stops at max redirects', async () => {
+    const mocks = [] as any[];
+    for (let i = 0; i < 25; i += 1) {
+      mocks.push({
+        status: 301,
+        headers: new Headers({ location: `https://b${i}.com` }),
+      });
+    }
+    (global.fetch as any) = jest.fn().mockImplementation(() => mocks.shift());
+
+    const hops = await followRedirectChain('https://start.com');
+    expect(hops[hops.length - 1].error).toContain('Maximum');
+  });
+
+  it('fetches open graph data', async () => {
+    const html = `<html><head><title>t</title><meta property="og:image" content="img.png"/></head></html>`;
+    (global.fetch as any) = jest.fn().mockResolvedValue({ text: () => Promise.resolve(html) });
+    const og = await fetchOpenGraph('https://a.com');
+    expect(og?.image).toBe('img.png');
+    expect(og?.title).toBe('t');
+  });
+
+  it('returns null on open graph error', async () => {
+    (global.fetch as any) = jest.fn().mockRejectedValue(new Error('x'));
+    const og = await fetchOpenGraph('https://a.com');
+    expect(og).toBeNull();
+  });
+});
+

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -50,3 +50,11 @@ import PentestSuitePage from '../src/tools/pentest/page';
 The Pentest Validator Suite runs a set of lightweight client‑side checks against any public URL. It tests HTTPS redirection, basic CORS policy, open redirects, reflected XSS and clickjacking protections. Results may be inconclusive when a site blocks cross‑origin access.
 Each validator is displayed on a single page with preview iframes so you can observe redirects and payload reflection directly in the browser.
 You can tweak the open redirect parameter and the XSS payload, and expand per-test logs for more detail.
+
+## Deep Link Chain
+
+```tsx
+import DeepLinkChainPage from '../src/tools/deep-link-chain/page';
+```
+
+Follow and visualize the redirect chain for any URL entirely in the browser. The tool lists each hop with status codes and headers, highlights the final destination and extracts any UTM parameters present. Long chains collapse automatically with an option to expand. If fetch is blocked by CORS the tool attempts a browser-only fallback. The final URL displays an Open Graph preview when accessible. Results can be exported or copied as a Markdown table.

--- a/model/deepLinkChain.ts
+++ b/model/deepLinkChain.ts
@@ -1,0 +1,105 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+export interface RedirectHop {
+  url: string;
+  status?: number;
+  headers?: Record<string, string>;
+  error?: string;
+  mixedProtocol?: boolean;
+}
+
+export interface OpenGraphPreview {
+  title: string;
+  image?: string;
+  domain: string;
+}
+
+export const parseUtmParams = (target: string): Record<string, string> => {
+  try {
+    const url = new URL(target);
+    const params: Record<string, string> = {};
+    url.searchParams.forEach((value, key) => {
+      if (key.toLowerCase().startsWith('utm_')) {
+        params[key] = value;
+      }
+    });
+    return params;
+  } catch {
+    return {};
+  }
+};
+
+export const MAX_REDIRECTS = 20;
+
+const tryFetchFinalUrl = async (url: string): Promise<string | undefined> => {
+  try {
+    const res = await fetch(url, { mode: 'no-cors', redirect: 'follow' });
+    return res.url || undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export async function followRedirectChain(initialUrl: string): Promise<RedirectHop[]> {
+  const hops: RedirectHop[] = [];
+  const visited = new Set<string>();
+  let url = initialUrl;
+  for (let i = 0; i < MAX_REDIRECTS; i += 1) {
+    if (visited.has(url)) {
+      hops.push({ url, error: 'Redirect loop detected' });
+      break;
+    }
+    visited.add(url);
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const res = await fetch(url, { redirect: 'manual' });
+      const hop: RedirectHop = { url, status: res.status, headers: {} };
+      res.headers.forEach((value, key) => {
+        hop.headers![key] = value;
+      });
+      hops.push(hop);
+      if (res.status >= 300 && res.status < 400) {
+        const loc = res.headers.get('location');
+        if (!loc) break;
+        const next = new URL(loc, url).toString();
+        hop.mixedProtocol = new URL(next).protocol !== new URL(url).protocol;
+        url = next;
+      } else {
+        break;
+      }
+    } catch (e) {
+      hops.push({ url, error: (e as Error).message });
+      // eslint-disable-next-line no-await-in-loop
+      const finalUrl = await tryFetchFinalUrl(url);
+      if (finalUrl && finalUrl !== url) {
+        hops.push({ url: finalUrl });
+      }
+      break;
+    }
+  }
+  if (hops.length >= MAX_REDIRECTS) {
+    hops.push({ url, error: 'Maximum redirects reached' });
+  }
+  return hops;
+}
+
+export async function fetchOpenGraph(url: string): Promise<OpenGraphPreview | null> {
+  try {
+    const res = await fetch(url);
+    const text = await res.text();
+    const doc = new DOMParser().parseFromString(text, 'text/html');
+    const title =
+      doc.querySelector('meta[property="og:title"]')?.getAttribute('content') ||
+      doc.title;
+    const image = doc.querySelector('meta[property="og:image"]')?.getAttribute('content') ||
+      undefined;
+    return { title, image, domain: new URL(url).hostname };
+  } catch {
+    return null;
+  }
+}
+
+export default followRedirectChain;
+

--- a/src/tools/deep-link-chain/index.ts
+++ b/src/tools/deep-link-chain/index.ts
@@ -1,0 +1,6 @@
+// Auto-generated index file
+import DeepLinkChainPage from './page';
+
+export { DeepLinkChainPage };
+export default DeepLinkChainPage;
+

--- a/src/tools/deep-link-chain/page.tsx
+++ b/src/tools/deep-link-chain/page.tsx
@@ -1,0 +1,14 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import useDeepLinkChain from '../../../viewmodel/useDeepLinkChain';
+import DeepLinkChainView from '../../../view/DeepLinkChainView';
+
+const DeepLinkChainPage: React.FC = () => {
+  const vm = useDeepLinkChain();
+  return <DeepLinkChainView {...vm} />;
+};
+
+export default DeepLinkChainPage;
+

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -250,6 +250,23 @@ const toolRegistry: Tool[] = [
     }
   },
   {
+    id: 'deep-link-chain',
+    route: '/deep-link-chain',
+    title: 'Deep Link Chain',
+    description: 'Follow redirects and extract UTM parameters entirely in the browser.',
+    icon: LinkTracerIcon,
+    component: lazy(() => import('./deep-link-chain/page')),
+    category: 'Testing',
+    metadata: {
+      keywords: ['redirect', 'utm', 'deep link', 'link trace', 'url'],
+      learnMoreUrl: 'https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections',
+      relatedTools: ['link-tracer', 'url-encoder'],
+    },
+    uiOptions: {
+      showExamples: false,
+    }
+  },
+  {
     id: 'components-demo',
     route: '/components-demo',
     title: 'Components Demo',

--- a/view/DeepLinkChainView.tsx
+++ b/view/DeepLinkChainView.tsx
@@ -1,0 +1,137 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React, { useState } from 'react';
+import { RedirectHop, OpenGraphPreview } from '../model/deepLinkChain';
+
+interface Props {
+  url: string;
+  setUrl: (v: string) => void;
+  chain: RedirectHop[];
+  loading: boolean;
+  error: string;
+  run: () => void;
+  exportJson: () => void;
+  exportMarkdown: () => void;
+  copyMarkdown: () => void;
+  utmParams: Record<string, string>;
+  openGraph: OpenGraphPreview | null;
+}
+
+export function DeepLinkChainView({
+  url,
+  setUrl,
+  chain,
+  loading,
+  error,
+  run,
+  exportJson,
+  exportMarkdown,
+  copyMarkdown,
+  utmParams,
+  openGraph,
+}: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const visibleChain =
+    !expanded && chain.length > 6
+      ? [...chain.slice(0, 2), ...chain.slice(-2)]
+      : chain;
+
+  const statusClass = (status?: number) => {
+    if (!status) return 'text-gray-500';
+    if (status >= 200 && status < 300) return 'text-green-600';
+    if (status >= 300 && status < 400) return 'text-blue-600';
+    if (status >= 400) return 'text-red-600';
+    return '';
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2">
+        <input
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          className="flex-1 border px-2 py-1 rounded"
+          placeholder="https://example.com"
+        />
+        <button
+          type="button"
+          onClick={run}
+          disabled={loading}
+          className="bg-blue-600 text-white px-4 py-1 rounded disabled:opacity-50"
+        >
+          Trace
+        </button>
+      </div>
+      {error && <div className="text-red-600">{error}</div>}
+      {chain.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="border-b">
+                <th className="px-2 py-1 text-left">Hop</th>
+                <th className="px-2 py-1 text-left">URL</th>
+                <th className="px-2 py-1 text-left">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {visibleChain.map((h) => {
+                const realIndex = chain.indexOf(h);
+                return (
+                  <tr
+                    key={`${h.url}-${realIndex}`}
+                    className={`border-b ${realIndex === chain.length - 1 ? 'bg-green-50 dark:bg-green-900' : ''}`}
+                  >
+                    <td className="px-2 py-1">{realIndex + 1}</td>
+                    <td className="px-2 py-1 break-all">{h.url}</td>
+                    <td className={`px-2 py-1 ${statusClass(h.status)}`}>{h.status ?? '—'}</td>
+                  </tr>
+                );
+              })}
+              {!expanded && chain.length > visibleChain.length && (
+                <tr>
+                  <td colSpan={3} className="text-center py-1">
+                    <button
+                      type="button"
+                      className="underline text-sm"
+                      onClick={() => setExpanded(true)}
+                    >
+                      Show all {chain.length} hops
+                    </button>
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+          <div className="flex gap-2 mt-2">
+            <button type="button" onClick={exportJson} className="text-sm underline">Export JSON</button>
+            <button type="button" onClick={exportMarkdown} className="text-sm underline">Export Markdown</button>
+            <button type="button" onClick={copyMarkdown} className="text-sm underline">Copy Markdown</button>
+          </div>
+        </div>
+      )}
+      {Object.keys(utmParams).length > 0 && (
+        <div>
+          <h3 className="font-bold">UTM Parameters</h3>
+          <ul className="list-disc ml-5">
+            {Object.entries(utmParams).map(([k, v]) => (
+              <li key={k}><span className="font-mono">{k}</span>: {v}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {openGraph && (
+        <div className="border rounded p-3 max-w-sm" aria-label="Open Graph preview">
+          {openGraph.image && (
+            <img src={openGraph.image} alt="Open Graph" className="w-full h-auto mb-2 rounded" />
+          )}
+          <div className="font-bold">{openGraph.title}</div>
+          <div className="text-sm text-gray-500">{openGraph.domain}</div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default DeepLinkChainView;
+

--- a/viewmodel/useDeepLinkChain.ts
+++ b/viewmodel/useDeepLinkChain.ts
@@ -1,0 +1,79 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { useState } from 'react';
+import followRedirectChainFn, { RedirectHop, parseUtmParams, fetchOpenGraph, OpenGraphPreview } from '../model/deepLinkChain';
+
+export const useDeepLinkChain = (initialUrl = '') => {
+  const [url, setUrl] = useState(initialUrl);
+  const [chain, setChain] = useState<RedirectHop[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [openGraph, setOpenGraph] = useState<OpenGraphPreview | null>(null);
+
+  const run = async () => {
+    if (!url) return;
+    setLoading(true);
+    setError('');
+    setOpenGraph(null);
+    try {
+      const hops = await followRedirectChainFn(url);
+      setChain(hops);
+      const last = hops[hops.length - 1];
+      if (last) {
+        const og = await fetchOpenGraph(last.url);
+        if (og) setOpenGraph(og);
+      }
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const exportJson = () => {
+    const blob = new Blob([JSON.stringify(chain, null, 2)], { type: 'application/json' });
+    const href = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = href;
+    a.download = 'redirect-chain.json';
+    a.click();
+    URL.revokeObjectURL(href);
+  };
+
+  const exportMarkdown = () => {
+    const lines = chain.map((h, i) => `- [${i === chain.length - 1 ? 'Final' : `Hop ${i + 1}`}] ${h.url}`);
+    const blob = new Blob([lines.join('\n')], { type: 'text/markdown' });
+    const href = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = href;
+    a.download = 'redirect-chain.md';
+    a.click();
+    URL.revokeObjectURL(href);
+  };
+
+  const copyMarkdown = async () => {
+    const rows = chain.map((h, i) => `| ${i + 1} | ${h.url} | ${h.status ?? ''} |`);
+    const table = ['| Hop | URL | Status |', '| --- | --- | --- |', ...rows].join('\n');
+    await navigator.clipboard.writeText(table);
+  };
+
+  const utmParams = chain.length ? parseUtmParams(chain[chain.length - 1].url) : {};
+
+  return {
+    url,
+    setUrl,
+    chain,
+    loading,
+    error,
+    run,
+    exportJson,
+    exportMarkdown,
+    copyMarkdown,
+    utmParams,
+    openGraph,
+  };
+};
+
+export default useDeepLinkChain;
+


### PR DESCRIPTION
## Summary
- implement browser-only redirect follower `followRedirectChain`
- add React hook `useDeepLinkChain`
- create `DeepLinkChainView` component and page
- register the new tool
- document usage in tools docs
- test redirect chain logic

------
https://chatgpt.com/codex/tasks/task_e_6849c077bc9883299a9e385c11d7f75b