### PR TITLE
Redesign pre-rendering tester

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -128,13 +128,13 @@ import VirtualCardPage from "../src/tools/virtual-card/page";
 
 Create a shareable contact card completely in-browser. The tool generates a `.vcf` download, QR code, and URL with base64 encoded data that pre-fills the form when opened.
 Access this tool at `/vcard`.
-## Pre-rendering Tester
+## Pre-rendering & SEO Meta Tester
 
 ```tsx
 import PreRenderingTesterPage from '../src/tools/pre-rendering-tester/page';
 ```
 
-Fetch HTML snapshots for any URL using multiple user-agent headers. Compare the page title, description and first H1 tag across crawlers or browsers. Results can be exported as raw markup or JSON.
+Analyze how Googlebot, Bingbot, FacebookBot and real browsers render your page metadata. Fetch HTML snapshots, compare title, description and H1 consistency, then export results or raw markup for further debugging.
 
 ## Fetch & Render Tool
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -490,13 +490,14 @@ const toolRegistry: Tool[] = [
   {
     id: 'pre-rendering-tester',
     route: '/pre-rendering-tester',
-    title: 'Pre-rendering Tester',
-    description: 'Compare HTML snapshots across user-agents.',
+    title: 'Pre-rendering & SEO Meta Tester',
+    description:
+      'Test how Googlebot, Bingbot, Facebook, and real users see your web content — including title, description and H1 rendering.',
     icon: TestingIcon,
     component: lazy(() => import('./pre-rendering-tester/page')),
     category: 'Testing',
     metadata: {
-      keywords: ['seo', 'prerender', 'crawler', 'user-agent'],
+      keywords: ['seo', 'prerender', 'crawler', 'meta description', 'user-agent'],
       relatedTools: ['fetch-render'],
     },
     uiOptions: { showExamples: false }

--- a/src/tools/pre-rendering-tester/page.tsx
+++ b/src/tools/pre-rendering-tester/page.tsx
@@ -4,10 +4,21 @@
 import React from 'react';
 import usePreRenderingTester from '../../../viewmodel/usePreRenderingTester';
 import PreRenderingTesterView from '../../../view/PreRenderingTesterView';
+import { getToolByRoute } from '../index';
+import { ToolLayout } from '../../design-system/components/layout';
 
 const PreRenderingTesterPage: React.FC = () => {
   const vm = usePreRenderingTester();
-  return <PreRenderingTesterView {...vm} />;
+  const tool = getToolByRoute('/pre-rendering-tester');
+  return (
+    <ToolLayout
+      tool={tool!}
+      title="Pre-rendering & SEO Meta Tester"
+      description="Test how Googlebot, Bingbot, Facebook, and real users see your web content — including title, description and H1 rendering."
+    >
+      <PreRenderingTesterView {...vm} />
+    </ToolLayout>
+  );
 };
 
 export default PreRenderingTesterPage;

--- a/viewmodel/usePreRenderingTester.ts
+++ b/viewmodel/usePreRenderingTester.ts
@@ -1,15 +1,41 @@
 /**
  * © 2025 MyDebugger Contributors – MIT License
  */
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { fetchSnapshot, Snapshot } from '../model/prerender';
 
-export const USER_AGENTS: Record<string, string> = {
-  Googlebot: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
-  Bingbot: 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)',
-  'Desktop Chrome':
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36',
-};
+export interface Agent {
+  id: string;
+  ua: string;
+  category: 'SEO Crawler' | 'Browser' | 'Social Bot';
+}
+
+export const AGENTS: Agent[] = [
+  {
+    id: 'Googlebot',
+    ua: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+    category: 'SEO Crawler',
+  },
+  {
+    id: 'Bingbot',
+    ua: 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)',
+    category: 'SEO Crawler',
+  },
+  {
+    id: 'FacebookBot',
+    ua: 'facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)',
+    category: 'Social Bot',
+  },
+  {
+    id: 'Desktop Chrome',
+    ua: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36',
+    category: 'Browser',
+  },
+];
+
+export const USER_AGENTS: Record<string, string> = Object.fromEntries(
+  AGENTS.map(a => [a.id, a.ua])
+);
 
 export const usePreRenderingTester = () => {
   const [url, setUrl] = useState('');
@@ -29,9 +55,10 @@ export const usePreRenderingTester = () => {
     setError('');
     try {
       const snaps = await Promise.all(
-        agents.map(id =>
-          fetchSnapshot(url, USER_AGENTS[id]).then(s => ({ ...s, userAgent: id }))
-        )
+        agents.map(id => {
+          const agent = AGENTS.find(a => a.id === id)!;
+          return fetchSnapshot(url, agent.ua).then(s => ({ ...s, userAgent: id }));
+        })
       );
       setResults(snaps);
     } catch (e) {
@@ -55,7 +82,34 @@ export const usePreRenderingTester = () => {
     URL.revokeObjectURL(href);
   };
 
-  return { url, setUrl, agents, toggleAgent, results, run, loading, error, copyJson, exportJson };
+  const summary = useMemo(() => {
+    if (!results.length) return '';
+    const agentsTested = results.length;
+    const titlesMatch = results.every(r => r.title === results[0].title);
+    const descMatch = results.every(r => r.description === results[0].description);
+    const missingH1 = results.some(r => !r.h1);
+    const descLen = results[0].description?.length ?? 0;
+    return `${agentsTested} agents • ${titlesMatch ? '✅ Titles match' : '⚠️ Title mismatch'} • ${descMatch ? '✅ Descriptions match' : '⚠️ Description mismatch'} • ${missingH1 ? '⚠️ Missing H1' : '✅ H1 present'} • 📏 Description: ${descLen} chars`;
+  }, [results]);
+
+  const copySnapshot = async (snap: Snapshot) => {
+    await navigator.clipboard.writeText(JSON.stringify(snap, null, 2));
+  };
+
+  return {
+    url,
+    setUrl,
+    agents,
+    toggleAgent,
+    results,
+    run,
+    loading,
+    error,
+    copyJson,
+    exportJson,
+    summary,
+    copySnapshot,
+  };
 };
 
 export default usePreRenderingTester;


### PR DESCRIPTION
## Summary
- modernize Pre-rendering Tester into **Pre-rendering & SEO Meta Tester**
- group user agents and add FacebookBot
- compute a quick summary bar for results
- present results in responsive cards with per-agent actions
- wrap page with `ToolLayout` and update docs

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm audit`

------
https://chatgpt.com/codex/tasks/task_e_68518b8c8348832999ce607a467c9c5b