### PR TITLE
Add Cache Inspector tool

### DIFF
--- a/__tests__/cacheInspector.test.ts
+++ b/__tests__/cacheInspector.test.ts
@@ -1,0 +1,76 @@
+import {
+  analyzeCacheFor,
+  parseCacheControl,
+  formatCacheControl,
+  exportCacheResults,
+} from '../model/cacheInspector';
+
+describe('analyzeCacheFor', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        headers: new Headers({ 'cache-control': 'max-age=0', etag: 'abc' }),
+      })
+    ) as any;
+
+    (global as any).caches = {
+      keys: () => Promise.resolve([]),
+      open: () => Promise.resolve({ match: () => Promise.resolve(undefined) }),
+    };
+
+    Object.defineProperty(global.performance, 'getEntriesByType', {
+      value: () => [
+        { name: 'https://example.com/app.js', initiatorType: 'script', transferSize: 0, decodedBodySize: 123 } as any,
+      ],
+      configurable: true,
+    });
+  });
+
+  it('marks resources as stale when max-age=0', async () => {
+    const res = await analyzeCacheFor(['https://example.com/app.js']);
+    expect(res[0].status).toBe('STALE');
+    expect(res[0].origin).toBe('memory');
+  });
+
+  it('guesses type from extension and service worker match', async () => {
+    (global as any).caches = {
+      keys: () => Promise.resolve(['v1']),
+      open: () => Promise.resolve({
+        match: (u: string) => Promise.resolve(u.endsWith('.css') ? {} : undefined),
+      }),
+    };
+    const res = await analyzeCacheFor(['https://example.com/style.css']);
+    expect(res[0].resourceType).toBe('style');
+    expect(res[0].serviceWorkerCaches).toEqual(['v1']);
+    expect(res[0].origin).toBe('service-worker');
+  });
+
+  it('parses cache-control headers', () => {
+    expect(parseCacheControl('max-age=3600, no-cache')).toEqual({ maxAge: 3600, noCache: true });
+  });
+
+  it('formats cache-control nicely', () => {
+    expect(formatCacheControl('max-age=60')).toBe('max-age=60 \u2794 1m');
+  });
+
+  it('exports grouped results', () => {
+    const data = [
+      {
+        url: 'https://a.com/foo.js',
+        resourceType: 'script',
+        cacheControl: 'max-age=0',
+        cacheControlLabel: 'max-age=0 \u2794 0s',
+        etag: null,
+        expires: null,
+        serviceWorkerCaches: [],
+        fromMemoryCache: false,
+        origin: 'network',
+        status: 'STALE',
+      },
+    ];
+    const json = exportCacheResults(data);
+    const obj = JSON.parse(json)[0];
+    expect(obj.domain).toBe('a.com');
+    expect(Array.isArray(obj.entries)).toBe(true);
+  });
+});

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -41,6 +41,14 @@ import CookieInspectorPage from '../src/tools/cookie-inspector';
 Use the Cookie Inspector to quickly view and filter cookies available to your session. You can export the visible cookies to a JSON file for debugging or QA reports.
 Click any cookie name or value to copy it. Long values can be expanded inline, and exports are named using the current hostname and timestamp.
 
