### PR TITLE
Implement device trace tool

### DIFF
--- a/__tests__/deviceTrace.test.ts
+++ b/__tests__/deviceTrace.test.ts
@@ -1,0 +1,43 @@
+import { renderHook, act } from '@testing-library/react';
+import { runDeviceTrace } from '../model/deviceTrace';
+import useDeviceTrace from '../viewmodel/useDeviceTrace';
+
+describe('runDeviceTrace', () => {
+  it('posts to the API and returns result', async () => {
+    (global.fetch as any) = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ url: 'https://a.com', overallTimeMs: 1, results: [] }),
+      })
+    );
+    const res = await runDeviceTrace('https://a.com');
+    expect(res.url).toBe('https://a.com');
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toBe('/api/device-trace');
+  });
+
+  it('throws when request fails', async () => {
+    (global.fetch as any) = jest.fn(() => Promise.resolve({ ok: false, status: 500 }));
+    await expect(runDeviceTrace('https://x.com')).rejects.toThrow('500');
+  });
+
+  it('copy and export helpers work', async () => {
+    (global.fetch as any) = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ url: 'https://a.com', overallTimeMs: 1, results: [] }),
+      })
+    );
+
+    const { result } = renderHook(() => useDeviceTrace());
+    await act(async () => {
+      result.current.setUrl('https://a.com');
+      await result.current.run();
+    });
+
+    (navigator as any).clipboard = { writeText: jest.fn() };
+    await act(async () => {
+      await result.current.copyJson();
+      result.current.exportJson();
+    });
+  });
+});

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -111,6 +111,15 @@ import DeepLinkChainPage from "../src/tools/deep-link-chain/page";
 
 Follow and visualize the redirect chain for any URL entirely in the browser. The tool lists each hop with status codes and headers, highlights the final destination and extracts any UTM parameters present. Long chains collapse automatically with an option to expand. If fetch is blocked by CORS the tool attempts a browser-only fallback. The final URL displays an Open Graph preview when accessible. Results can be exported or copied as a Markdown table.
 
