### PR TITLE
Fix label spacing in tool grid header

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -411,7 +411,9 @@ const Home: React.FC = () => {
           <div className="mb-4 flex justify-between items-center">
             <div className="text-sm text-gray-600 dark:text-gray-400">
               {visibleTools.length > 0 ? (
-                <span>Showing {visibleTools.length} tool{visibleTools.length !== 1 ? 's' : ''}</span>
+                <p className="mt-4 mb-4 text-sm text-gray-500 pl-1">
+                  Showing {visibleTools.length} tool{visibleTools.length !== 1 ? 's' : ''}
+                </p>
               ) : null}
             </div>
             <div className="flex space-x-2">


### PR DESCRIPTION
## Summary
- use paragraph element with Tailwind spacing to display count of visible tools

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68517c5af7fc83298517ecaa32b5c217