### PR TITLE
Add Device Trace page

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -114,11 +114,11 @@ Follow and visualize the redirect chain for any URL entirely in the browser. The
 ## Dynamic-Link Probe
 
 ```tsx
-import DeviceTracePage from "../src/tools/linktracer/DeviceTrace";
+import DeviceTracePage from "../src/tools/device-trace/page";
 ```
 
 Simulate how OneLink or custom dynamic URLs behave across iOS and Android with or without your app installed. Provide optional app identifiers and a deep-link scheme to verify that redirects land on the correct store page or launch the app as expected.
-Results can be copied to the clipboard or downloaded as JSON for further analysis.
+Results can be copied to the clipboard or downloaded as JSON for further analysis. Access this tool at `/device-trace`.
 
 ## Virtual Name Card
 

--- a/src/tools/device-trace/index.ts
+++ b/src/tools/device-trace/index.ts
@@ -1,0 +1,3 @@
+import DeviceTraceToolPage from './page';
+export { DeviceTraceToolPage };
+export default DeviceTraceToolPage;

--- a/src/tools/device-trace/page.tsx
+++ b/src/tools/device-trace/page.tsx
@@ -1,0 +1,10 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import DeviceTracePage from '../linktracer/DeviceTrace';
+
+// Wrapper page so the Device Trace tool can live at /device-trace
+export default function DeviceTraceToolPage() {
+  return <DeviceTracePage />;
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -294,7 +294,7 @@ const toolRegistry: Tool[] = [
     description:
       "Test how App Flyer/OneLink URLs behave across different device contexts and installation states.",
     icon: LinkTracerIcon, // Reusing the same icon for now
-    component: lazy(() => import("./linktracer/DeviceTrace")),
+    component: lazy(() => import("./device-trace/page")),
     category: "Testing",
     metadata: {
       keywords: [


### PR DESCRIPTION
## Summary
- add Device Trace tool page wrapper
- update tool registry to load new page
- document `/device-trace` route in tools doc

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68514fad91e883299eb8b574eb38e6b1