### PR TITLE
Add SEO audit tools

### DIFF
--- a/__tests__/prerender.test.ts
+++ b/__tests__/prerender.test.ts
@@ -1,0 +1,23 @@
+import { parseMetadata, fetchSnapshot } from '../model/prerender';
+
+describe('parseMetadata', () => {
+  it('extracts title, meta description and h1', () => {
+    const html = '<html><head><title>T</title><meta name="description" content="D"/></head><body><h1>H</h1></body></html>';
+    expect(parseMetadata(html)).toEqual({ title: 'T', description: 'D', h1: 'H' });
+  });
+
+  it('handles missing tags', () => {
+    expect(parseMetadata('<html></html>')).toEqual({ title: null, description: null, h1: null });
+  });
+});
+
+describe('fetchSnapshot', () => {
+  it('calls proxy and parses', async () => {
+    (global.fetch as any) = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({ status: 200, html: '<title>x</title>' }) })
+    );
+    const snap = await fetchSnapshot('https://a.com', 'ua');
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain('/api/fetch-proxy');
+    expect(snap.title).toBe('x');
+  });
+});

--- a/api/fetch-proxy.js
+++ b/api/fetch-proxy.js
@@ -1,0 +1,29 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import fetch from 'node-fetch';
+
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  const { url, ua } = req.query;
+  if (!url) {
+    res.status(400).json({ error: 'Missing url parameter' });
+    return;
+  }
+
+  try {
+    const resp = await fetch(url, { headers: ua ? { 'User-Agent': ua } : undefined });
+    const html = await resp.text();
+    res.status(200).json({ status: resp.status, html });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+}

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -109,3 +109,18 @@ import VirtualCardPage from '../src/tools/virtual-card/page';
 
 Create a shareable contact card completely in-browser. The tool generates a `.vcf` download, QR code, and URL with base64 encoded data that pre-fills the form when opened.
 Access this tool at `/vcard`.
+## Pre-rendering Tester
+
+```tsx
+import PreRenderingTesterPage from '../src/tools/pre-rendering-tester/page';
+```
+
+Fetch HTML snapshots for any URL using multiple user-agent headers. Compare the page title, description and first H1 tag across crawlers or browsers. Results can be exported as raw markup or JSON.
+
+## Fetch & Render Tool
+
+```tsx
+import FetchRenderPage from '../src/tools/fetch-render/page';
+```
+
+Simulate JavaScript rendering in a sandboxed iframe. Set a timeout before capture, inspect console output and export the rendered DOM to clipboard or file for further analysis.

--- a/model/prerender.ts
+++ b/model/prerender.ts
@@ -1,0 +1,31 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+export interface Metadata {
+  title: string | null;
+  description: string | null;
+  h1: string | null;
+}
+
+export const parseMetadata = (html: string): Metadata => {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const title = doc.querySelector('title')?.textContent ?? null;
+  const description = doc.querySelector('meta[name="description"]')?.getAttribute('content') ?? null;
+  const h1 = doc.querySelector('h1')?.textContent?.trim() ?? null;
+  return { title, description, h1 };
+};
+
+export interface Snapshot extends Metadata {
+  userAgent: string;
+  status: number;
+  html: string;
+}
+
+export const fetchSnapshot = async (url: string, userAgent: string): Promise<Snapshot> => {
+  const res = await fetch(`/api/fetch-proxy?url=${encodeURIComponent(url)}&ua=${encodeURIComponent(userAgent)}`);
+  if (!res.ok) throw new Error('Failed to fetch');
+  const data = await res.json();
+  const meta = parseMetadata(data.html);
+  return { userAgent, status: data.status, html: data.html, ...meta };
+};

--- a/src/tools/fetch-render/index.ts
+++ b/src/tools/fetch-render/index.ts
@@ -1,0 +1,5 @@
+// Auto-generated index file
+import FetchRenderPage from './page';
+
+export { FetchRenderPage };
+export default FetchRenderPage;

--- a/src/tools/fetch-render/page.tsx
+++ b/src/tools/fetch-render/page.tsx
@@ -1,0 +1,13 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import useFetchRender from '../../../viewmodel/useFetchRender';
+import FetchRenderView from '../../../view/FetchRenderView';
+
+const FetchRenderPage: React.FC = () => {
+  const vm = useFetchRender();
+  return <FetchRenderView {...vm} />;
+};
+
+export default FetchRenderPage;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -447,6 +447,34 @@ const toolRegistry: Tool[] = [
     },
     uiOptions: { showExamples: false }
   },
