### PR TITLE
Improve pentest suite layout

### DIFF
--- a/view/PentestSuiteView.tsx
+++ b/view/PentestSuiteView.tsx
@@ -79,8 +79,11 @@ export function PentestSuiteView({
     setClickjacking('passed');
   };
 
+  const renderBadge = (s?: ValidationStatus) =>
+    s ? <Badge variant={statusColor[s]}>{s}</Badge> : <span className="text-gray-500">-</span>;
+
   return (
-    <div className="space-y-6">
+    <div className="max-w-6xl mx-auto px-6 py-8 space-y-6">
       <div className="flex gap-2 items-end">
         <TextInput
           label="Target URL"
@@ -97,9 +100,9 @@ export function PentestSuiteView({
         <Button onClick={runTests}>Run All Tests</Button>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2">
+      <div className="grid gap-6 md:grid-cols-2">
         {/* Clickjacking */}
-        <div className={`${TOOL_PANEL_CLASS} space-y-3`}>
+        <div className={`relative space-y-3 ${TOOL_PANEL_CLASS.replace('p-6', 'p-5')}`}>
           <h2 className="text-lg font-bold">Clickjacking Validator</h2>
           {url && (
             <iframe
@@ -112,31 +115,41 @@ export function PentestSuiteView({
               title="clickjacking-test"
             />
           )}
-          <p className="text-sm text-gray-400">Tests if this site blocks iframe embedding.</p>
+          <p className="text-sm text-gray-500">Tests if this site blocks iframe embedding.</p>
           {results.clickjacking && (
-            <Badge variant={statusColor[results.clickjacking]}>
+            <Badge
+              variant={statusColor[results.clickjacking]}
+              className="absolute top-4 right-4"
+            >
               {results.clickjacking}
             </Badge>
           )}
           {results.clickjacking && results.clickjacking !== 'inconclusive' && (
             <Collapsible title="Logs" className="mt-2">
-              {results.clickjacking}
+              <div className="bg-gray-50 dark:bg-gray-900 rounded-md border border-gray-200 dark:border-gray-700 text-sm p-3 font-mono text-gray-800 dark:text-gray-200">
+                {results.clickjacking}
+              </div>
             </Collapsible>
           )}
         </div>
 
         {/* HTTPS Redirect */}
-        <div className={`${TOOL_PANEL_CLASS} space-y-3`}>
+        <div className={`relative space-y-3 ${TOOL_PANEL_CLASS.replace('p-6', 'p-5')}`}>
           <h2 className="text-lg font-bold">HTTPS Redirect Checker</h2>
           <p className="text-sm text-gray-400">Detects if http:// redirects to https://</p>
           {results.https && (
-            <Badge variant={statusColor[results.https.status]}>
+            <Badge
+              variant={statusColor[results.https.status]}
+              className="absolute top-4 right-4"
+            >
               {results.https.status}
             </Badge>
           )}
           {results.https?.details && (
             <Collapsible title="Logs" className="mt-2">
-              {results.https.details}
+              <div className="bg-gray-50 dark:bg-gray-900 rounded-md border border-gray-200 dark:border-gray-700 text-sm p-3 font-mono text-gray-800 dark:text-gray-200">
+                {results.https.details}
+              </div>
             </Collapsible>
           )}
           {httpUrl && (
@@ -145,7 +158,7 @@ export function PentestSuiteView({
         </div>
 
         {/* Open Redirect */}
-        <div className={`${TOOL_PANEL_CLASS} space-y-3`}>
+        <div className={`relative space-y-3 ${TOOL_PANEL_CLASS.replace('p-6', 'p-5')}`}>
           <h2 className="text-lg font-bold">Open Redirect Detector</h2>
           <SelectInput
             value={redirectParam}
@@ -163,19 +176,24 @@ export function PentestSuiteView({
           )}
           <p className="text-sm text-gray-400">Checks common redirect parameters.</p>
           {results.openRedirect && (
-            <Badge variant={statusColor[results.openRedirect.status]}>
+            <Badge
+              variant={statusColor[results.openRedirect.status]}
+              className="absolute top-4 right-4"
+            >
               {results.openRedirect.status}
             </Badge>
           )}
           {results.openRedirect?.details && (
             <Collapsible title="Logs" className="mt-2">
-              {results.openRedirect.details}
+              <div className="bg-gray-50 dark:bg-gray-900 rounded-md border border-gray-200 dark:border-gray-700 text-sm p-3 font-mono text-gray-800 dark:text-gray-200">
+                {results.openRedirect.details}
+              </div>
             </Collapsible>
           )}
         </div>
 
         {/* XSS Reflection */}
-        <div className={`${TOOL_PANEL_CLASS} space-y-3`}>
+        <div className={`relative space-y-3 ${TOOL_PANEL_CLASS.replace('p-6', 'p-5')}`}>
           <h2 className="text-lg font-bold">XSS Reflection Tester</h2>
           <TextInput
             label="Payload"
@@ -188,33 +206,72 @@ export function PentestSuiteView({
           )}
           <p className="text-sm text-gray-400">Injects a basic payload via query string.</p>
           {results.xss && (
-            <Badge variant={statusColor[results.xss.status]}>
+            <Badge
+              variant={statusColor[results.xss.status]}
+              className="absolute top-4 right-4"
+            >
               {results.xss.status}
             </Badge>
           )}
           {results.xss?.details && (
             <Collapsible title="Logs" className="mt-2">
-              {results.xss.details}
+              <div className="bg-gray-50 dark:bg-gray-900 rounded-md border border-gray-200 dark:border-gray-700 text-sm p-3 font-mono text-gray-800 dark:text-gray-200">
+                {results.xss.details}
+              </div>
             </Collapsible>
           )}
         </div>
 
         {/* CORS */}
-        <div className={`${TOOL_PANEL_CLASS} space-y-3`}>
+        <div className={`relative space-y-3 ${TOOL_PANEL_CLASS.replace('p-6', 'p-5')}`}>
           <h2 className="text-lg font-bold">CORS Validator</h2>
           <p className="text-sm text-gray-400">Attempts cross-origin fetch to the target.</p>
           {results.cors && (
-            <Badge variant={statusColor[results.cors.status]}>
+            <Badge
+              variant={statusColor[results.cors.status]}
+              className="absolute top-4 right-4"
+            >
               {results.cors.status}
             </Badge>
           )}
           {results.cors?.details && (
             <Collapsible title="Logs" className="mt-2">
-              {results.cors.details}
+              <div className="bg-gray-50 dark:bg-gray-900 rounded-md border border-gray-200 dark:border-gray-700 text-sm p-3 font-mono text-gray-800 dark:text-gray-200">
+                {results.cors.details}
+              </div>
             </Collapsible>
           )}
         </div>
       </div>
+
+      {Object.keys(results).length > 0 && (
+        <div className={`space-y-2 ${TOOL_PANEL_CLASS.replace('p-6', 'p-4')}`}>
+          <h2 className="text-lg font-bold">Summary</h2>
+          <ul className="space-y-1 text-sm">
+            <li className="flex justify-between">
+              <span>HTTPS Redirect</span>
+              {renderBadge(results.https?.status)}
+            </li>
+            <li className="flex justify-between">
+              <span>CORS</span>
+              {renderBadge(results.cors?.status)}
+            </li>
+            <li className="flex justify-between">
+              <span>Open Redirect</span>
+              {renderBadge(results.openRedirect?.status)}
+            </li>
+            <li className="flex justify-between">
+              <span>XSS Reflection</span>
+              {renderBadge(results.xss?.status)}
+            </li>
+            <li className="flex justify-between">
+              <span>Clickjacking</span>
+              {renderBadge(results.clickjacking)}
+            </li>
+          </ul>
+        </div>
+      )}
+
       <InfoBox variant="warning" title="Aggressive tests">
         Some validators use iframes and redirects which may trigger network requests. Manual review is recommended for XSS payloads.
       </InfoBox>


### PR DESCRIPTION
## Summary
- refine PentestSuiteView layout with design system card class
- show summary block with test results
- maintain styled log containers and status badges

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm audit`


------
https://chatgpt.com/codex/tasks/task_e_68517eaaa6f08329aab3a0679d68dd99