### PR TITLE
Remove canonical URL from JWT pages

### DIFF
--- a/src/tools/jwt/JwtDecoder.tsx
+++ b/src/tools/jwt/JwtDecoder.tsx
@@ -256,11 +256,9 @@ const JwtDecoder: React.FC = () => {
         <meta property="og:title" content={pageTitle} />
         <meta property="og:description" content={pageDescription} />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://mydebugger.vercel.app/jwt" />
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:title" content={pageTitle} />
         <meta name="twitter:description" content={pageDescription} />
-        <link rel="canonical" href="https://mydebugger.vercel.app/jwt" />
       </Helmet>
     
       <div className="flex justify-center">

--- a/src/tools/jwt/JwtToolkit.new.tsx
+++ b/src/tools/jwt/JwtToolkit.new.tsx
@@ -31,11 +31,9 @@ const JwtToolkit: React.FC = () => {
         <meta property="og:title" content={pageTitle} />
         <meta property="og:description" content={pageDescription} />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://mydebugger.vercel.app/jwt" />
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:title" content={pageTitle} />
         <meta name="twitter:description" content={pageDescription} />
-        <link rel="canonical" href="https://mydebugger.vercel.app/jwt" />
       </Helmet>
       
       <ToolLayout tool={tool!}>

--- a/src/tools/jwt/JwtToolkit.tsx
+++ b/src/tools/jwt/JwtToolkit.tsx
@@ -44,11 +44,9 @@ const JwtToolkit: React.FC = () => {
         <meta property="og:title" content={pageTitle} />
         <meta property="og:description" content={pageDescription} />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://mydebugger.vercel.app/jwt" />
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:title" content={pageTitle} />
         <meta name="twitter:description" content={pageDescription} />
-        <link rel="canonical" href="https://mydebugger.vercel.app/jwt" />
       </Helmet>
       
       <ToolLayout tool={jwtTool!}>

--- a/src/tools/jwt/JwtToolkit.tsx.new
+++ b/src/tools/jwt/JwtToolkit.tsx.new
@@ -31,11 +31,9 @@ const JwtToolkit: React.FC = () => {
         <meta property="og:title" content={pageTitle} />
         <meta property="og:description" content={pageDescription} />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://mydebugger.vercel.app/jwt" />
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:title" content={pageTitle} />
         <meta name="twitter:description" content={pageDescription} />
-        <link rel="canonical" href="https://mydebugger.vercel.app/jwt" />
       </Helmet>
       
       <ToolLayout tool={tool!}>

--- a/src/tools/jwtplayground/JwtPlayground.tsx
+++ b/src/tools/jwtplayground/JwtPlayground.tsx
@@ -266,11 +266,9 @@ const JwtPlayground: React.FC = () => {
         <meta property="og:title" content={pageTitle} />
         <meta property="og:description" content={pageDescription} />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://mydebugger.vercel.app/jwt" />
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:title" content={pageTitle} />
         <meta name="twitter:description" content={pageDescription} />
-        <link rel="canonical" href="https://mydebugger.vercel.app/jwt" />
       </Helmet>
       
       <div className="container mx-auto px-4 py-8">


### PR DESCRIPTION
## Summary
- strip hardcoded `https://mydebugger.vercel.app/jwt` meta tags from JWT tools

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68514ffbdde48329b9d2e6d1ab969085