+  {
+    id: 'pre-rendering-tester',
+    route: '/pre-rendering-tester',
+    title: 'Pre-rendering Tester',
+    description: 'Compare HTML snapshots across user-agents.',
+    icon: TestingIcon,
+    component: lazy(() => import('./pre-rendering-tester/page')),
+    category: 'Testing',
+    metadata: {
+      keywords: ['seo', 'prerender', 'crawler', 'user-agent'],
+      relatedTools: ['fetch-render'],
+    },
+    uiOptions: { showExamples: false }
+  },
+  {
+    id: 'fetch-render',
+    route: '/fetch-render',
+    title: 'Fetch & Render',
+    description: 'Emulate JS rendering and capture DOM.',
+    icon: TestingIcon,
+    component: lazy(() => import('./fetch-render/page')),
+    category: 'Testing',
+    metadata: {
+      keywords: ['seo', 'render', 'javascript', 'dom snapshot'],
+      relatedTools: ['pre-rendering-tester'],
+    },
+    uiOptions: { showExamples: false }
+  },
 ];
 
 export default toolRegistry;

--- a/src/tools/pre-rendering-tester/index.ts
+++ b/src/tools/pre-rendering-tester/index.ts
@@ -1,0 +1,5 @@
+// Auto-generated index file
+import PreRenderingTesterPage from './page';
+
+export { PreRenderingTesterPage };
+export default PreRenderingTesterPage;

--- a/src/tools/pre-rendering-tester/page.tsx
+++ b/src/tools/pre-rendering-tester/page.tsx
@@ -1,0 +1,13 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import usePreRenderingTester from '../../../viewmodel/usePreRenderingTester';
+import PreRenderingTesterView from '../../../view/PreRenderingTesterView';
+
+const PreRenderingTesterPage: React.FC = () => {
+  const vm = usePreRenderingTester();
+  return <PreRenderingTesterView {...vm} />;
+};
+
+export default PreRenderingTesterPage;

