### PR TITLE
Add Header Scanner tool

### DIFF
--- a/__tests__/headerScanner.test.ts
+++ b/__tests__/headerScanner.test.ts
@@ -1,0 +1,37 @@
+import { analyzeHeaders } from '../model/headerScanner';
+
+describe('analyzeHeaders', () => {
+  it('marks headers as ok when values are secure', async () => {
+    (global.fetch as any) = jest.fn(() => Promise.resolve({
+      type: 'basic',
+      headers: new Headers({
+        'x-frame-options': 'DENY',
+        'content-security-policy': "default-src 'self'",
+        'x-content-type-options': 'nosniff',
+        'referrer-policy': 'no-referrer',
+        'strict-transport-security': 'max-age=31536000; includeSubDomains',
+      }),
+    }));
+
+    const res = await analyzeHeaders('https://example.com');
+    const statuses = Object.fromEntries(res.map(r => [r.name, r.status]));
+    expect(statuses['x-frame-options']).toBe('ok');
+    expect(statuses['content-security-policy']).toBe('ok');
+  });
+
+  it('flags missing headers', async () => {
+    (global.fetch as any) = jest.fn(() => Promise.resolve({
+      type: 'basic',
+      headers: new Headers(),
+    }));
+
+    const res = await analyzeHeaders('https://example.com');
+    expect(res.find(r => r.name === 'x-frame-options')?.status).toBe('missing');
+  });
+
+  it('returns warnings on fetch error', async () => {
+    (global.fetch as any) = jest.fn(() => Promise.reject(new Error('fail')));
+    const res = await analyzeHeaders('https://bad.com');
+    expect(res.every(r => r.status === 'warning')).toBe(true);
+  });
+});

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -50,3 +50,11 @@ import PentestSuitePage from '../src/tools/pentest/page';
 The Pentest Validator Suite runs a set of lightweight client‑side checks against any public URL. It tests HTTPS redirection, basic CORS policy, open redirects, reflected XSS and clickjacking protections. Results may be inconclusive when a site blocks cross‑origin access.
 Each validator is displayed on a single page with preview iframes so you can observe redirects and payload reflection directly in the browser.
 You can tweak the open redirect parameter and the XSS payload, and expand per-test logs for more detail.
+
+## Header Scanner
+
+```tsx
+import HeaderScannerPage from '../src/tools/header-scanner/page';
+```
+
+The Header Scanner fetches a URL and analyzes common security headers like CSP, X-Frame-Options and HSTS. Results are shown with status chips and quick fix tips. You can copy header values or export the full report as JSON for audits.

--- a/model/headerScanner.ts
+++ b/model/headerScanner.ts
@@ -1,0 +1,79 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+export type HeaderStatus = 'ok' | 'warning' | 'missing';
+
+export interface HeaderAuditResult {
+  name: string;
+  value: string | null;
+  status: HeaderStatus;
+  fix: string;
+}
+
+interface Rule {
+  check: (v: string | null) => boolean;
+  fix: string;
+}
+
+const rules: Record<string, Rule> = {
+  'x-frame-options': {
+    check: (v) => ['deny', 'sameorigin'].includes((v ?? '').toLowerCase()),
+    fix: 'Set X-Frame-Options to "DENY" or "SAMEORIGIN"',
+  },
+  'content-security-policy': {
+    check: (v) => !!v,
+    fix: 'Define a strong Content-Security-Policy',
+  },
+  'x-content-type-options': {
+    check: (v) => (v ?? '').toLowerCase() === 'nosniff',
+    fix: 'Add X-Content-Type-Options: nosniff',
+  },
+  'referrer-policy': {
+    check: (v) => /no-referrer|same-origin|strict/.test((v ?? '').toLowerCase()),
+    fix: 'Set Referrer-Policy to no-referrer, same-origin or strict-origin',
+  },
+  'strict-transport-security': {
+    check: (v) => /max-age=\d+/.test(v ?? ''),
+    fix: 'Enable HSTS with max-age and includeSubDomains',
+  },
+};
+
+const securityHeaders = Object.keys(rules);
+
+export const analyzeHeaders = async (
+  url: string,
+): Promise<HeaderAuditResult[]> => {
+  const target = url.startsWith('http') ? url : `https://${url}`;
+  try {
+    const res = await fetch(target, { method: 'GET', redirect: 'manual' });
+    if (res.type === 'opaque') {
+      return securityHeaders.map((name) => ({
+        name,
+        value: null,
+        status: 'warning',
+        fix: rules[name].fix,
+      }));
+    }
+    return securityHeaders.map((name) => {
+      const value = res.headers.get(name);
+      if (!value) {
+        return { name, value: null, status: 'missing' as const, fix: rules[name].fix };
+      }
+      return {
+        name,
+        value,
+        status: rules[name].check(value) ? 'ok' : 'warning',
+        fix: rules[name].fix,
+      };
+    });
+  } catch {
+    return securityHeaders.map((name) => ({
+      name,
+      value: null,
+      status: 'warning',
+      fix: rules[name].fix,
+    }));
+  }
+};
+

--- a/src/tools/header-scanner/index.ts
+++ b/src/tools/header-scanner/index.ts
@@ -1,0 +1,4 @@
+import HeaderScannerPage from './page';
+
+export { HeaderScannerPage };
+export default HeaderScannerPage;

