### PR TITLE
Redesign cache inspector

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -47,7 +47,7 @@ Click any cookie name or value to copy it. Long values can be expanded inline, a
 import CacheInspectorPage from "../src/tools/cache-inspector";
 ```
 
-Use the Cache Inspector to analyze caching behaviour for resources loaded in your session. It now shows cache freshness badges (`FRESH`, `STALE`, `EXPIRED`, `NO-CACHE`), lists matching Service Worker cache names, and annotates whether a resource came from the network or memory. Results can be exported to a timestamped JSON file grouped by domain.
+Use the Cache Inspector to analyze caching behaviour for resources loaded in your session. It now shows cache freshness badges (`FRESH`, `STALE`, `EXPIRED`, `NO-CACHE`), lists matching Service Worker cache names, and annotates whether a resource came from the network or memory. A summary panel highlights totals per resource type and overall freshness. Results can be exported to JSON or CSV and you can copy a sharable link to revisit the inspection later.
 
 ## Cookie Scope
 

--- a/src/tools/cache-inspector/page.tsx
+++ b/src/tools/cache-inspector/page.tsx
@@ -2,12 +2,19 @@
  * © 2025 MyDebugger Contributors – MIT License
  */
 import React from 'react';
+import { getToolByRoute } from '../index';
 import useCacheInspector from '../../../viewmodel/useCacheInspector';
 import CacheInspectorView from '../../../view/CacheInspectorView';
+import { ToolLayout } from '../../design-system/components/layout';
 
 const CacheInspectorPage: React.FC = () => {
   const vm = useCacheInspector();
-  return <CacheInspectorView {...vm} />;
+  const tool = getToolByRoute('/cache-inspector');
+  return (
+    <ToolLayout tool={tool!} title="Cache Inspector" description="Inspect browser caching for loaded resources." showRelatedTools>
+      <CacheInspectorView {...vm} />
+    </ToolLayout>
+  );
 };
 
 export default CacheInspectorPage;

--- a/view/CacheInspectorView.tsx
+++ b/view/CacheInspectorView.tsx
@@ -3,25 +3,65 @@
  */
 import React from 'react';
 import { TOOL_PANEL_CLASS } from '../src/design-system/foundations/layout';
-import { GroupedResults } from '../viewmodel/useCacheInspector';
+import { GroupedResults, CacheSummary } from '../viewmodel/useCacheInspector';
 
 interface Props {
   grouped: GroupedResults[];
   loading: boolean;
+  summary: CacheSummary;
   exportJson: () => void;
+  exportCsv: () => void;
+  copyShareLink: () => void;
 }
 
-export function CacheInspectorView({ grouped, loading, exportJson }: Props) {
+export function CacheInspectorView({
+  grouped,
+  loading,
+  summary,
+  exportJson,
+  exportCsv,
+  copyShareLink,
+}: Props) {
   return (
     <div className={TOOL_PANEL_CLASS}>
-      <div className="flex justify-between items-center mb-4">
-        <h2 className="text-2xl font-bold text-gray-800 dark:text-white">Cache Inspector</h2>
+      <header className="mb-4">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+          Cache Inspector – Analyze HTTP Cache-Control, ETag, and CDN Behavior
+        </h1>
+        <p className="text-gray-600 dark:text-gray-300 mt-1">
+          Inspect JavaScript, CSS, images, and API responses for cache status, max-age, and freshness using MyDebugger&apos;s Cache Inspector.
+        </p>
+      </header>
+      <div className="mb-4 bg-gray-50 dark:bg-gray-900/20 p-3 rounded-md text-sm text-gray-800 dark:text-gray-200">
+        <p className="font-semibold mb-1">📊 Cache Summary:</p>
+        <ul className="space-y-1">
+          <li>🔧 Scripts: {summary.counts.script} scanned | {summary.statusCounts.FRESH ?? 0} FRESH</li>
+          <li>🎨 Styles: {summary.counts.style} files</li>
+          <li>🖼️ Images: {summary.counts.image} total</li>
+          <li>🔁 API Fetch: {summary.counts.fetch}</li>
+        </ul>
+      </div>
+      <div className="flex gap-2 mb-4">
         <button
           type="button"
           className="px-3 py-1 bg-primary-500 text-white rounded hover:bg-primary-600"
           onClick={exportJson}
         >
           Export JSON
+        </button>
+        <button
+          type="button"
+          className="px-3 py-1 bg-primary-500 text-white rounded hover:bg-primary-600"
+          onClick={exportCsv}
+        >
+          Export CSV
+        </button>
+        <button
+          type="button"
+          className="px-3 py-1 bg-primary-500 text-white rounded hover:bg-primary-600"
+          onClick={copyShareLink}
+        >
+          Copy Share Link
         </button>
       </div>
       {loading && <p className="text-gray-700 dark:text-gray-300">Analyzing...</p>}
@@ -42,6 +82,7 @@ export function CacheInspectorView({ grouped, loading, exportJson }: Props) {
                     <th className="px-2 py-1">SW Caches</th>
                     <th className="px-2 py-1">Origin</th>
                     <th className="px-2 py-1">Status</th>
+                    <th className="px-2 py-1">Issues</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -67,6 +108,9 @@ export function CacheInspectorView({ grouped, loading, exportJson }: Props) {
                             </span>
                           );
                         })()}
+                      </td>
+                      <td className="px-2 py-1 break-all text-xs text-red-600 dark:text-red-400">
+                        {r.issues.join('; ')}
                       </td>
                     </tr>
                   ))}


### PR DESCRIPTION
## Summary
- overhaul Cache Inspector UI with summary panel and export buttons
- compute caching issue heuristics and CSV export
- expose Cache Inspector via ToolLayout with SEO meta
- document new features

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test -- --coverage`
- `pnpm audit`

------
https://chatgpt.com/codex/tasks/task_e_68518c061f8c8329b37b9ece65554821