### PR TITLE
Add interactive virtual name card UI

### DIFF
--- a/view/VirtualCardActions.tsx
+++ b/view/VirtualCardActions.tsx
@@ -1,0 +1,53 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React, { useEffect, useState } from 'react';
+
+interface Props {
+  download: () => void;
+  shareCard: () => void;
+  showQr: () => void;
+}
+
+export default function VirtualCardActions({ download, shareCard, showQr }: Props) {
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    let lastY = window.scrollY;
+    const onScroll = () => {
+      const current = window.scrollY;
+      setHidden(current > lastY);
+      lastY = current;
+    };
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  return (
+    <div
+      className={`fixed bottom-4 inset-x-0 flex justify-center gap-3 md:hidden transition-transform duration-300 ${hidden ? 'translate-y-24 opacity-0' : 'translate-y-0'}`}
+    >
+      <button
+        type="button"
+        onClick={download}
+        className="px-4 py-2 rounded-full bg-primary-600 text-white shadow"
+      >
+        Save to Contacts
+      </button>
+      <button
+        type="button"
+        onClick={shareCard}
+        className="px-4 py-2 rounded-full bg-primary-600 text-white shadow"
+      >
+        Share My Card
+      </button>
+      <button
+        type="button"
+        onClick={showQr}
+        className="px-4 py-2 rounded-full bg-gray-200 text-gray-800 shadow"
+      >
+        Show QR Again
+      </button>
+    </div>
+  );
+}

