### PR TITLE
Enhance deep-link QR generator

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -143,3 +143,11 @@ import FetchRenderPage from '../src/tools/fetch-render/page';
 ```
 
 Simulate JavaScript rendering in a sandboxed iframe. Set a timeout before capture, inspect console output and export the rendered DOM to clipboard or file for further analysis.
+
+## Deep-Link QR Generator
+
+```tsx
+import QRCodeGeneratorPage from "../src/tools/qrcode/QRCodeGenerator";
+```
+
+Generate QR codes for any URL or mobile deep link. The tool auto-encodes query parameters, shows a real-time preview and lets you open or share the link instantly. Access it at `/qrcode`.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://mydebugger.vercel.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://mydebugger.vercel.app/qrcode</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add SEO tags and JSON-LD schema for the QR generator page
- improve UX with mobile-friendly run button, recent links history and auto copy
- expose robots.txt and sitemap.xml for search crawlers
- document the QR generator tool

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test -- --coverage`
- `pnpm audit`


------
https://chatgpt.com/codex/tasks/task_e_685150a19f948329b524206461857e53