--- a/src/tools/header-scanner/page.tsx
+++ b/src/tools/header-scanner/page.tsx
@@ -1,0 +1,20 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import useHeaderScanner from '../../../viewmodel/useHeaderScanner';
+import HeaderScannerView from '../../../view/HeaderScannerView';
+import { getToolByRoute } from '../index';
+import { ToolLayout } from '../../design-system/components/layout';
+
+const HeaderScannerPage: React.FC = () => {
+  const vm = useHeaderScanner();
+  const tool = getToolByRoute('/header-scanner');
+  return (
+    <ToolLayout tool={tool!}>
+      <HeaderScannerView {...vm} />
+    </ToolLayout>
+  );
+};
+
+export default HeaderScannerPage;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -333,6 +333,20 @@ const toolRegistry: Tool[] = [
       showExamples: false
     }
   },
+  {
+    id: 'header-scanner',
+    route: '/header-scanner',
+    title: 'Header Scanner',
+    description: 'Scan security headers and get fix tips.',
+    icon: HeadersIcon,
+    component: lazy(() => import('./header-scanner/page')),
+    category: 'Security',
+    metadata: {
+      keywords: ['security headers', 'csp', 'hsts', 'referrer-policy'],
+      relatedTools: ['headers-analyzer', 'pentest-suite'],
+    },
+    uiOptions: { showExamples: false }
+  },
 ];
 
 export default toolRegistry;

--- a/view/HeaderScannerView.tsx
+++ b/view/HeaderScannerView.tsx
@@ -1,0 +1,109 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import { Badge } from '../src/design-system/components/display/Badge';
+import { Button } from '../src/design-system/components/inputs/Button';
+import { Card } from '../src/design-system/components/layout/Card';
+import { LoadingSpinner } from '../src/design-system/components/feedback/LoadingSpinner';
+import { HeaderAuditResult } from '../model/headerScanner';
+
+interface Props {
+  url: string;
+  setUrl: (u: string) => void;
+  results: HeaderAuditResult[];
+  loading: boolean;
+  error: string;
+  copied: boolean;
+  scan: () => void;
+  copy: (text: string) => void;
+  exportJson: () => void;
+}
+
+const statusBadge = (status: string) => {
+  switch (status) {
+    case 'ok':
+      return <Badge variant="success" pill>✅</Badge>;
+    case 'missing':
+      return <Badge variant="danger" pill>❌</Badge>;
+    default:
+      return <Badge variant="warning" pill>⚠️</Badge>;
+  }
+};
+
+export function HeaderScannerView({
+  url,
+  setUrl,
+  results,
+  loading,
+  error,
+  copied,
+  scan,
+  copy,
+  exportJson,
+}: Props) {
+  const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') scan();
+  };
+  return (
+    <div className="space-y-6">
+      <Card isElevated>
+          <div className="space-y-4">
+            <div>
+              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+              <label htmlFor="scan-url" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">URL</label>
+              <div className="flex">
+                <input
+                  id="scan-url"
+                  type="text"
+                  className="flex-grow rounded-l-md border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:text-white shadow-sm focus:border-primary-500 focus:ring focus:ring-primary-200 dark:focus:ring-primary-900 focus:ring-opacity-50"
+                  placeholder="example.com"
+                  value={url}
+                  onChange={(e) => setUrl(e.target.value)}
+                  onKeyPress={handleKey}
+                  disabled={loading}
+                />
+                <Button onClick={scan} isLoading={loading} disabled={loading || !url} className="rounded-l-none">Scan</Button>
+              </div>
+            </div>
+            {error && (
+              <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md text-red-700 dark:text-red-400 text-sm">
+                {error}
+              </div>
+            )}
+            {loading && (
+              <div className="flex justify-center py-8"><LoadingSpinner /></div>
+            )}
+            {results.length > 0 && !loading && (
+              <div className="space-y-4">
+                <div className="flex justify-end">
+                  <Button size="sm" onClick={exportJson}>Export JSON</Button>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {results.map((r) => (
+                    <div key={r.name} className="border border-gray-200 dark:border-gray-700 rounded-md p-4 flex flex-col gap-2">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium text-gray-800 dark:text-gray-100">{r.name}</span>
+                        {statusBadge(r.status)}
+                      </div>
+                      <div className="text-sm text-gray-700 dark:text-gray-300 break-all font-mono">
+                        {r.value ?? 'Not present'}
+                      </div>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">{r.fix}</p>
+                      <button
+                        type="button"
+                        onClick={() => copy(r.value ?? '')}
+                        className="self-start text-xs text-primary-600 dark:text-primary-400 hover:underline"
+                      >{copied ? 'Copied' : 'Copy value'}</button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </Card>
+      </div>
+  );
+}
+
+export default HeaderScannerView;

--- a/viewmodel/useHeaderScanner.ts
+++ b/viewmodel/useHeaderScanner.ts
@@ -1,0 +1,64 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { useState } from 'react';
+import { analyzeHeaders, HeaderAuditResult } from '../model/headerScanner';
+
+export const useHeaderScanner = () => {
+  const [url, setUrl] = useState('');
+  const [results, setResults] = useState<HeaderAuditResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  const scan = async () => {
+    if (!url) {
+      setError('URL required');
+      return;
+    }
+    setLoading(true);
+    setError('');
+    try {
+      const res = await analyzeHeaders(url);
+      setResults(res);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unexpected error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const copy = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  const exportJson = () => {
+    const blob = new Blob([JSON.stringify(results, null, 2)], {
+      type: 'application/json',
+    });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'header-scan.json';
+    a.click();
+    URL.revokeObjectURL(a.href);
+  };
+
+  return {
+    url,
+    setUrl,
+    results,
+    loading,
+    error,
+    copied,
+    scan,
+    copy,
+    exportJson,
+  };
+};
+
+export default useHeaderScanner;


### PR DESCRIPTION
## Summary
- implement `analyzeHeaders` in model
- add `useHeaderScanner` view model
- add `HeaderScannerView` component and page
- register header-scanner tool
- document Header Scanner
- add tests

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849c0975d1083299a110acb829dd47b