--- a/view/FetchRenderView.tsx
+++ b/view/FetchRenderView.tsx
@@ -1,0 +1,115 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import { TOOL_PANEL_CLASS } from '../src/design-system/foundations/layout';
+
+/* eslint-disable react/require-default-props */
+
+interface Props {
+  url: string;
+  setUrl: (v: string) => void;
+  delay: number;
+  setDelay: (v: number) => void;
+  run: () => void;
+  loading: boolean;
+  error: string;
+  iframeRef: React.RefObject<HTMLIFrameElement>;
+  srcDoc?: string;
+  rawHtml: string;
+  renderedHtml: string;
+  logs: string[];
+  copyHtml: () => void;
+  exportHtml: () => void;
+}
+
+export function FetchRenderView({
+  url,
+  setUrl,
+  delay,
+  setDelay,
+  run,
+  loading,
+  error,
+  iframeRef,
+  srcDoc,
+  rawHtml,
+  renderedHtml,
+  logs,
+  copyHtml,
+  exportHtml,
+}: Props) {
+  return (
+    <div className={TOOL_PANEL_CLASS}>
+      <h2 className="text-xl font-bold mb-4 text-gray-800 dark:text-white">Fetch &amp; Render</h2>
+      <div className="space-y-4">
+        <div>
+          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+          <label htmlFor="url" className="text-sm font-medium text-gray-700 dark:text-gray-300">URL</label>
+          <input
+            id="url"
+            type="text"
+            value={url}
+            onChange={e => setUrl(e.target.value)}
+            className="w-full border p-2 rounded dark:bg-gray-700 dark:text-gray-200"
+          />
+        </div>
+        <div>
+          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+          <label htmlFor="delay" className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            Delay (s)
+          </label>
+          <input
+            id="delay"
+            type="number"
+            min="0"
+            max="10"
+            value={delay}
+            onChange={e => setDelay(Number(e.target.value))}
+            className="border p-1 w-20 ml-2 rounded dark:bg-gray-700 dark:text-gray-200"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={run}
+          disabled={loading}
+          className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:opacity-50"
+        >
+          {loading ? 'Fetching...' : 'Fetch & Render'}
+        </button>
+        {error && <div className="text-red-600" aria-live="polite">{error}</div>}
+        {srcDoc && (
+          <iframe ref={iframeRef} srcDoc={srcDoc} title="render" className="w-full h-64 border" />
+        )}
+        {rawHtml && (
+          <div>
+            <h3 className="font-semibold">Raw HTML</h3>
+            <textarea value={rawHtml} readOnly className="w-full h-32 border p-2 rounded bg-gray-50 dark:bg-gray-900" />
+          </div>
+        )}
+        {renderedHtml && (
+          <div>
+            <h3 className="font-semibold">Rendered HTML</h3>
+            <textarea value={renderedHtml} readOnly className="w-full h-32 border p-2 rounded bg-gray-50 dark:bg-gray-900" />
+            <div className="flex gap-2 mt-2">
+              <button type="button" onClick={copyHtml} className="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded">
+                Copy
+              </button>
+              <button type="button" onClick={exportHtml} className="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded">
+                Download
+              </button>
+            </div>
+          </div>
+        )}
+        {logs.length > 0 && (
+          <div>
+            <h3 className="font-semibold">Console</h3>
+            <pre className="bg-gray-100 dark:bg-gray-900 p-2 overflow-x-auto text-xs h-32">{logs.join('\n')}</pre>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default FetchRenderView;

--- a/view/PreRenderingTesterView.tsx
+++ b/view/PreRenderingTesterView.tsx
@@ -1,0 +1,111 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import { TOOL_PANEL_CLASS } from '../src/design-system/foundations/layout';
+import { USER_AGENTS } from '../viewmodel/usePreRenderingTester';
+import { Snapshot } from '../model/prerender';
+
+interface Props {
+  url: string;
+  setUrl: (v: string) => void;
+  agents: string[];
+  toggleAgent: (id: string) => void;
+  run: () => void;
+  loading: boolean;
+  error: string;
+  results: Snapshot[];
+  copyJson: () => void;
+  exportJson: () => void;
+}
+
+export function PreRenderingTesterView({
+  url,
+  setUrl,
+  agents,
+  toggleAgent,
+  run,
+  loading,
+  error,
+  results,
+  copyJson,
+  exportJson,
+}: Props) {
+  return (
+    <div className={TOOL_PANEL_CLASS}>
+      <h2 className="text-xl font-bold mb-4 text-gray-800 dark:text-white">Pre-rendering Tester</h2>
+      <div className="space-y-4">
+        <div>
+          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+          <label htmlFor="url" className="text-sm font-medium text-gray-700 dark:text-gray-300">URL</label>
+          <input
+            id="url"
+            type="text"
+            value={url}
+            onChange={e => setUrl(e.target.value)}
+            className="w-full border p-2 rounded dark:bg-gray-700 dark:text-gray-200"
+          />
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {Object.keys(USER_AGENTS).map(id => (
+            // eslint-disable-next-line jsx-a11y/label-has-associated-control
+            <label key={id} className="flex items-center gap-1 text-sm text-gray-700 dark:text-gray-300">
+              <input
+                type="checkbox"
+                checked={agents.includes(id)}
+                onChange={() => toggleAgent(id)}
+                className="mr-1"
+              />
+              {id}
+            </label>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={run}
+          disabled={loading}
+          className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:opacity-50"
+        >
+          {loading ? 'Fetching...' : 'Fetch'}
+        </button>
+        {error && <div className="text-red-600" aria-live="polite">{error}</div>}
+        {results.length > 0 && (
+          <div className="space-y-2">
+            <table className="min-w-full text-sm border border-gray-200 dark:border-gray-700">
+              <thead>
+                <tr className="bg-gray-50 dark:bg-gray-900">
+                  <th className="px-2 py-1 text-left">Agent</th>
+                  <th className="px-2 py-1 text-left">Title</th>
+                  <th className="px-2 py-1 text-left">Description</th>
+                  <th className="px-2 py-1 text-left">H1</th>
+                  <th className="px-2 py-1 text-left">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {results.map(r => (
+                  <tr key={r.userAgent} className="border-t border-gray-200 dark:border-gray-700">
+                    <td className="px-2 py-1 break-all">{r.userAgent}</td>
+                    <td className="px-2 py-1 break-all">{r.title ?? '-'}</td>
+                    <td className="px-2 py-1 break-all">{r.description ?? '-'}</td>
+                    <td className="px-2 py-1 break-all">{r.h1 ?? '-'}</td>
+                    <td className="px-2 py-1">{r.status}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <div className="flex gap-2">
+              <button type="button" onClick={copyJson} className="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded">
+                Copy JSON
+              </button>
+              <button type="button" onClick={exportJson} className="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded">
+                Download
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default PreRenderingTesterView;

--- a/viewmodel/useFetchRender.ts
+++ b/viewmodel/useFetchRender.ts
@@ -1,0 +1,106 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { useEffect, useRef, useState } from 'react';
+import { fetchSnapshot } from '../model/prerender';
+
+export const useFetchRender = () => {
+  const [url, setUrl] = useState('');
+  const [delay, setDelay] = useState(2); // seconds
+  const [rawHtml, setRawHtml] = useState('');
+  const [renderedHtml, setRenderedHtml] = useState('');
+  const [logs, setLogs] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const run = async () => {
+    if (!url) return;
+    setLoading(true);
+    setError('');
+    setRenderedHtml('');
+    setLogs([]);
+    try {
+      const snap = await fetchSnapshot(url, 'MyDebugger-FetchRender/1.0');
+      setRawHtml(snap.html);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!rawHtml) return undefined;
+    const frame = iframeRef.current;
+    if (!frame) return undefined;
+
+    const handler = (ev: MessageEvent) => {
+      if (ev.source === frame.contentWindow && ev.data?.type === 'log') {
+        setLogs(l => [...l, ev.data.message]);
+      }
+    };
+    window.addEventListener('message', handler);
+
+    const timer = window.setTimeout(() => {
+      try {
+        const doc = frame.contentDocument;
+        if (doc) setRenderedHtml(doc.documentElement.outerHTML);
+      } catch {
+        // ignore cross origin
+      }
+    }, delay * 1000);
+
+    return () => {
+      window.removeEventListener('message', handler);
+      window.clearTimeout(timer);
+    };
+  }, [rawHtml, delay]);
+
+  const srcDoc = rawHtml
+    ? rawHtml.replace(
+        // eslint-disable-next-line no-useless-escape
+        /<\/body>/i,
+        `<script>(function(){['log','warn','error'].forEach(t=>{const o=console[t];console[t]=function(...a){parent.postMessage({type:'log',message:t+': '+a.join(' ')},'*');o.apply(console,a);};});window.onerror=function(m,s,l,c,e){parent.postMessage({type:'log',message:'error: '+m},'*');};})();</script></body>`
+      )
+    : undefined;
+
+  const copyHtml = async () => {
+    if (!renderedHtml) return;
+    try {
+      await navigator.clipboard.writeText(renderedHtml);
+    } catch {
+      // ignore clipboard errors
+    }
+  };
+
+  const exportHtml = () => {
+    if (!renderedHtml) return;
+    const blob = new Blob([renderedHtml], { type: 'text/html' });
+    const href = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = href;
+    a.download = 'rendered.html';
+    a.click();
+    URL.revokeObjectURL(href);
+  };
+
+  return {
+    url,
+    setUrl,
+    delay,
+    setDelay,
+    run,
+    loading,
+    error,
+    iframeRef,
+    srcDoc,
+    rawHtml,
+    renderedHtml,
+    logs,
+    copyHtml,
+    exportHtml,
+  };
+};
+
+export default useFetchRender;

--- a/viewmodel/usePreRenderingTester.ts
+++ b/viewmodel/usePreRenderingTester.ts
@@ -1,0 +1,61 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { useState } from 'react';
+import { fetchSnapshot, Snapshot } from '../model/prerender';
+
+export const USER_AGENTS: Record<string, string> = {
+  Googlebot: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+  Bingbot: 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)',
+  'Desktop Chrome':
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36',
+};
+
+export const usePreRenderingTester = () => {
+  const [url, setUrl] = useState('');
+  const [agents, setAgents] = useState<string[]>([]);
+  const [results, setResults] = useState<Snapshot[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const toggleAgent = (id: string) => {
+    setAgents(prev => (prev.includes(id) ? prev.filter(a => a !== id) : [...prev, id]));
+  };
+
+  const run = async () => {
+    if (!url || agents.length === 0) return;
+    setLoading(true);
+    setResults([]);
+    setError('');
+    try {
+      const snaps = await Promise.all(
+        agents.map(id =>
+          fetchSnapshot(url, USER_AGENTS[id]).then(s => ({ ...s, userAgent: id }))
+        )
+      );
+      setResults(snaps);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const copyJson = async () => {
+    await navigator.clipboard.writeText(JSON.stringify(results, null, 2));
+  };
+
+  const exportJson = () => {
+    const blob = new Blob([JSON.stringify(results, null, 2)], { type: 'application/json' });
+    const href = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = href;
+    a.download = 'prerender-results.json';
+    a.click();
+    URL.revokeObjectURL(href);
+  };
+
+  return { url, setUrl, agents, toggleAgent, results, run, loading, error, copyJson, exportJson };
+};
+
+export default usePreRenderingTester;


### PR DESCRIPTION
## Summary
- implement Pre-rendering Tester and Fetch & Render tool
- add fetch proxy API for custom user-agent
- document the new tools with usage examples
- enhance Fetch & Render tool with export options

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm audit` (low vulnerabilities)


------
https://chatgpt.com/codex/tasks/task_e_6851140169808329b4188860356aac09