+## Dynamic-Link Probe
+
+```tsx
+import DeviceTracePage from "../src/tools/linktracer/DeviceTrace";
+```
+
+Simulate how OneLink or custom dynamic URLs behave across iOS and Android with or without your app installed. Provide optional app identifiers and a deep-link scheme to verify that redirects land on the correct store page or launch the app as expected.
+Results can be copied to the clipboard or downloaded as JSON for further analysis.
+
 ## Virtual Name Card
 
 ```tsx

--- a/model/deviceTrace.ts
+++ b/model/deviceTrace.ts
@@ -1,0 +1,29 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { DeviceTraceResult } from '../src/tools/linktracer/types';
+
+export interface DeviceTraceOptions {
+  maxHops?: number;
+  iosAppId?: string;
+  androidPackage?: string;
+  deepLinkScheme?: string;
+}
+
+export const runDeviceTrace = async (
+  url: string,
+  options: DeviceTraceOptions = {},
+): Promise<DeviceTraceResult> => {
+  const res = await fetch('/api/device-trace', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ url, ...options }),
+  });
+  if (!res.ok) {
+    throw new Error(`Request failed with status ${res.status}`);
+  }
+  const data = (await res.json()) as DeviceTraceResult;
+  return data;
+};
+
+export default runDeviceTrace;

--- a/src/tools/linktracer/DeviceTrace.tsx
+++ b/src/tools/linktracer/DeviceTrace.tsx
@@ -1,51 +1,16 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
 import React from 'react';
-import { TOOL_PANEL_CLASS } from '../../design-system/foundations/layout';
-// Remove import from helmet
-// import { Helmet } from 'react-helmet-async';
+import useDeviceTrace from '../../../viewmodel/useDeviceTrace';
+import DeviceTraceView from '../../../view/DeviceTraceView';
 
-// Simplified DeviceTrace component
-const DeviceTrace: React.FC = () => {
+const DeviceTracePage: React.FC = () => {
+  const vm = useDeviceTrace();
   React.useEffect(() => {
     document.title = 'Device Trace | MyDebugger';
   }, []);
-
-  return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold mb-4">Device Trace Tool</h1>
-      <p className="mb-8">
-        This tool helps you trace how links behave across different devices and configurations.
-      </p>
-      
-      <div className="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-8">
-        <p className="text-yellow-700">
-          The device tracing functionality is currently disabled.
-        </p>
-      </div>
-      
-      {/* Simplified form */}
-      <div className={TOOL_PANEL_CLASS}>
-        <form>
-          <div className="mb-4">
-            <label className="block text-gray-700 font-medium mb-2">URL to Trace</label>
-            <input
-              type="url"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md"
-              placeholder="https://example.com"
-              disabled
-            />
-          </div>
-          
-          <button
-            type="button"
-            disabled
-            className="bg-blue-500 text-white px-4 py-2 rounded-md opacity-50 cursor-not-allowed"
-          >
-            Trace URL
-          </button>
-        </form>
-      </div>
-    </div>
-  );
+  return <DeviceTraceView {...vm} />;
 };
 
-export default DeviceTrace;
+export default DeviceTracePage;

--- a/view/DeviceTraceView.tsx
+++ b/view/DeviceTraceView.tsx
@@ -1,0 +1,161 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import { TOOL_PANEL_CLASS } from '../src/design-system/foundations/layout';
+import { Badge } from '../src/design-system/components/display/Badge';
+import { Button } from '../src/design-system/components/inputs/Button';
+import { DeviceTraceResult, ScenarioResult } from '../src/tools/linktracer/types';
+
+interface Props {
+  url: string;
+  setUrl: (v: string) => void;
+  iosAppId: string;
+  setIosAppId: (v: string) => void;
+  androidPackage: string;
+  setAndroidPackage: (v: string) => void;
+  deepLinkScheme: string;
+  setDeepLinkScheme: (v: string) => void;
+  maxHops: number;
+  setMaxHops: (v: number) => void;
+  loading: boolean;
+  result: DeviceTraceResult | null;
+  error: string;
+  run: () => void;
+  copyJson: () => void;
+  exportJson: () => void;
+}
+
+function ScenarioTable({ data }: { data: ScenarioResult }) {
+  return (
+    <details className="border rounded mb-4">
+      <summary className="cursor-pointer px-2 py-1 font-medium flex items-center gap-2">
+        <span>{data.name}</span>
+        <Badge variant={data.isValidOutcome ? 'success' : 'warning'} size="sm" pill>
+          {data.status}
+        </Badge>
+      </summary>
+      <div className="overflow-x-auto p-2">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="border-b">
+            <th className="px-2 py-1 text-left">Hop</th>
+            <th className="px-2 py-1 text-left">URL</th>
+            <th className="px-2 py-1 text-left">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.hops.map((h) => (
+            <tr key={h.n} className="border-b">
+              <td className="px-2 py-1">{h.n}</td>
+              <td className="px-2 py-1 break-all">{h.url}</td>
+              <td className="px-2 py-1">{h.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {data.deep_link && (
+        <p className="mt-2 text-sm break-all">
+          Deep Link: <code>{data.deep_link}</code>
+        </p>
+      )}
+      {data.final_url && data.final_url !== data.deep_link && (
+        <p className="mt-1 text-sm break-all">
+          Final URL: <code>{data.final_url}</code>
+        </p>
+      )}
+        {data.warnings.length > 0 && (
+          <p className="mt-1 text-sm text-yellow-700">
+            Warnings: {data.warnings.join(', ')}
+          </p>
+        )}
+      </div>
+    </details>
+  );
+}
+
+export function DeviceTraceView({
+  url,
+  setUrl,
+  iosAppId,
+  setIosAppId,
+  androidPackage,
+  setAndroidPackage,
+  deepLinkScheme,
+  setDeepLinkScheme,
+  maxHops,
+  setMaxHops,
+  loading,
+  result,
+  error,
+  run,
+  copyJson,
+  exportJson,
+}: Props) {
+  return (
+    <div className={TOOL_PANEL_CLASS}>
+      <div className="space-y-4">
+        <div className="flex gap-2">
+          <input
+            className="flex-1 border px-2 py-1 rounded"
+            placeholder="https://example.com"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+          />
+          <button
+            type="button"
+            onClick={run}
+            disabled={loading}
+            className="bg-blue-600 text-white px-4 py-1 rounded disabled:opacity-50"
+          >
+            Trace
+          </button>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-4 gap-2">
+          <input
+            className="border px-2 py-1 rounded"
+            placeholder="iOS App ID"
+            value={iosAppId}
+            onChange={(e) => setIosAppId(e.target.value)}
+          />
+          <input
+            className="border px-2 py-1 rounded"
+            placeholder="Android Package"
+            value={androidPackage}
+            onChange={(e) => setAndroidPackage(e.target.value)}
+          />
+          <input
+            className="border px-2 py-1 rounded"
+            placeholder="Deep Link Scheme"
+            value={deepLinkScheme}
+            onChange={(e) => setDeepLinkScheme(e.target.value)}
+          />
+          <input
+            type="number"
+            className="border px-2 py-1 rounded"
+            placeholder="Max Hops"
+            value={maxHops}
+            onChange={(e) => setMaxHops(Number(e.target.value))}
+            min={1}
+            max={50}
+          />
+        </div>
+        {error && <div className="text-red-600">{error}</div>}
+        {result && (
+          <div>
+            <h3 className="font-bold mb-2">Results ({result.overallTimeMs}ms)</h3>
+            {result.results.map((r) => (
+              <ScenarioTable key={r.scenario} data={r} />
+            ))}
+            <div className="flex gap-2 mt-2">
+              <Button size="sm" onClick={copyJson} variant="secondary">Copy JSON</Button>
+              <Button size="sm" onClick={exportJson} variant="secondary">Download</Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default DeviceTraceView;

--- a/viewmodel/useDeviceTrace.ts
+++ b/viewmodel/useDeviceTrace.ts
@@ -1,0 +1,74 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { useState } from 'react';
+import { runDeviceTrace, DeviceTraceOptions } from '../model/deviceTrace';
+import { DeviceTraceResult } from '../src/tools/linktracer/types';
+
+export const useDeviceTrace = () => {
+  const [url, setUrl] = useState('');
+  const [iosAppId, setIosAppId] = useState('');
+  const [androidPackage, setAndroidPackage] = useState('');
+  const [deepLinkScheme, setDeepLinkScheme] = useState('');
+  const [maxHops, setMaxHops] = useState(20);
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<DeviceTraceResult | null>(null);
+  const [error, setError] = useState('');
+
+  const run = async () => {
+    if (!url) return;
+    setLoading(true);
+    setError('');
+    try {
+      const opts: DeviceTraceOptions = {};
+      if (iosAppId) opts.iosAppId = iosAppId;
+      if (androidPackage) opts.androidPackage = androidPackage;
+      if (deepLinkScheme) opts.deepLinkScheme = deepLinkScheme;
+      const data = await runDeviceTrace(url, { ...opts, maxHops });
+      setResult(data);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const copyJson = async () => {
+    if (!result) return;
+    await navigator.clipboard.writeText(JSON.stringify(result, null, 2));
+  };
+
+  const exportJson = () => {
+    if (!result) return;
+    const blob = new Blob([JSON.stringify(result, null, 2)], {
+      type: 'application/json',
+    });
+    const href = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = href;
+    a.download = 'device-trace.json';
+    a.click();
+    URL.revokeObjectURL(href);
+  };
+
+  return {
+    url,
+    setUrl,
+    iosAppId,
+    setIosAppId,
+    androidPackage,
+    setAndroidPackage,
+    deepLinkScheme,
+    setDeepLinkScheme,
+    maxHops,
+    setMaxHops,
+    loading,
+    result,
+    error,
+    run,
+    copyJson,
+    exportJson,
+  };
+};
+
+export default useDeviceTrace;


### PR DESCRIPTION
## Summary
- add model for device trace that posts to API
- implement useDeviceTrace hook with export helpers
- add DeviceTraceView with improved developer UI
- update docs on Dynamic-Link Probe
- cover device trace hook helpers with tests

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm audit` (reported 4 vulnerabilities)


------
https://chatgpt.com/codex/tasks/task_e_685121aba5208329aa93dd7fc32ff53f