### PR TITLE
Fix deep link chain by using API backend

### DIFF
--- a/__tests__/deepLinkChain.test.ts
+++ b/__tests__/deepLinkChain.test.ts
@@ -1,4 +1,4 @@
-import { followRedirectChain, parseUtmParams, fetchOpenGraph } from '../model/deepLinkChain';
+import { followRedirectChain, followRedirectChainRemote, parseUtmParams, fetchOpenGraph } from '../model/deepLinkChain';
 
 describe('parseUtmParams', () => {
   it('extracts utm parameters', () => {
@@ -79,6 +79,19 @@ describe('followRedirectChain', () => {
     (global.fetch as any) = jest.fn().mockRejectedValue(new Error('x'));
     const og = await fetchOpenGraph('https://a.com');
     expect(og).toBeNull();
+  });
+
+  it('requests redirect chain from API', async () => {
+    (global.fetch as any) = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ hops: [{ url: 'https://a.com', status: 200 }] }),
+    });
+    const hops = await followRedirectChainRemote('https://a.com');
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/deep-link-chain',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(hops[0].status).toBe(200);
   });
 });
 

--- a/api/deep-link-chain.js
+++ b/api/deep-link-chain.js
@@ -1,0 +1,72 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import fetch from 'node-fetch';
+
+const MAX_REDIRECTS = 20;
+
+async function followRedirectChain(initialUrl, maxHops = MAX_REDIRECTS) {
+  const hops = [];
+  const visited = new Set();
+  let url = initialUrl;
+  for (let i = 0; i < maxHops; i += 1) {
+    if (visited.has(url)) {
+      hops.push({ url, error: 'Redirect loop detected' });
+      break;
+    }
+    visited.add(url);
+    try {
+      const res = await fetch(url, { redirect: 'manual' });
+      const hop = { url, status: res.status, headers: {} };
+      res.headers.forEach((value, key) => {
+        hop.headers[key] = value;
+      });
+      hops.push(hop);
+      if (res.status >= 300 && res.status < 400) {
+        const loc = res.headers.get('location');
+        if (!loc) break;
+        const next = new URL(loc, url).toString();
+        hop.mixedProtocol = new URL(next).protocol !== new URL(url).protocol;
+        url = next;
+      } else {
+        break;
+      }
+    } catch (e) {
+      hops.push({ url, error: e.message });
+      break;
+    }
+  }
+  if (hops.length >= maxHops) {
+    hops.push({ url, error: 'Maximum redirects reached' });
+  }
+  return hops;
+}
+
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const { url, maxHops } = req.body || {};
+  if (!url) {
+    res.status(400).json({ error: 'Missing url parameter' });
+    return;
+  }
+
+  try {
+    const hops = await followRedirectChain(url, Number(maxHops) || MAX_REDIRECTS);
+    res.status(200).json({ hops });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+}

--- a/api/index.js
+++ b/api/index.js
@@ -6,3 +6,4 @@ export { default as auditTools } from './audit-tools.js';
 export { default as probeRouter } from './probe-router.js';
 export { default as headlessRunner } from './headless-runner.js';
 export { default as utilityTools } from './utility-tools.js';
+export { default as deepLinkChain } from './deep-link-chain.js';

--- a/model/deepLinkChain.ts
+++ b/model/deepLinkChain.ts
@@ -33,6 +33,27 @@ export const parseUtmParams = (target: string): Record<string, string> => {
 
 export const MAX_REDIRECTS = 20;
 
+/**
+ * Request the redirect chain from the serverless API to avoid CORS issues.
+ * @param initialUrl URL to trace
+ */
+export const followRedirectChainRemote = async (
+  initialUrl: string,
+): Promise<RedirectHop[]> => {
+  try {
+    const res = await fetch('/api/deep-link-chain', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url: initialUrl }),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    return Array.isArray(data.hops) ? data.hops : [];
+  } catch (e) {
+    return [{ url: initialUrl, error: (e as Error).message }];
+  }
+};
+
 const tryFetchFinalUrl = async (url: string): Promise<string | undefined> => {
   try {
     const res = await fetch(url, { mode: 'no-cors', redirect: 'follow' });

--- a/viewmodel/useDeepLinkChain.ts
+++ b/viewmodel/useDeepLinkChain.ts
@@ -2,7 +2,13 @@
  * © 2025 MyDebugger Contributors – MIT License
  */
 import { useState } from 'react';
-import followRedirectChainFn, { RedirectHop, parseUtmParams, fetchOpenGraph, OpenGraphPreview } from '../model/deepLinkChain';
+import {
+  RedirectHop,
+  parseUtmParams,
+  fetchOpenGraph,
+  OpenGraphPreview,
+  followRedirectChainRemote,
+} from '../model/deepLinkChain';
 
 export const useDeepLinkChain = (initialUrl = '') => {
   const [url, setUrl] = useState(initialUrl);
@@ -17,7 +23,7 @@ export const useDeepLinkChain = (initialUrl = '') => {
     setError('');
     setOpenGraph(null);
     try {
-      const hops = await followRedirectChainFn(url);
+      const hops = await followRedirectChainRemote(url);
       setChain(hops);
       const last = hops[hops.length - 1];
       if (last) {


### PR DESCRIPTION
## Summary
- add `/api/deep-link-chain` route to trace redirects server-side
- call new API from `useDeepLinkChain` hook
- expose helper `followRedirectChainRemote`
- export new handler and test the API path

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68518377965083298920a26daac0f6b0