### PR TITLE
Add trust banner to footer

### DIFF
--- a/__tests__/TrustBanner.test.tsx
+++ b/__tests__/TrustBanner.test.tsx
@@ -1,0 +1,8 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import TrustBanner from "../view/TrustBanner";
+
+test("renders trust message", () => {
+  render(<TrustBanner />);
+  expect(screen.getByText(/Trusted by 1,200\+ developers/i)).toBeInTheDocument();
+});

--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import TrustBanner from '../../view/TrustBanner';
 
 // Helper function for icons
 const getIconHelper = (name: string) => {
@@ -138,7 +139,9 @@ const Footer: React.FC = () => {
             </a>
           </div>
         </div>
-        
+
+        <TrustBanner />
+
         {/* Bottom section */}
         <div className="border-t border-gray-200 dark:border-gray-700 pt-6 flex flex-col md:flex-row justify-between items-center">
           <p className="text-sm text-gray-500 dark:text-gray-400">

--- a/view/TrustBanner.tsx
+++ b/view/TrustBanner.tsx
@@ -1,0 +1,43 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+
+export function TrustBanner() {
+  return (
+    <div className="bg-gray-50 dark:bg-gray-800 border-t border-b border-gray-200 dark:border-gray-700 py-4 text-center text-sm">
+    <p className="flex flex-col sm:flex-row items-center justify-center gap-2">
+      <span className="flex items-center gap-1">
+        <span role="img" aria-label="brain">🧠</span>
+        Trusted by 1,200+ developers
+      </span>
+      <span className="hidden sm:inline">|</span>
+      <span className="flex items-center gap-1">
+        <span role="img" aria-label="zap">⚡</span>
+        Open Source
+      </span>
+      <span className="hidden sm:inline">|</span>
+      <span className="flex items-center gap-1">
+        <span role="img" aria-label="speech balloon">💬</span>
+        Instant feedback welcome!
+      </span>
+    </p>
+    <div className="mt-2 flex flex-wrap justify-center gap-3">
+      <img
+        src="https://img.shields.io/github/stars/HydrogenB/mydebugger?style=social"
+        alt="GitHub stars"
+      />
+      <img
+        src="https://img.shields.io/badge/Vercel-Ready-black?logo=vercel"
+        alt="Vercel deploy"
+      />
+      <img
+        src="https://img.shields.io/badge/SEO-100%25-green"
+        alt="Lighthouse score"
+      />
+    </div>
+  </div>
+  );
+}
+
+export default TrustBanner;


### PR DESCRIPTION
## Summary
- add TrustBanner component to promote credibility
- show the banner in the footer
- test TrustBanner rendering

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm audit`

------
https://chatgpt.com/codex/tasks/task_e_6851517d01988329baa5c30fc319a2b9