### PR TITLE
Fix tool duplication on home screen

### DIFF
--- a/__tests__/toolFilters.test.ts
+++ b/__tests__/toolFilters.test.ts
@@ -1,0 +1,19 @@
+import { excludeById } from '../src/utils/toolFilters';
+
+type Item = { id: string; value: string };
+
+describe('excludeById', () => {
+  it('removes items present in the exclusion list', () => {
+    const all: Item[] = [
+      { id: 'a', value: '1' },
+      { id: 'b', value: '2' },
+      { id: 'c', value: '3' },
+    ];
+    const exclude: Item[] = [{ id: 'b', value: '2' }];
+    const res = excludeById(all, exclude);
+    expect(res).toEqual([
+      { id: 'a', value: '1' },
+      { id: 'c', value: '3' },
+    ]);
+  });
+});

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -20,6 +20,7 @@ import {
 } from '../design-system';
 import { TOOL_PANEL_CLASS } from '../design-system/foundations/layout';
 import { getTools, getAllCategories, getToolsByCategory, getPopularTools, getNewTools, Tool, ToolCategory, categories as categoryInfo } from '../tools';
+import { excludeById } from '../utils/toolFilters';
 import './Home.css';
 
 const Home: React.FC = () => {
@@ -97,7 +98,7 @@ const Home: React.FC = () => {
       let filtered: Tool[];
       
       if (activeTab === 'all') {
-        filtered = allTools;
+        filtered = searchTerm ? allTools : excludeById(allTools, recentTools);
       } else if (activeTab === 'popular') {
         filtered = popularTools;
       } else if (activeTab === 'new') {

--- a/src/utils/toolFilters.ts
+++ b/src/utils/toolFilters.ts
@@ -1,0 +1,8 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+export interface Identifiable { id: string }
+
+export function excludeById<T extends Identifiable>(items: T[], exclude: T[]): T[] {
+  return items.filter(item => !exclude.some(e => e.id === item.id));
+}


### PR DESCRIPTION
## Summary
- filter out recently used tools from main grid
- add utility to exclude tools by ID
- test utility helper

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68517ba528c48329961c7bf17992353c