### PR TITLE
Add CodeBlock component for scrollable logs

### DIFF
--- a/src/design-system/components/display/CodeBlock.tsx
+++ b/src/design-system/components/display/CodeBlock.tsx
@@ -1,0 +1,32 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+
+export interface CodeBlockProps {
+  /** Code content to display */
+  children: React.ReactNode;
+  /** Optional additional CSS classes */
+  className?: string;
+  /** Max height for scrollable area */
+  maxHeight?: string | number;
+}
+
+/**
+ * CodeBlock - Consistent styling for code or log output.
+ * Adds overflow scrolling and responsive theming.
+ */
+export const CodeBlock: React.FC<CodeBlockProps> = ({
+  children,
+  className = '',
+  maxHeight = '16rem',
+}) => (
+  <pre
+    className={`bg-gray-100 dark:bg-gray-900 text-sm rounded p-4 overflow-x-auto whitespace-pre-wrap ${className}`}
+    style={{ maxHeight }}
+  >
+    {children}
+  </pre>
+);
+
+export default CodeBlock;

--- a/src/design-system/components/display/index.ts
+++ b/src/design-system/components/display/index.ts
@@ -5,3 +5,4 @@ export { Badge, BadgeContainer } from './Badge';
 export { default as ResponsiveImage } from './ResponsiveImage';
 export { default as InfoBox } from './InfoBox';
 export { default as Tag } from './Tag';
+export { default as CodeBlock } from './CodeBlock';

--- a/src/design-system/index.ts
+++ b/src/design-system/index.ts
@@ -32,6 +32,7 @@ export { Button } from './components/inputs';
 export { Card } from './components/layout';
 export { Alert } from './components/feedback';
 export { Badge, BadgeContainer } from './components/display';
+export { CodeBlock } from './components/display';
 export { Modal } from './components/overlays';
 export { TabGroup, Tab, TabPanel } from './components/navigation';
 export { Text } from './components/typography';

--- a/view/CorsTesterView.tsx
+++ b/view/CorsTesterView.tsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { TOOL_PANEL_CLASS } from '../src/design-system/foundations/layout';
+import { CodeBlock } from '../src/design-system/components/display/CodeBlock';
 import { CorsResult, CorsAnalysis } from '../model/cors';
 
 interface Props {
@@ -124,7 +125,9 @@ export function CorsTesterView({
           )}
           <details className="mt-4">
             <summary className="cursor-pointer">Request Flow & cURL</summary>
-            <pre className="bg-gray-100 dark:bg-gray-900 p-2 mt-2 rounded text-xs whitespace-pre-wrap">{JSON.stringify(result, null, 2)}</pre>
+            <CodeBlock className="mt-2 text-xs" maxHeight="16rem">
+              {JSON.stringify(result, null, 2)}
+            </CodeBlock>
             <div className="mt-2 flex items-center gap-2">
               <code className="px-2 py-1 bg-gray-100 dark:bg-gray-900 rounded text-xs break-all">{curlCommand}</code>
               <button


### PR DESCRIPTION
## Summary
- add `CodeBlock` to design system for consistent log display
- expose `CodeBlock` exports
- show CORS preflight results using new `CodeBlock`

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test --silent`
- `pnpm audit --audit-level=high`

------
https://chatgpt.com/codex/tasks/task_e_68518224caa883299dffb2e179dabaf6