### PR TITLE
Add CORS Tester enhancements

### DIFF
--- a/__tests__/cors.test.ts
+++ b/__tests__/cors.test.ts
@@ -1,0 +1,80 @@
+import { runCorsPreflight, analyzeCors, generateCurlCommand } from '../model/cors';
+
+describe('runCorsPreflight', () => {
+  it('parses CORS headers', async () => {
+    const headers = new Headers({
+      'access-control-allow-origin': 'https://example.com',
+      'access-control-allow-methods': 'GET, POST',
+      'access-control-allow-headers': 'content-type',
+    });
+    (global.fetch as any) = jest.fn(() => Promise.resolve({
+      status: 204,
+      type: 'cors',
+      headers,
+    }));
+
+    const res = await runCorsPreflight('https://api.com', 'GET', {});
+    expect(res.response.headers['access-control-allow-origin']).toBe('https://example.com');
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toBe('https://api.com');
+  });
+
+  it('handles network errors', async () => {
+    (global.fetch as any) = jest.fn(() => Promise.reject(new Error('fail')));
+    const res = await runCorsPreflight('https://api.com', 'GET', {});
+    expect(res.response.error).toBe('fail');
+  });
+
+  it('returns status when denied', async () => {
+    (global.fetch as any) = jest.fn(() =>
+      Promise.resolve({ status: 403, type: 'cors', headers: new Headers() })
+    );
+    const res = await runCorsPreflight('https://api.com', 'POST', {});
+    expect(res.response.status).toBe(403);
+  });
+
+  it('handles opaque responses', async () => {
+    (global.fetch as any) = jest.fn(() =>
+      Promise.resolve({ status: 0, type: 'opaque', headers: new Headers() })
+    );
+    const res = await runCorsPreflight('https://api.com', 'GET', {});
+    expect(res.response.type).toBe('opaque');
+  });
+});
+
+describe('analyzeCors', () => {
+  it('detects mismatches and guides', () => {
+    const result = {
+      request: {
+        url: 'https://api.com',
+        method: 'POST',
+        headers: {},
+        actualHeaders: { Authorization: 'token', 'Content-Type': 'text/plain' },
+      },
+      response: {
+        status: 200,
+        type: 'cors',
+        headers: {
+          'access-control-allow-origin': 'https://site.com',
+          'access-control-allow-methods': 'GET',
+          'access-control-allow-headers': 'content-type',
+        },
+      },
+    } as any;
+
+    const res = analyzeCors(result, 'https://site.com', result.request.actualHeaders);
+    expect(res.mismatches.method).toBe(true);
+    expect(res.mismatches.headers).toBe(true);
+    expect(res.mismatches.credentials).toBe(true);
+    expect(res.guides.credentials).toBeDefined();
+  });
+});
+
+describe('generateCurlCommand', () => {
+  it('generates curl string', () => {
+    const cmd = generateCurlCommand('https://a.com', 'POST', {
+      Authorization: 'Bearer t',
+    });
+    expect(cmd).toContain("curl -X POST 'https://a.com'");
+    expect(cmd).toContain("-H 'Authorization: Bearer t'");
+  });
+});

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -50,3 +50,12 @@ import PentestSuitePage from '../src/tools/pentest/page';
 The Pentest Validator Suite runs a set of lightweight client‑side checks against any public URL. It tests HTTPS redirection, basic CORS policy, open redirects, reflected XSS and clickjacking protections. Results may be inconclusive when a site blocks cross‑origin access.
 Each validator is displayed on a single page with preview iframes so you can observe redirects and payload reflection directly in the browser.
 You can tweak the open redirect parameter and the XSS payload, and expand per-test logs for more detail.
+
+## CORS Tester
+
+```tsx
+import CorsTesterPage from '../src/tools/cors-tester';
+```
+
+Use the CORS Tester to simulate preflight requests and inspect the `Access-Control-*` headers returned by a server. Enter a target URL, HTTP method and custom headers to see how the server responds and whether your origin is permitted.
+Common CORS mistakes are highlighted with inline tips and a list of browsers that would block the request. You can quickly add preset headers from a dropdown and copy a generated `curl` command to reproduce the request locally.