--- a/view/VirtualCardHero.tsx
+++ b/view/VirtualCardHero.tsx
@@ -1,0 +1,143 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React, { forwardRef, useImperativeHandle } from 'react';
+
+const clsx = (...c: Array<string | false | null | undefined>) => c.filter(Boolean).join(' ');
+
+interface Props {
+  fullName: string;
+  phone: string;
+  email: string;
+  qrDataUrl: string;
+  flipped: boolean;
+  flip: (toBack?: boolean) => void;
+  download: () => void;
+  downloadQr: () => void;
+  copyVcard: () => void;
+  shareCard: () => void;
+  onInteract: () => void;
+}
+
+export interface VirtualCardHeroHandle {
+  showQr: () => void;
+}
+
+const VirtualCardHero = forwardRef<VirtualCardHeroHandle, Props>(({ 
+  fullName,
+  phone,
+  email,
+  qrDataUrl,
+  flipped,
+  flip,
+  download,
+  downloadQr,
+  copyVcard,
+  shareCard,
+  onInteract,
+}, ref) => {
+  const handleFlip = () => flip(!flipped);
+
+  useImperativeHandle(ref, () => ({ showQr: () => flip(true) }));
+
+  return (
+    <div className="relative mx-auto my-6 w-72 h-96 [perspective:1000px]">
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => { handleFlip(); onInteract(); }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') { handleFlip(); onInteract(); }
+        }}
+        aria-label="Flip card"
+        className={clsx(
+          'absolute inset-0 [transform-style:preserve-3d]',
+          'transition-transform duration-700 [transition-timing-function:cubic-bezier(0.34,1.56,0.64,1)]',
+          'motion-reduce:transition-opacity motion-reduce:duration-300',
+          flipped && 'rotate-y-180 motion-reduce:rotate-y-0',
+        )}
+      >
+        <div
+          className={clsx(
+            'absolute inset-0 flex flex-col items-center justify-center rounded-2xl shadow-xl',
+            'bg-white dark:bg-gray-800 [backface-visibility:hidden] motion-reduce:[backface-visibility:visible]',
+            'transition-opacity duration-300',
+            flipped && 'opacity-0 motion-reduce:opacity-100',
+          )}
+        >
+          <div className="w-24 h-24 rounded-full bg-gray-200 dark:bg-gray-700 shadow mb-4" />
+          <p className="text-xl font-semibold text-gray-800 dark:text-white">{fullName || 'Your Name'}</p>
+          {phone && <p className="text-gray-600 dark:text-gray-300 text-sm">{phone}</p>}
+          {email && <p className="text-gray-600 dark:text-gray-300 text-sm">{email}</p>}
+          <div className="flex gap-3 mt-4">
+            {phone && (
+              <a
+                href={`tel:${phone}`}
+                className="flex items-center gap-1 px-3 py-1 text-sm bg-primary-600 text-white rounded focus:outline-none"
+              >
+                📞 Call
+              </a>
+            )}
+            {email && (
+              <a
+                href={`mailto:${email}`}
+                className="flex items-center gap-1 px-3 py-1 text-sm bg-primary-600 text-white rounded focus:outline-none"
+              >
+                ✉️ Email
+              </a>
+            )}
+            <button
+              type="button"
+              onClick={() => { shareCard(); onInteract(); }}
+              className="flex items-center gap-1 px-3 py-1 text-sm bg-primary-600 text-white rounded focus:outline-none"
+            >
+              🔗 Share
+            </button>
+          </div>
+        </div>
+        <div
+          className={clsx(
+            'absolute inset-0 flex flex-col items-center justify-center rounded-2xl shadow-xl rotate-y-180',
+            'bg-white dark:bg-gray-800 [backface-visibility:hidden] motion-reduce:[backface-visibility:visible]',
+            'transition-opacity duration-300',
+            flipped ? 'opacity-100' : 'opacity-0 motion-reduce:opacity-100',
+          )}
+        >
+          {qrDataUrl ? (
+            <img src={qrDataUrl} alt="QR code" aria-live="polite" className="w-60 h-60" />
+          ) : (
+            <div className="w-60 h-60 bg-gray-200 dark:bg-gray-700" />
+          )}
+          <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">Scan to save</p>
+          <div className="flex gap-2 mt-4">
+            <button
+              type="button"
+              onClick={() => { download(); onInteract(); }}
+              className="px-3 py-1 text-sm bg-primary-600 text-white rounded"
+            >
+              ⬇ Save Contact
+            </button>
+            <button
+              type="button"
+              onClick={() => { copyVcard(); onInteract(); }}
+              className="px-3 py-1 text-sm bg-gray-200 dark:bg-gray-700 rounded text-gray-800 dark:text-gray-200"
+            >
+              📋 Copy Info
+            </button>
+            <button
+              type="button"
+              onClick={() => { downloadQr(); onInteract(); }}
+              className="px-3 py-1 text-sm bg-gray-200 dark:bg-gray-700 rounded text-gray-800 dark:text-gray-200"
+            >
+              💾 QR
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+VirtualCardHero.displayName = 'VirtualCardHero';
+
+export default VirtualCardHero;

--- a/view/VirtualCardView.tsx
+++ b/view/VirtualCardView.tsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 import { TOOL_PANEL_CLASS } from '../src/design-system/foundations/layout';
+import VirtualCardHero from './VirtualCardHero';
+import VirtualCardActions from './VirtualCardActions';
 
 interface Props {
   fullName: string;
@@ -13,11 +15,17 @@ interface Props {
   setEmail: (v: string) => void;
   vcard: string;
   qrDataUrl: string;
-  shareUrl: string;
   showRaw: boolean;
   toggleRaw: () => void;
   download: () => void;
   copyLink: () => void;
+  copyVcard: () => void;
+  downloadQr: () => void;
+  shareCard: () => void;
+  isFlipped: boolean;
+  flip: (toBack?: boolean) => void;
+  toastMessage: string;
+  cancelFlip: () => void;
 }
 
 export function VirtualCardView({
@@ -29,11 +37,17 @@ export function VirtualCardView({
   setEmail,
   vcard,
   qrDataUrl,
-  shareUrl,
   showRaw,
   toggleRaw,
   download,
   copyLink,
+  copyVcard,
+  shareCard,
+  downloadQr,
+  isFlipped,
+  flip,
+  toastMessage,
+  cancelFlip,
 }: Props) {
   return (
     <div className={TOOL_PANEL_CLASS}>
@@ -80,12 +94,31 @@ export function VirtualCardView({
         {showRaw && (
           <textarea className="w-full h-32 p-2 border rounded dark:bg-gray-700" readOnly value={vcard} />
         )}
-        {qrDataUrl && (
-          <div className="mt-4 text-center">
-            <img src={qrDataUrl} alt="QR code" className="inline-block" />
-            <p className="mt-2 break-all text-sm">{shareUrl}</p>
+        {toastMessage && (
+          <div className="fixed top-20 right-4 z-50 bg-gray-800 text-white px-4 py-2 rounded-md shadow-lg animate-fade-in-out">
+            {toastMessage}
           </div>
         )}
+        <div className="transition-opacity duration-300 delay-150">
+          <VirtualCardHero
+            fullName={fullName}
+            phone={phone}
+            email={email}
+            qrDataUrl={qrDataUrl}
+            flipped={isFlipped}
+            flip={flip}
+            download={download}
+            downloadQr={downloadQr}
+            copyVcard={copyVcard}
+            shareCard={shareCard}
+            onInteract={cancelFlip}
+          />
+          <VirtualCardActions
+            download={download}
+            shareCard={shareCard}
+            showQr={() => flip(true)}
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- build `VirtualCardHero` component for flipping card
- add sticky `VirtualCardActions` for mobile
- expose `copyVcard` and `share` helpers in `useVirtualCard`
- integrate hero and actions into `VirtualCardView`


------
https://chatgpt.com/codex/tasks/task_e_685147d5a6b0832983c8160aac9d6be4