### PR TITLE
Add Virtual Name Card tool with new icon

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -108,3 +108,4 @@ import VirtualCardPage from '../src/tools/virtual-card/page';
 ```
 
 Create a shareable contact card completely in-browser. The tool generates a `.vcf` download, QR code, and URL with base64 encoded data that pre-fills the form when opened.
+Access this tool at `/vcard`.

--- a/src/design-system/icons/tool-icons.tsx
+++ b/src/design-system/icons/tool-icons.tsx
@@ -1,3 +1,6 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
 import React from 'react';
 
 // Tool icon components for the application
@@ -114,3 +117,21 @@ export const CacheIcon: React.FC<IconProps> = ({ className }) => (
     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
   </svg>
 );
+
+export const ContactCardIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M15 9h3.75M15 12h3.75M15 15h3.75M4.5 19.5h15A2.25 2.25 0 0 0 21.75 17.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15A2.25 2.25 0 0 0 2.25 6.75v10.5A2.25 2.25 0 0 0 4.5 19.5Zm6-10.125a1.875 1.875 0 1 1-3.75 0 1.875 1.875 0 0 1 3.75 0Zm1.294 6.336a6.721 6.721 0 0 1-3.17.789 6.721 6.721 0 0 1-3.168-.789 3.376 3.376 0 0 1 6.338 0Z"
+    />
+  </svg>
+);
+

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -63,7 +63,8 @@ import {
   LinkTracerIcon,
   Base64ImageIcon,
   CookieIcon,
-  CacheIcon
+  CacheIcon,
+  ContactCardIcon
 } from '../design-system/icons/tool-icons';
 
 // Category definitions with icons for consistent UI
@@ -345,6 +346,22 @@ const toolRegistry: Tool[] = [
     metadata: {
       keywords: ['localStorage', 'sessionStorage', 'debug', 'storage'],
       relatedTools: [],
+    },
+    uiOptions: {
+      showExamples: false,
+    },
+  },
+  {
+    id: 'virtual-card',
+    route: '/vcard',
+    title: 'Virtual Name Card',
+    description: 'Generate and share a digital contact card with QR code and download.',
+    icon: ContactCardIcon,
+    component: lazy(() => import('./virtual-card/page')),
+    category: 'Utilities',
+    metadata: {
+      keywords: ['vcard', 'contact', 'qr', 'vcf', 'share'],
+      relatedTools: ['qrcode-generator'],
     },
     uiOptions: {
       showExamples: false,


### PR DESCRIPTION
## Summary
- add MIT license header to `tool-icons.tsx`
- add new `ContactCardIcon`
- register Virtual Name Card tool at `/vcard`
- document `/vcard` route in tools docs

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm audit`

------
https://chatgpt.com/codex/tasks/task_e_68510a754da88329b3ca23d42bbd3439