+## Cache Inspector
+
+```tsx
+import CacheInspectorPage from '../src/tools/cache-inspector';
+```
+
+Use the Cache Inspector to analyze caching behaviour for resources loaded in your session. It now shows cache freshness badges (`FRESH`, `STALE`, `EXPIRED`, `NO-CACHE`), lists matching Service Worker cache names, and annotates whether a resource came from the network or memory. Results can be exported to a timestamped JSON file grouped by domain.
+
 ## Pentest Validator Suite
 
 ```tsx

--- a/model/cacheInspector.ts
+++ b/model/cacheInspector.ts
@@ -1,0 +1,159 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+export type ResourceType = 'script' | 'style' | 'image' | 'fetch';
+
+export type CacheStatus = 'FRESH' | 'STALE' | 'EXPIRED' | 'NO-CACHE';
+export type CacheOrigin = 'network' | 'memory' | 'service-worker';
+
+export interface CacheResult {
+  url: string;
+  resourceType: ResourceType;
+  cacheControl: string | null;
+  cacheControlLabel: string | null;
+  etag: string | null;
+  expires: string | null;
+  serviceWorkerCaches: string[];
+  fromMemoryCache: boolean;
+  origin: CacheOrigin;
+  status: CacheStatus;
+}
+
+export interface ParsedCacheControl {
+  maxAge?: number;
+  noCache?: boolean;
+  noStore?: boolean;
+}
+
+export const parseCacheControl = (header: string | null): ParsedCacheControl => {
+  if (!header) return {};
+  return header.split(',').reduce<ParsedCacheControl>((acc, part) => {
+    const token = part.trim().toLowerCase();
+    if (token === 'no-cache') acc.noCache = true;
+    else if (token === 'no-store') acc.noStore = true;
+    else if (token.startsWith('max-age=')) {
+      const n = parseInt(token.split('=')[1], 10);
+      if (!Number.isNaN(n)) acc.maxAge = n;
+    }
+    return acc;
+  }, {});
+};
+
+export const formatCacheControl = (header: string | null): string | null => {
+  if (!header) return null;
+  const parsed = parseCacheControl(header);
+  if (parsed.maxAge !== undefined) {
+    const s = parsed.maxAge;
+    const h = Math.floor(s / 3600);
+    const m = Math.floor((s % 3600) / 60);
+    const sec = s % 60;
+    const pieces = [] as string[];
+    if (h) pieces.push(`${h}h`);
+    if (m) pieces.push(`${m}m`);
+    if (sec || pieces.length === 0) pieces.push(`${sec}s`);
+    return `max-age=${s} \u2794 ${pieces.join(' ')}`;
+  }
+  if (parsed.noStore) return 'no-store';
+  if (parsed.noCache) return 'no-cache';
+  return header;
+};
+
+export const groupResultsByDomain = (
+  results: CacheResult[],
+): Record<string, CacheResult[]> =>
+  results.reduce<Record<string, CacheResult[]>>((acc, item) => {
+    const url = new URL(item.url);
+    const domain = url.hostname;
+    if (!acc[domain]) acc[domain] = [];
+    acc[domain].push(item);
+    return acc;
+  }, {});
+
+export const exportCacheResults = (results: CacheResult[]): string => {
+  const grouped = groupResultsByDomain(results);
+  const payload = Object.entries(grouped).map(([domain, entries]) => ({
+    domain,
+    timestamp: new Date().toISOString(),
+    entries,
+  }));
+  return JSON.stringify(payload, null, 2);
+};
+
+const guessType = (url: string, initiator?: string): ResourceType => {
+  const byInit =
+    initiator &&
+    ({
+      script: 'script',
+      css: 'style',
+      img: 'image',
+      xmlhttprequest: 'fetch',
+      fetch: 'fetch',
+    } as Record<string, ResourceType | undefined>)[initiator];
+  if (byInit) return byInit;
+  if (/\.css($|\?)/i.test(url)) return 'style';
+  if (/\.(png|jpe?g|gif|svg|webp)($|\?)/i.test(url)) return 'image';
+  if (/\.(js|mjs|ts)($|\?)/i.test(url)) return 'script';
+  return 'fetch';
+};
+
+export const analyzeCacheFor = async (urls: string[]): Promise<CacheResult[]> => {
+  const entries = performance.getEntriesByType('resource') as PerformanceResourceTiming[];
+  const cacheNames = await caches.keys();
+  const cacheObjects = await Promise.all(cacheNames.map((n) => caches.open(n)));
+
+  const findSwMatches = async (url: string) => {
+    const matches = await Promise.all(
+      cacheObjects.map(async (c, i) => {
+        const m = await c.match(url);
+        return m ? cacheNames[i] : null;
+      })
+    );
+    return matches.filter(Boolean) as string[];
+  };
+
+  return Promise.all(
+    urls.map(async (url) => {
+      const entry = entries.find((e) => e.name === url);
+      let cacheControl: string | null = null;
+      let etag: string | null = null;
+      let expires: string | null = null;
+      try {
+        const res = await fetch(url, { method: 'HEAD', cache: 'no-cache' });
+        cacheControl = res.headers.get('cache-control');
+        etag = res.headers.get('etag');
+        expires = res.headers.get('expires');
+      } catch {
+        // ignore failures (cross-origin etc.)
+      }
+      const swCaches = await findSwMatches(url);
+      const fromMemoryCache =
+        entry ? entry.transferSize === 0 && entry.decodedBodySize > 0 : false;
+      let origin: CacheOrigin = 'network';
+      if (swCaches.length > 0) origin = 'service-worker';
+      else if (fromMemoryCache) origin = 'memory';
+      const parsed = parseCacheControl(cacheControl);
+      const label = formatCacheControl(cacheControl);
+      let status: CacheStatus = 'FRESH';
+      const now = Date.now();
+      const exp = expires ? Date.parse(expires) : undefined;
+      if (parsed.noStore) status = 'NO-CACHE';
+      else if (parsed.noCache || parsed.maxAge === 0) status = 'STALE';
+      else if (exp !== undefined && exp < now) status = 'EXPIRED';
+      else status = 'FRESH';
+
+      return {
+        url,
+        resourceType: guessType(url, entry?.initiatorType),
+        cacheControl,
+        cacheControlLabel: label,
+        etag,
+        expires,
+        serviceWorkerCaches: swCaches,
+        fromMemoryCache,
+        origin,
+        status,
+      } as CacheResult;
+    })
+  );
+};

--- a/src/design-system/icons/tool-icons.tsx
+++ b/src/design-system/icons/tool-icons.tsx
@@ -108,3 +108,9 @@ export const CookieIcon: React.FC<IconProps> = ({ className }) => (
     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 15h.01M12 12h.01M12 18h.01M16 14h.01" />
   </svg>
 );
+
+export const CacheIcon: React.FC<IconProps> = ({ className }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+  </svg>
+);

--- a/src/tools/cache-inspector/index.ts
+++ b/src/tools/cache-inspector/index.ts
@@ -1,0 +1,5 @@
+// Auto-generated index file
+import CacheInspectorPage from './page';
+
+export { CacheInspectorPage };
+export default CacheInspectorPage;

--- a/src/tools/cache-inspector/page.tsx
+++ b/src/tools/cache-inspector/page.tsx
@@ -1,0 +1,13 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import useCacheInspector from '../../../viewmodel/useCacheInspector';
+import CacheInspectorView from '../../../view/CacheInspectorView';
+
+const CacheInspectorPage: React.FC = () => {
+  const vm = useCacheInspector();
+  return <CacheInspectorView {...vm} />;
+};
+
+export default CacheInspectorPage;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -61,7 +61,8 @@ import {
   ClickJackingIcon,
   LinkTracerIcon,
   Base64ImageIcon,
-  CookieIcon
+  CookieIcon,
+  CacheIcon
 } from '../design-system/icons/tool-icons';
 
 // Category definitions with icons for consistent UI
@@ -294,6 +295,22 @@ const toolRegistry: Tool[] = [
     metadata: {
       keywords: ['cookie', 'debug', 'browser', 'httpOnly', 'session'],
       relatedTools: [],
+    },
+    uiOptions: {
+      showExamples: false
+    }
+  },
+  {
+    id: 'cache-inspector',
+    route: '/cache-inspector',
+    title: 'Cache Inspector',
+    description: 'Inspect browser caching for loaded resources.',
+    icon: CacheIcon,
+    component: lazy(() => import('./cache-inspector/page')),
+    category: 'Testing',
+    metadata: {
+      keywords: ['cache', 'http', 'service worker', 'resource timing'],
+      relatedTools: ['headers-analyzer'],
     },
     uiOptions: {
       showExamples: false

--- a/view/CacheInspectorView.tsx
+++ b/view/CacheInspectorView.tsx
@@ -1,0 +1,81 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import { GroupedResults } from '../viewmodel/useCacheInspector';
+
+interface Props {
+  grouped: GroupedResults[];
+  loading: boolean;
+  exportJson: () => void;
+}
+
+export function CacheInspectorView({ grouped, loading, exportJson }: Props) {
+  return (
+    <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-2xl font-bold text-gray-800 dark:text-white">Cache Inspector</h2>
+        <button
+          type="button"
+          className="px-3 py-1 bg-primary-500 text-white rounded hover:bg-primary-600"
+          onClick={exportJson}
+        >
+          Export JSON
+        </button>
+      </div>
+      {loading && <p className="text-gray-700 dark:text-gray-300">Analyzing...</p>}
+      {!loading &&
+        grouped.map((group) => (
+          <details key={group.type} className="mb-4 border rounded">
+            <summary className="cursor-pointer px-2 py-1 font-medium capitalize text-gray-800 dark:text-gray-200">
+              {group.type}
+            </summary>
+            <div className="overflow-x-auto mt-2">
+              <table className="min-w-full text-sm text-left text-gray-700 dark:text-gray-200">
+                <thead>
+                  <tr>
+                    <th className="px-2 py-1">URL</th>
+                    <th className="px-2 py-1">Cache-Control</th>
+                    <th className="px-2 py-1">ETag</th>
+                    <th className="px-2 py-1">Expires</th>
+                    <th className="px-2 py-1">SW Caches</th>
+                    <th className="px-2 py-1">Origin</th>
+                    <th className="px-2 py-1">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {group.items.map((r) => (
+                    <tr key={r.url} className="border-b dark:border-gray-700">
+                      <td className="px-2 py-1 break-all">{r.url}</td>
+                      <td className="px-2 py-1 break-all">{r.cacheControlLabel ?? r.cacheControl ?? '-'}</td>
+                      <td className="px-2 py-1 break-all">{r.etag ?? '-'}</td>
+                      <td className="px-2 py-1 break-all">{r.expires ?? '-'}</td>
+                      <td className="px-2 py-1 break-all">
+                        {r.serviceWorkerCaches.length > 0 ? r.serviceWorkerCaches.join(', ') : '-'}
+                      </td>
+                      <td className="px-2 py-1 capitalize">{r.origin}</td>
+                      <td className="px-2 py-1">
+                        {(() => {
+                          let cls = 'bg-gray-600';
+                          if (r.status === 'FRESH') cls = 'bg-green-600';
+                          else if (r.status === 'STALE') cls = 'bg-yellow-600';
+                          else if (r.status === 'EXPIRED') cls = 'bg-red-600';
+                          return (
+                            <span className={`inline-block px-2 py-0.5 rounded-full text-white text-xs ${cls}`}>
+                              {r.status}
+                            </span>
+                          );
+                        })()}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </details>
+        ))}
+    </div>
+  );
+}
+
+export default CacheInspectorView;

--- a/viewmodel/useCacheInspector.ts
+++ b/viewmodel/useCacheInspector.ts
@@ -57,7 +57,7 @@ export const useCacheInspector = () => {
       .map(([type, items]) => ({ type: type as ResourceType, items }));
   }, [results]);
 
-  const exportJson = () => {
+  const exportJson = useCallback(() => {
     const blob = new Blob([exportCacheResults(results)], {
       type: 'application/json',
     });

--- a/viewmodel/useCacheInspector.ts
+++ b/viewmodel/useCacheInspector.ts
@@ -43,16 +43,16 @@ export const useCacheInspector = () => {
   }, []);
 
   const grouped = useMemo(() => {
-    const g: Record<ResourceType, CacheResult[]> = {
+    const groupedMap: Record<ResourceType, CacheResult[]> = {
       script: [],
       style: [],
       image: [],
       fetch: [],
     };
     results.forEach((r) => {
-      g[r.resourceType].push(r);
+      groupedMap[r.resourceType].push(r);
     });
-    return Object.entries(g)
+    return Object.entries(groupedMap)
       .filter(([, arr]) => arr.length > 0)
       .map(([type, items]) => ({ type: type as ResourceType, items }));
   }, [results]);

--- a/viewmodel/useCacheInspector.ts
+++ b/viewmodel/useCacheInspector.ts
@@ -20,13 +20,26 @@ export const useCacheInspector = () => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    let isMounted = true;
     (async () => {
-      const entries = performance.getEntriesByType('resource') as PerformanceResourceTiming[];
-      const urls = Array.from(new Set(entries.map((e) => e.name)));
-      const data = await analyzeCacheFor(urls);
-      setResults(data);
-      setLoading(false);
+      try {
+        const entries = performance.getEntriesByType('resource') as PerformanceResourceTiming[];
+        const urls = Array.from(new Set(entries.map((e) => e.name)));
+        const data = await analyzeCacheFor(urls);
+        if (isMounted) {
+          setResults(data);
+        }
+      } catch (error) {
+        console.error('Error analyzing cache:', error);
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
     })();
+    return () => {
+      isMounted = false;
+    };
   }, []);
 
   const grouped = useMemo(() => {

--- a/viewmodel/useCacheInspector.ts
+++ b/viewmodel/useCacheInspector.ts
@@ -1,0 +1,61 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { useEffect, useMemo, useState } from 'react';
+import {
+  analyzeCacheFor,
+  CacheResult,
+  ResourceType,
+  exportCacheResults,
+} from '../model/cacheInspector';
+import { formatExportFilename } from '../model/cookies';
+
+export interface GroupedResults {
+  type: ResourceType;
+  items: CacheResult[];
+}
+
+export const useCacheInspector = () => {
+  const [results, setResults] = useState<CacheResult[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const entries = performance.getEntriesByType('resource') as PerformanceResourceTiming[];
+      const urls = Array.from(new Set(entries.map((e) => e.name)));
+      const data = await analyzeCacheFor(urls);
+      setResults(data);
+      setLoading(false);
+    })();
+  }, []);
+
+  const grouped = useMemo(() => {
+    const g: Record<ResourceType, CacheResult[]> = {
+      script: [],
+      style: [],
+      image: [],
+      fetch: [],
+    };
+    results.forEach((r) => {
+      g[r.resourceType].push(r);
+    });
+    return Object.entries(g)
+      .filter(([, arr]) => arr.length > 0)
+      .map(([type, items]) => ({ type: type as ResourceType, items }));
+  }, [results]);
+
+  const exportJson = () => {
+    const blob = new Blob([exportCacheResults(results)], {
+      type: 'application/json',
+    });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = formatExportFilename(window.location.hostname);
+    a.click();
+    URL.revokeObjectURL(a.href);
+  };
+
+  return { grouped, loading, exportJson };
+};
+
+export default useCacheInspector;


### PR DESCRIPTION
## Summary
- implement Cache Inspector model with `analyzeCacheFor`
- add React hook and view
- register new route and icon
- document usage in tools guide
- cover new model with tests
- enhance Cache Inspector with freshness badges and SW cache details
- export results to JSON grouped by domain

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test -- --coverage`
- `pnpm audit`

------
https://chatgpt.com/codex/tasks/task_e_6849c0928038832993b1be6b520a4820