### PR TITLE
Add Cookie Scope conflict detector and export options

### DIFF
--- a/__tests__/cookieScope.test.ts
+++ b/__tests__/cookieScope.test.ts
@@ -1,0 +1,41 @@
+import { parseCookies } from '../model/cookieScope';
+
+describe('parseCookies', () => {
+  it('parses cookies from document.cookie', async () => {
+    document.cookie = 'foo=bar';
+    document.cookie = 'baz=qux';
+    const res = await parseCookies();
+    expect(res.find((c) => c.name === 'foo')?.value).toBe('bar');
+    expect(res.find((c) => c.name === 'baz')?.value).toBe('qux');
+  });
+
+  it('returns empty array when cookies disabled', async () => {
+    const enabled = Object.getOwnPropertyDescriptor(Navigator.prototype, 'cookieEnabled');
+    Object.defineProperty(Navigator.prototype, 'cookieEnabled', { value: false, configurable: true });
+    const res = await parseCookies();
+    expect(res).toEqual([]);
+    if (enabled) Object.defineProperty(Navigator.prototype, 'cookieEnabled', enabled);
+  });
+
+  it('uses cookieStore when available', async () => {
+    (global as any).window.cookieStore = {
+      getAll: async () => [
+        { name: 'cs', value: '1', domain: 'example.com', path: '/', sameSite: 'Lax', secure: true },
+      ],
+    };
+    const res = await parseCookies();
+    expect(res[0].name).toBe('cs');
+    expect(res[0].secure).toBe(true);
+    delete (global as any).window.cookieStore;
+  });
+
+  it('handles malformed cookie strings', async () => {
+    document.cookie = 'good=1';
+    document.cookie = 'malformed';
+    document.cookie = 'another=value';
+    const res = await parseCookies();
+    expect(res.find((c) => c.name === 'good')?.value).toBe('1');
+    expect(res.find((c) => c.name === 'malformed')?.value).toBe('');
+    expect(res.find((c) => c.name === 'another')?.value).toBe('value');
+  });
+});

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -41,6 +41,15 @@ import CookieInspectorPage from '../src/tools/cookie-inspector';
 Use the Cookie Inspector to quickly view and filter cookies available to your session. You can export the visible cookies to a JSON file for debugging or QA reports.
 Click any cookie name or value to copy it. Long values can be expanded inline, and exports are named using the current hostname and timestamp.
 