--- a/model/cors.ts
+++ b/model/cors.ts
@@ -1,0 +1,162 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+export interface CorsHeaders {
+  [key: string]: string | null;
+}
+
+export interface CorsResult {
+  request: {
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    actualHeaders: Record<string, string>;
+  };
+  response: {
+    status: number;
+    type: Response['type'];
+    headers: CorsHeaders;
+    error?: string;
+  };
+}
+
+export const runCorsPreflight = async (
+  url: string,
+  method: string,
+  headers: Record<string, string>
+): Promise<CorsResult> => {
+  const { origin } = window.location;
+  const requestHeaders: Record<string, string> = {
+    Origin: origin,
+    'Access-Control-Request-Method': method.toUpperCase(),
+  };
+  const headerNames = Object.keys(headers);
+  if (headerNames.length > 0) {
+    requestHeaders['Access-Control-Request-Headers'] = headerNames.join(',');
+  }
+
+  try {
+    const res = await fetch(url, {
+      method: 'OPTIONS',
+      mode: 'cors',
+      headers: requestHeaders,
+    });
+
+    const corsHeaders: CorsHeaders = {
+      'access-control-allow-origin': res.headers.get('access-control-allow-origin'),
+      'access-control-allow-methods': res.headers.get('access-control-allow-methods'),
+      'access-control-allow-headers': res.headers.get('access-control-allow-headers'),
+      'access-control-allow-credentials': res.headers.get('access-control-allow-credentials'),
+    };
+
+    return {
+      request: { url, method, headers: requestHeaders, actualHeaders: headers },
+      response: {
+        status: res.status,
+        type: res.type,
+        headers: corsHeaders,
+      },
+    };
+  } catch (err: unknown) {
+    return {
+      request: { url, method, headers: requestHeaders, actualHeaders: headers },
+      response: {
+        status: 0,
+        type: 'error',
+        headers: {},
+        error: err instanceof Error ? err.message : String(err),
+      },
+    };
+  }
+};
+
+export default runCorsPreflight;
+
+export const generateCurlCommand = (
+  url: string,
+  method: string,
+  headers: Record<string, string>
+): string => {
+  const parts = [`curl -X ${method.toUpperCase()} '${url}'`];
+  Object.entries(headers).forEach(([k, v]) => {
+    parts.push(`-H '${k}: ${v}'`);
+  });
+  return parts.join(' ');
+};
+
+export interface CorsAnalysis {
+  mismatches: {
+    origin: boolean;
+    method: boolean;
+    headers: boolean;
+    credentials: boolean;
+  };
+  guides: Record<string, string>;
+  blockedBrowsers: string[];
+}
+
+export const analyzeCors = (
+  result: CorsResult,
+  origin: string,
+  actualHeaders: Record<string, string>
+): CorsAnalysis => {
+  const resHeaders = result.response.headers;
+  const allowOrigin = resHeaders['access-control-allow-origin'] || '';
+  const allowMethods = (resHeaders['access-control-allow-methods'] || '')
+    .toUpperCase()
+    .split(/,\s*/);
+  const allowHeaders = (resHeaders['access-control-allow-headers'] || '')
+    .toLowerCase()
+    .split(/,\s*/);
+
+  const reqHeaderNames = Object.keys(actualHeaders).map((h) => h.toLowerCase());
+
+  const originAllowed = allowOrigin === '*' || allowOrigin === origin;
+  const methodAllowed = allowMethods.includes(result.request.method.toUpperCase());
+  const headersAllowed = reqHeaderNames.every(
+    (h) => allowHeaders.includes(h) || allowHeaders.includes('*')
+  );
+  const credentialsNeeded = reqHeaderNames.some((h) =>
+    ['authorization', 'cookie'].includes(h)
+  );
+  const credentialsAllowed =
+    !credentialsNeeded || resHeaders['access-control-allow-credentials'] === 'true';
+
+  const mismatches = {
+    origin: !originAllowed,
+    method: !methodAllowed,
+    headers: !headersAllowed,
+    credentials: !credentialsAllowed,
+  };
+
+  const guides: Record<string, string> = {};
+  if (mismatches.origin) {
+    guides.origin =
+      'Server must send Access-Control-Allow-Origin with your origin or "*".';
+  }
+  if (mismatches.method) {
+    guides.method = 'Add the method to Access-Control-Allow-Methods.';
+  }
+  if (mismatches.headers) {
+    guides.headers =
+      'Ensure Access-Control-Allow-Headers lists all request headers.';
+  }
+  if (mismatches.credentials) {
+    guides.credentials =
+      'Use Access-Control-Allow-Credentials: true and avoid "*" for origin when sending credentials.';
+  }
+
+  const blockedBrowsers: string[] = [];
+  if (
+    resHeaders['access-control-allow-credentials'] === 'true' &&
+    allowOrigin === '*'
+  ) {
+    blockedBrowsers.push('Safari');
+  }
+  if (Object.values(mismatches).some(Boolean)) {
+    ['Chrome', 'Firefox', 'Edge'].forEach((b) => blockedBrowsers.push(b));
+  }
+
+  return { mismatches, guides, blockedBrowsers };
+};

--- a/src/tools/cors-tester/index.ts
+++ b/src/tools/cors-tester/index.ts
@@ -1,0 +1,4 @@
+import CorsTesterPage from './page';
+
+export { CorsTesterPage };
+export default CorsTesterPage;

