### PR TITLE
Fix cookie scope crash and add coverage

### DIFF
--- a/__tests__/CookieScopeView.test.tsx
+++ b/__tests__/CookieScopeView.test.tsx
@@ -1,0 +1,69 @@
+import "@testing-library/jest-dom";
+import { render } from '@testing-library/react';
+import CookieScopeView from '../view/CookieScopeView';
+import { ParsedCookie } from '../model/cookieScope';
+
+const baseCookie: ParsedCookie = {
+  name: 'foo',
+  value: 'bar',
+  domain: 'example.com',
+  path: '/',
+  sameSite: 'Lax',
+  secure: false,
+  httpOnly: false,
+  accessible: true,
+};
+
+test('row has style classes for duplicates and conflicts', () => {
+  const { container } = render(
+    <CookieScopeView
+      cookies={[baseCookie]}
+      search=""
+      setSearch={() => {}}
+      showHttpOnly
+      setShowHttpOnly={() => {}}
+      duplicates={new Set(['foo'])}
+      conflicts={new Set(['foo'])}
+      sameSiteMismatch={new Set(['foo'])}
+      exportJson={() => {}}
+      exportHar={() => {}}
+      copy={() => {}}
+      toastMessage=""
+    />,
+  );
+  const row = container.querySelector('tbody tr');
+  expect(row).toHaveClass('bg-yellow-50');
+  expect(row).toHaveClass('bg-red-50');
+  expect(row).toHaveClass('bg-orange-50');
+});
+
+
+test('renders toast message and buttons fire callbacks', () => {
+  const exportJson = jest.fn();
+  const exportHar = jest.fn();
+  const copy = jest.fn();
+  const { getByText } = render(
+    <CookieScopeView
+      cookies={[baseCookie]}
+      search=""
+      setSearch={() => {}}
+      showHttpOnly
+      setShowHttpOnly={() => {}}
+      duplicates={new Set()}
+      conflicts={new Set()}
+      sameSiteMismatch={new Set()}
+      exportJson={exportJson}
+      exportHar={exportHar}
+      copy={copy}
+      toastMessage="Done"
+    />,
+  );
+  expect(getByText('Done')).toBeInTheDocument();
+  getByText('Download JSON').click();
+  getByText('Download HAR').click();
+  getByText('Copy JSON').click();
+  expect(exportJson).toHaveBeenCalled();
+  expect(exportHar).toHaveBeenCalled();
+  expect(copy).toHaveBeenCalled();
+});
+

--- a/view/CookieScopeView.tsx
+++ b/view/CookieScopeView.tsx
@@ -33,6 +33,14 @@ export function CookieScopeView({
   copy,
   toastMessage,
 }: Props) {
+  const getRowClassName = (name: string) =>
+    [
+      duplicates.has(name) && 'bg-yellow-50 dark:bg-yellow-900',
+      conflicts.has(name) && 'bg-red-50 dark:bg-red-900',
+      sameSiteMismatch.has(name) && 'bg-orange-50 dark:bg-orange-900',
+    ]
+      .filter(Boolean)
+      .join(' ');
   return (
     <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md">
       <h2 className="text-2xl font-bold mb-4 text-gray-800 dark:text-white">Cookie Scope</h2>

--- a/viewmodel/useCacheInspector.ts
+++ b/viewmodel/useCacheInspector.ts
@@ -1,7 +1,7 @@
 /**
  * © 2025 MyDebugger Contributors – MIT License
  */
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, useCallback } from 'react';
 import {
   analyzeCacheFor,
   CacheResult,
@@ -66,7 +66,7 @@ export const useCacheInspector = () => {
     a.download = formatExportFilename(window.location.hostname);
     a.click();
     URL.revokeObjectURL(a.href);
-  };
+  }, [results]);
 
   return { grouped, loading, exportJson };
 };

--- a/viewmodel/useCorsTester.ts
+++ b/viewmodel/useCorsTester.ts
@@ -1,7 +1,7 @@
 /**
  * © 2025 MyDebugger Contributors – MIT License
  */
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import {
   runCorsPreflight,
   CorsResult,


### PR DESCRIPTION
## Summary
- define row style helper in `CookieScopeView`
- fix callback dependency in `useCacheInspector`
- add missing React import in `useCorsTester`
- test `CookieScopeView` row styling and actions

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6849c96c7898832996a2cf1dc7adbe2c