+## Cookie Scope
+
+```tsx
+import CookieScopePage from '../src/tools/cookie-scope';
+```
+
+Cookie Scope visualizes cookies from `document.cookie` directly in the browser. It highlights cookies with the same name across different paths or domains and detects SameSite inconsistencies.
+Use the debounced search bar to filter, toggle visibility of HttpOnly cookies, and copy or export the table as JSON or HAR without any network requests.
+
 ## Pentest Validator Suite
 
 ```tsx

--- a/model/cookieScope.ts
+++ b/model/cookieScope.ts
@@ -1,0 +1,57 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { parseCookieString } from './cookies';
+
+interface CookieStoreItem {
+  name: string;
+  value: string;
+  domain?: string;
+  path?: string;
+  sameSite?: string;
+  secure?: boolean;
+}
+
+export interface ParsedCookie {
+  name: string;
+  value: string;
+  domain?: string;
+  path?: string;
+  sameSite?: string;
+  secure: boolean;
+  httpOnly: boolean;
+  accessible: boolean;
+}
+
+export const parseCookies = async (): Promise<ParsedCookie[]> => {
+  if (typeof document === 'undefined' || !navigator.cookieEnabled) {
+    return [];
+  }
+
+  if (typeof window !== 'undefined' && (window as unknown as { cookieStore?: { getAll: () => Promise<CookieStoreItem[]> } }).cookieStore?.getAll) {
+    try {
+      const list: CookieStoreItem[] = await (window as unknown as { cookieStore: { getAll: () => Promise<CookieStoreItem[]> } }).cookieStore.getAll();
+      return list.map((c) => ({
+        name: c.name,
+        value: c.value,
+        domain: c.domain,
+        path: c.path,
+        sameSite: c.sameSite,
+        secure: !!c.secure,
+        httpOnly: false,
+        accessible: true,
+      }));
+    } catch {
+      // fall through to document.cookie parsing
+    }
+  }
+
+  const fromDoc = parseCookieString(document.cookie);
+  return fromDoc.map((c) => ({
+    name: c.name,
+    value: c.value,
+    secure: window.location.protocol === 'https:',
+    httpOnly: false,
+    accessible: true,
+  }));
+};

--- a/src/tools/cookie-scope/index.ts
+++ b/src/tools/cookie-scope/index.ts
@@ -1,0 +1,5 @@
+// Auto-generated index file
+import CookieScopePage from './page';
+
+export { CookieScopePage };
+export default CookieScopePage;

--- a/src/tools/cookie-scope/page.tsx
+++ b/src/tools/cookie-scope/page.tsx
@@ -1,0 +1,13 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import useCookieScope from '../../../viewmodel/useCookieScope';
+import CookieScopeView from '../../../view/CookieScopeView';
+
+const CookieScopePage: React.FC = () => {
+  const vm = useCookieScope();
+  return <CookieScopeView {...vm} />;
+};
+
+export default CookieScopePage;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -300,6 +300,22 @@ const toolRegistry: Tool[] = [
     }
   },
   {
+    id: 'cookie-scope',
+    route: '/cookie-scope',
+    title: 'Cookie Scope',
+    description: 'Visualize document cookies and highlight duplicates.',
+    icon: CookieIcon,
+    component: lazy(() => import('./cookie-scope/page')),
+    category: 'Testing',
+    metadata: {
+      keywords: ['cookie', 'scope', 'document.cookie', 'browser'],
+      relatedTools: ['cookie-inspector'],
+    },
+    uiOptions: {
+      showExamples: false
+    }
+  },
+  {
     id: 'crypto-lab',
     route: '/crypto-lab',
     title: 'Crypto Lab',

--- a/view/CookieScopeView.tsx
+++ b/view/CookieScopeView.tsx
@@ -1,0 +1,129 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import { ParsedCookie } from '../model/cookieScope';
+
+interface Props {
+  cookies: ParsedCookie[];
+  search: string;
+  setSearch: (v: string) => void;
+  showHttpOnly: boolean;
+  setShowHttpOnly: (v: boolean) => void;
+  duplicates: Set<string>;
+  conflicts: Set<string>;
+  sameSiteMismatch: Set<string>;
+  exportJson: () => void;
+  exportHar: () => void;
+  copy: (text: string) => void;
+  toastMessage: string;
+}
+
+export function CookieScopeView({
+  cookies,
+  search,
+  setSearch,
+  showHttpOnly,
+  setShowHttpOnly,
+  duplicates,
+  conflicts,
+  sameSiteMismatch,
+  exportJson,
+  exportHar,
+  copy,
+  toastMessage,
+}: Props) {
+  return (
+    <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md">
+      <h2 className="text-2xl font-bold mb-4 text-gray-800 dark:text-white">Cookie Scope</h2>
+      <div className="flex flex-col sm:flex-row sm:items-center mb-4 gap-2">
+        <input
+          type="text"
+          aria-label="Search cookies"
+          className="border px-3 py-2 rounded flex-1 dark:bg-gray-700 dark:text-gray-200 focus:ring"
+          placeholder="Search cookies"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <label htmlFor="toggle-httpOnly" className="inline-flex items-center text-sm text-gray-700 dark:text-gray-200">
+          <input
+            id="toggle-httpOnly"
+            type="checkbox"
+            checked={showHttpOnly}
+            onChange={(e) => setShowHttpOnly(e.target.checked)}
+            className="mr-2"
+          />
+          Show HttpOnly
+        </label>
+        <button
+          type="button"
+          className="px-3 py-2 bg-primary-500 text-white rounded hover:bg-primary-600 focus:ring"
+          onClick={exportJson}
+        >
+          Download JSON
+        </button>
+        <button
+          type="button"
+          className="px-3 py-2 bg-primary-500 text-white rounded hover:bg-primary-600 focus:ring"
+          onClick={exportHar}
+        >
+          Download HAR
+        </button>
+        <button
+          type="button"
+          className="px-3 py-2 bg-primary-500 text-white rounded hover:bg-primary-600 focus:ring"
+          onClick={() => copy(JSON.stringify(cookies, null, 2))}
+        >
+          Copy JSON
+        </button>
+      </div>
+      {toastMessage && (
+        <div className="fixed top-20 right-4 z-50 bg-gray-800 text-white px-4 py-2 rounded-md shadow-lg animate-fade-in-out">
+          {toastMessage}
+        </div>
+      )}
+      <div className="overflow-x-auto max-h-96">
+        <table className="min-w-full text-sm text-left text-gray-700 dark:text-gray-200">
+          <thead className="sticky top-0 bg-gray-100 dark:bg-gray-700 z-10">
+            <tr>
+              <th className="px-2 py-1">Name</th>
+              <th className="px-2 py-1">Value</th>
+              <th className="px-2 py-1">Domain</th>
+              <th className="px-2 py-1">Path</th>
+              <th className="px-2 py-1">SameSite</th>
+              <th className="px-2 py-1">Secure</th>
+              <th className="px-2 py-1">HttpOnly</th>
+              <th className="px-2 py-1">Accessible</th>
+            </tr>
+          </thead>
+          <tbody>
+            {cookies.map((c) => (
+              <tr
+                key={`${c.name}-${c.domain ?? 'd'}-${c.path ?? 'p'}`}
+                className={`border-b dark:border-gray-700 ${duplicates.has(c.name) ? 'bg-yellow-50 dark:bg-yellow-900' : ''} ${conflicts.has(c.name) ? 'bg-red-50 dark:bg-red-900' : ''} ${sameSiteMismatch.has(c.name) ? 'bg-orange-50 dark:bg-orange-900' : ''}`}
+              >
+                <td className="px-2 py-1 break-all">{c.name}</td>
+                <td className="px-2 py-1 break-all">{c.value}</td>
+                <td className="px-2 py-1">{c.domain ?? '-'}</td>
+                <td className="px-2 py-1">{c.path ?? '-'}</td>
+                <td className="px-2 py-1">{c.sameSite ?? '-'}</td>
+                <td className="px-2 py-1">{c.secure ? 'Yes' : 'No'}</td>
+                <td className="px-2 py-1">{c.httpOnly ? 'Yes' : 'No'}</td>
+                <td className="px-2 py-1">{c.accessible ? 'Yes' : 'No'}</td>
+              </tr>
+            ))}
+            {cookies.length === 0 && (
+              <tr>
+                <td className="px-2 py-4 text-center" colSpan={8}>
+                  No cookies found.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default CookieScopeView;

--- a/viewmodel/useCookieScope.ts
+++ b/viewmodel/useCookieScope.ts
@@ -1,0 +1,144 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { useEffect, useState } from 'react';
+import { ParsedCookie, parseCookies } from '../model/cookieScope';
+import { formatExportFilename } from '../model/cookies';
+
+export const useCookieScope = () => {
+  const [cookies, setCookies] = useState<ParsedCookie[]>([]);
+  const [search, setSearch] = useState('');
+  const [filter, setFilter] = useState('');
+  const [showHttpOnly, setShowHttpOnly] = useState(false);
+  const [toastMessage, setToastMessage] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      const data = await parseCookies();
+      setCookies(data);
+    })();
+  }, []);
+
+  useEffect(() => {
+    const id = setTimeout(() => setFilter(search), 300);
+    return () => clearTimeout(id);
+  }, [search]);
+
+  const filtered = cookies.filter((c) => {
+    if (!showHttpOnly && c.httpOnly) return false;
+    return (
+      c.name.toLowerCase().includes(filter.toLowerCase()) ||
+      c.value.toLowerCase().includes(filter.toLowerCase())
+    );
+  });
+
+  const duplicates = new Set<string>();
+  const conflicts = new Set<string>();
+  const sameSiteMismatch = new Set<string>();
+  const map = new Map<string, ParsedCookie[]>();
+  cookies.forEach((c) => {
+    const arr = map.get(c.name) || [];
+    arr.push(c);
+    map.set(c.name, arr);
+  });
+  map.forEach((arr, name) => {
+    if (arr.length > 1) {
+      duplicates.add(name);
+      const domainPaths = new Set(arr.map((x) => `${x.domain ?? ''}|${x.path ?? ''}`));
+      if (domainPaths.size > 1) conflicts.add(name);
+      const sameSiteSecure = new Set(arr.map((x) => `${x.sameSite ?? ''}|${x.secure}`));
+      if (sameSiteSecure.size > 1) sameSiteMismatch.add(name);
+    }
+  });
+
+  const exportJson = () => {
+    const blob = new Blob([JSON.stringify(filtered, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = formatExportFilename(window.location.hostname);
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const exportHar = () => {
+    const har = {
+      log: {
+        version: '1.2',
+        creator: { name: 'Cookie Scope', version: '1.0' },
+        entries: [
+          {
+            startedDateTime: new Date().toISOString(),
+            time: 0,
+            request: {
+              method: 'GET',
+              url: window.location.href,
+              httpVersion: 'HTTP/1.1',
+              cookies: filtered,
+              headers: [],
+              queryString: [],
+              headersSize: -1,
+              bodySize: -1,
+            },
+            response: {
+              status: 0,
+              statusText: '',
+              httpVersion: 'HTTP/1.1',
+              cookies: filtered,
+              headers: [],
+              content: { size: 0, mimeType: '', text: '' },
+              redirectURL: '',
+              headersSize: -1,
+              bodySize: -1,
+            },
+            cache: {},
+            timings: { send: 0, wait: 0, receive: 0 },
+          },
+        ],
+      },
+    };
+    const blob = new Blob([JSON.stringify(har, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = formatExportFilename(window.location.hostname).replace('.json', '.har');
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const copy = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setToastMessage('Copied!');
+    } catch {
+      setToastMessage('Clipboard access denied');
+    }
+  };
+
+  useEffect(() => {
+    if (!toastMessage) return undefined;
+    const t = setTimeout(() => setToastMessage(''), 2000);
+    return () => clearTimeout(t);
+  }, [toastMessage]);
+
+  return {
+    cookies: filtered,
+    search,
+    setSearch,
+    showHttpOnly,
+    setShowHttpOnly,
+    duplicates,
+    conflicts,
+    sameSiteMismatch,
+    exportJson,
+    exportHar,
+    copy,
+    toastMessage,
+  };
+};
+
+export default useCookieScope;


### PR DESCRIPTION
## Summary
- enhance Cookie Scope tool with conflict & SameSite detection
- add HttpOnly toggle, copy/export buttons and debounced search
- update docs with new features
- test cookie parser against malformed strings

## Checklist
* [x] **Model** `/model/cookieScope.ts`
* [x] **ViewModel** `/viewmodel/useCookieScope.ts`
* [x] **View** `/view/CookieScopeView.tsx`
* [x] **Route** `/tools/cookie-scope/page.tsx`
* [x] **Tests** `/__tests__/cookieScope.test.ts`
* [x] **Docs** `/docs/tools.md`

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6849c087c2b48329a4d9eb4f3a7bef68