--- a/src/tools/cors-tester/page.tsx
+++ b/src/tools/cors-tester/page.tsx
@@ -1,0 +1,13 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import useCorsTester from '../../../viewmodel/useCorsTester';
+import CorsTesterView from '../../../view/CorsTesterView';
+
+const CorsTesterPage: React.FC = () => {
+  const vm = useCorsTester();
+  return <CorsTesterView {...vm} />;
+};
+
+export default CorsTesterPage;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -300,6 +300,22 @@ const toolRegistry: Tool[] = [
     }
   },
   {
+    id: 'cors-tester',
+    route: '/cors-tester',
+    title: 'CORS Tester',
+    description: 'Debug CORS preflight responses.',
+    icon: HeadersIcon,
+    component: lazy(() => import('./cors-tester/page')),
+    category: 'Testing',
+    metadata: {
+      keywords: ['cors', 'preflight', 'debug', 'headers'],
+      relatedTools: ['headers-analyzer'],
+    },
+    uiOptions: {
+      showExamples: false
+    }
+  },
+  {
     id: 'crypto-lab',
     route: '/crypto-lab',
     title: 'Crypto Lab',

--- a/view/CorsTesterView.tsx
+++ b/view/CorsTesterView.tsx
@@ -1,0 +1,144 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import { CorsResult, CorsAnalysis } from '../model/cors';
+
+interface Props {
+  url: string;
+  setUrl: (v: string) => void;
+  method: string;
+  setMethod: (v: string) => void;
+  headerJson: string;
+  setHeaderJson: (v: string) => void;
+  runTest: () => void;
+  addPreset: (key: string) => void;
+  result: CorsResult | null;
+  analysis: CorsAnalysis | null;
+  curlCommand: string;
+  error: string;
+}
+
+export function CorsTesterView({
+  url,
+  setUrl,
+  method,
+  setMethod,
+  headerJson,
+  setHeaderJson,
+  runTest,
+  addPreset,
+  result,
+  analysis,
+  curlCommand,
+  error,
+}: Props) {
+  const mismatches = analysis ? analysis.mismatches : { origin: false, method: false, headers: false, credentials: false };
+  const guides = analysis?.guides || {};
+  const blockedBrowsers = analysis?.blockedBrowsers || [];
+
+  return (
+    <div className="space-y-4 bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md">
+      <h2 className="text-2xl font-bold text-gray-800 dark:text-white">CORS Tester</h2>
+      <div className="flex flex-col gap-4 md:flex-row md:items-end">
+        <input
+          type="text"
+          className="border px-3 py-2 rounded w-full dark:bg-gray-700 dark:text-gray-200"
+          placeholder="https://api.example.com"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+        />
+        <select
+          className="border px-3 py-2 rounded dark:bg-gray-700 dark:text-gray-200"
+          value={method}
+          onChange={(e) => setMethod(e.target.value)}
+        >
+          {['GET', 'POST', 'PUT', 'DELETE', 'PATCH'].map((m) => (
+            <option key={m} value={m}>{m}</option>
+          ))}
+        </select>
+        <select
+          className="border px-3 py-2 rounded dark:bg-gray-700 dark:text-gray-200"
+          onChange={(e) => { addPreset(e.target.value); e.currentTarget.selectedIndex = 0; }}
+        >
+          <option value="">Add header...</option>
+          {['Authorization', 'Content-Type', 'X-Custom'].map((p) => (
+            <option key={p} value={p}>{p}</option>
+          ))}
+        </select>
+        <button
+          type="button"
+          className="px-4 py-2 bg-primary-500 text-white rounded hover:bg-primary-600"
+          onClick={runTest}
+        >
+          Run Preflight
+        </button>
+      </div>
+      <textarea
+        className="border px-3 py-2 rounded w-full h-24 dark:bg-gray-700 dark:text-gray-200"
+        placeholder='{"Content-Type": "application/json"}'
+        value={headerJson}
+        onChange={(e) => setHeaderJson(e.target.value)}
+      />
+      {error && <div className="text-red-600">{error}</div>}
+      {result && (
+        <>
+          <table className="min-w-full text-sm text-left">
+            <thead>
+              <tr>
+                <th className="px-2 py-1">Header</th>
+                <th className="px-2 py-1">Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.entries(result.response.headers).map(([k, v]) => {
+                const keyMap: Record<string, 'origin' | 'method' | 'headers' | 'credentials' | ''> = {
+                  'access-control-allow-origin': 'origin',
+                  'access-control-allow-methods': 'method',
+                  'access-control-allow-headers': 'headers',
+                  'access-control-allow-credentials': 'credentials',
+                };
+                const mismatchKey = keyMap[k] || '';
+                const highlight = mismatchKey && mismatches[mismatchKey] ? 'text-red-600' : '';
+                return (
+                  <React.Fragment key={k}>
+                    <tr className="border-b">
+                      <td className="px-2 py-1 font-medium">{k}</td>
+                      <td className={`px-2 py-1 ${highlight}`}>{v ?? '-'}</td>
+                    </tr>
+                    {mismatchKey && mismatches[mismatchKey] && (
+                      <tr className="bg-red-50 text-xs text-red-600">
+                        <td colSpan={2} className="px-2 py-1">{guides[mismatchKey]}</td>
+                      </tr>
+                    )}
+                  </React.Fragment>
+                );
+              })}
+            </tbody>
+          </table>
+          {blockedBrowsers.length > 0 && (
+            <div className="mt-2 text-sm text-red-700">
+              Blocked browsers: {blockedBrowsers.join(', ')}
+            </div>
+          )}
+          <details className="mt-4">
+            <summary className="cursor-pointer">Request Flow & cURL</summary>
+            <pre className="bg-gray-100 dark:bg-gray-900 p-2 mt-2 rounded text-xs whitespace-pre-wrap">{JSON.stringify(result, null, 2)}</pre>
+            <div className="mt-2 flex items-center gap-2">
+              <code className="px-2 py-1 bg-gray-100 dark:bg-gray-900 rounded text-xs break-all">{curlCommand}</code>
+              <button
+                type="button"
+                className="px-2 py-1 bg-primary-500 text-white text-xs rounded"
+                onClick={() => navigator.clipboard.writeText(curlCommand)}
+              >
+                Copy curl
+              </button>
+            </div>
+          </details>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default CorsTesterView;

--- a/viewmodel/useCorsTester.ts
+++ b/viewmodel/useCorsTester.ts
@@ -56,17 +56,16 @@ export const useCorsTester = () => {
     }
   };
 
-  const curlCommand = generateCurlCommand(
-    url,
-    method,
-    (() => {
+  const curlCommand = useMemo(() => {
+    const headers = (() => {
       try {
         return JSON.parse(headerJson || '{}');
       } catch {
         return {};
       }
-    })()
-  );
+    })();
+    return generateCurlCommand(url, method, headers);
+  }, [url, method, headerJson]);
 
   return {
     url,

--- a/viewmodel/useCorsTester.ts
+++ b/viewmodel/useCorsTester.ts
@@ -1,0 +1,87 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { useState } from 'react';
+import {
+  runCorsPreflight,
+  CorsResult,
+  generateCurlCommand,
+  analyzeCors,
+  CorsAnalysis,
+} from '../model/cors';
+
+const presets: Record<string, Record<string, string>> = {
+  Authorization: { Authorization: 'Bearer <token>' },
+  'Content-Type': { 'Content-Type': 'application/json' },
+  'X-Custom': { 'X-Custom': 'test' },
+};
+
+export const useCorsTester = () => {
+  const [url, setUrl] = useState('');
+  const [method, setMethod] = useState('GET');
+  const [headerJson, setHeaderJson] = useState('{}');
+  const [result, setResult] = useState<CorsResult | null>(null);
+  const [analysis, setAnalysis] = useState<CorsAnalysis | null>(null);
+  const [error, setError] = useState('');
+
+  const runTest = async () => {
+    setError('');
+    setResult(null);
+    setAnalysis(null);
+    let headers: Record<string, string> = {};
+    try {
+      headers = JSON.parse(headerJson || '{}');
+    } catch {
+      setError('Invalid JSON for headers');
+      return;
+    }
+    try {
+      const res = await runCorsPreflight(url, method, headers);
+      setResult(res);
+      setAnalysis(analyzeCors(res, window.location.origin, headers));
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const addPreset = (key: string) => {
+    const preset = presets[key];
+    if (!preset) return;
+    try {
+      const obj = JSON.parse(headerJson || '{}');
+      Object.assign(obj, preset);
+      setHeaderJson(JSON.stringify(obj, null, 2));
+    } catch {
+      setError('Invalid JSON for headers');
+    }
+  };
+
+  const curlCommand = generateCurlCommand(
+    url,
+    method,
+    (() => {
+      try {
+        return JSON.parse(headerJson || '{}');
+      } catch {
+        return {};
+      }
+    })()
+  );
+
+  return {
+    url,
+    setUrl,
+    method,
+    setMethod,
+    headerJson,
+    setHeaderJson,
+    addPreset,
+    runTest,
+    result,
+    analysis,
+    curlCommand,
+    error,
+  };
+};
+
+export default useCorsTester;


### PR DESCRIPTION
## Summary
- refine model to analyze CORS results and build curl commands
- enhance `useCorsTester` with presets, curl copy and analysis state
- show inline CORS guides and request flow panel in `CorsTesterView`
- document advanced CORS Tester features
- expand tests for CORS logic

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849c07d9ae883299c0f2e56e0c4a565