### PR TITLE
Enhance Virtual Name Card

### DIFF
--- a/__tests__/virtualCard.test.ts
+++ b/__tests__/virtualCard.test.ts
@@ -9,9 +9,13 @@ describe('generateVCard', () => {
   });
 
   it('includes optional fields', () => {
-    const v = generateVCard({ fullName: 'J', phone: '+1', email: 'a@b.c' });
+    const v = generateVCard({ fullName: 'J', phone: '+1', email: 'a@b.c', organization: 'Org', title: 'CEO', website: 'https://a', address: '123' });
     expect(v).toContain('TEL;TYPE=CELL:+1');
     expect(v).toContain('EMAIL:a@b.c');
+    expect(v).toContain('ORG:Org');
+    expect(v).toContain('TITLE:CEO');
+    expect(v).toContain('URL:https://a');
+    expect(v).toContain('ADR:123');
   });
 
   it('throws without fullName', () => {
@@ -22,7 +26,7 @@ describe('generateVCard', () => {
 
 describe('encodeContactData/decodeContactData', () => {
   it('round trips contact info', () => {
-    const info = { fullName: 'John Doe', phone: '+123', email: 'a@b.com' };
+    const info = { fullName: 'John Doe', phone: '+123', email: 'a@b.com', organization: 'Org', title: 'Dev', website: 'https://a', address: '123' };
     const enc = encodeContactData(info);
     const dec = decodeContactData(enc);
     expect(dec).toEqual(info);

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -127,6 +127,7 @@ import VirtualCardPage from "../src/tools/virtual-card/page";
 ```
 
 Create a shareable contact card completely in-browser. The tool generates a `.vcf` download, QR code, and URL with base64 encoded data that pre-fills the form when opened.
+It now supports organization, title, website and address fields, renders a preview business card and can download the card as a PNG image. Opening a link with `?data=` switches to view-only mode showing just the card.
 Access this tool at `/vcard`.
 ## Pre-rendering Tester
 

--- a/model/virtualCard.ts
+++ b/model/virtualCard.ts
@@ -6,6 +6,10 @@ export interface ContactInfo {
   fullName: string;
   phone?: string;
   email?: string;
+  organization?: string;
+  title?: string;
+  website?: string;
+  address?: string;
 }
 
 export const generateVCard = (info: ContactInfo): string => {
@@ -17,6 +21,10 @@ export const generateVCard = (info: ContactInfo): string => {
   ];
   if (info.phone) lines.push(`TEL;TYPE=CELL:${info.phone}`);
   if (info.email) lines.push(`EMAIL:${info.email}`);
+  if (info.organization) lines.push(`ORG:${info.organization}`);
+  if (info.title) lines.push(`TITLE:${info.title}`);
+  if (info.website) lines.push(`URL:${info.website}`);
+  if (info.address) lines.push(`ADR:${info.address}`);
   lines.push('END:VCARD');
   return lines.join('\n');
 };

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@heroicons/react": "^2.2.0",
     "@vitejs/plugin-react": "^4.0.3",
     "chalk": "^5.3.0",
+    "html-to-image": "^1.11.13",
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",
     "lz-string": "^1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       chalk:
         specifier: ^5.3.0
         version: 5.4.1
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
@@ -1939,6 +1942,9 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -5768,6 +5774,8 @@ snapshots:
       whatwg-encoding: 3.1.1
 
   html-escaper@2.0.2: {}
+
+  html-to-image@1.11.13: {}
 
   http-proxy-agent@7.0.2:
     dependencies:

--- a/src/tools/virtual-card/page.tsx
+++ b/src/tools/virtual-card/page.tsx
@@ -2,12 +2,23 @@
  * © 2025 MyDebugger Contributors – MIT License
  */
 import React from 'react';
+import { Helmet } from 'react-helmet';
 import useVirtualCard from '../../../viewmodel/useVirtualCard';
 import VirtualCardView from '../../../view/VirtualCardView';
 
 const VirtualCardPage: React.FC = () => {
   const vm = useVirtualCard();
-  return <VirtualCardView {...vm} />;
+  return (
+    <>
+      <Helmet>
+        <title>{vm.fullName ? `${vm.fullName} – Digital Contact Card` : 'Virtual Business Card Generator'}</title>
+        <meta name="description" content="Create and share a digital contact card with QR and vCard download." />
+        <meta property="og:title" content={vm.fullName ? `${vm.fullName} – vCard` : 'Virtual Business Card Generator'} />
+        <meta property="og:description" content="Save this digital business card." />
+      </Helmet>
+      <VirtualCardView {...vm} />
+    </>
+  );
 };
 
 export default VirtualCardPage;

--- a/view/VirtualCardHero.tsx
+++ b/view/VirtualCardHero.tsx
@@ -1,7 +1,7 @@
 /**
  * © 2025 MyDebugger Contributors – MIT License
  */
-import React, { forwardRef, useImperativeHandle } from 'react';
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
 
 const clsx = (...c: Array<string | false | null | undefined>) => c.filter(Boolean).join(' ');
 
@@ -9,6 +9,10 @@ interface Props {
   fullName: string;
   phone: string;
   email: string;
+  organization: string;
+  title: string;
+  website: string;
+  address: string;
   qrDataUrl: string;
   flipped: boolean;
   flip: (toBack?: boolean) => void;
@@ -21,12 +25,17 @@ interface Props {
 
 export interface VirtualCardHeroHandle {
   showQr: () => void;
+  root: HTMLDivElement | null;
 }
 
 const VirtualCardHero = forwardRef<VirtualCardHeroHandle, Props>(({ 
   fullName,
   phone,
   email,
+  organization,
+  title,
+  website,
+  address,
   qrDataUrl,
   flipped,
   flip,
@@ -36,12 +45,13 @@ const VirtualCardHero = forwardRef<VirtualCardHeroHandle, Props>(({
   shareCard,
   onInteract,
 }, ref) => {
+  const rootRef = useRef<HTMLDivElement>(null);
   const handleFlip = () => flip(!flipped);
 
-  useImperativeHandle(ref, () => ({ showQr: () => flip(true) }));
+  useImperativeHandle(ref, () => ({ showQr: () => flip(true), root: rootRef.current }));
 
   return (
-    <div className="relative mx-auto my-6 w-72 h-96 [perspective:1000px]">
+    <div ref={rootRef} className="relative mx-auto my-6 w-72 h-96 [perspective:1000px]">
       <div
         role="button"
         tabIndex={0}
@@ -67,8 +77,16 @@ const VirtualCardHero = forwardRef<VirtualCardHeroHandle, Props>(({
         >
           <div className="w-24 h-24 rounded-full bg-gray-200 dark:bg-gray-700 shadow mb-4" />
           <p className="text-xl font-semibold text-gray-800 dark:text-white">{fullName || 'Your Name'}</p>
+          {title && <p className="text-gray-600 dark:text-gray-300 text-sm">{title}</p>}
+          {organization && <p className="text-gray-600 dark:text-gray-300 text-sm">{organization}</p>}
           {phone && <p className="text-gray-600 dark:text-gray-300 text-sm">{phone}</p>}
           {email && <p className="text-gray-600 dark:text-gray-300 text-sm">{email}</p>}
+          {website && (
+            <a href={website} className="text-primary-600 dark:text-primary-400 text-sm" target="_blank" rel="noopener noreferrer">
+              {website}
+            </a>
+          )}
+          {address && <p className="text-gray-600 dark:text-gray-300 text-sm text-center">{address}</p>}
           <div className="flex gap-3 mt-4">
             {phone && (
               <a

--- a/view/VirtualCardView.tsx
+++ b/view/VirtualCardView.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { TOOL_PANEL_CLASS } from '../src/design-system/foundations/layout';
-import VirtualCardHero from './VirtualCardHero';
+import VirtualCardHero, { VirtualCardHeroHandle } from './VirtualCardHero';
 import VirtualCardActions from './VirtualCardActions';
 
 interface Props {
@@ -13,11 +13,20 @@ interface Props {
   setPhone: (v: string) => void;
   email: string;
   setEmail: (v: string) => void;
+  organization: string;
+  setOrganization: (v: string) => void;
+  title: string;
+  setTitle: (v: string) => void;
+  website: string;
+  setWebsite: (v: string) => void;
+  address: string;
+  setAddress: (v: string) => void;
   vcard: string;
   qrDataUrl: string;
   showRaw: boolean;
   toggleRaw: () => void;
   download: () => void;
+  downloadImage: () => void;
   copyLink: () => void;
   copyVcard: () => void;
   downloadQr: () => void;
@@ -26,6 +35,8 @@ interface Props {
   flip: (toBack?: boolean) => void;
   toastMessage: string;
   cancelFlip: () => void;
+  viewOnly: boolean;
+  heroRef: React.RefObject<VirtualCardHeroHandle>;
 }
 
 export function VirtualCardView({
@@ -35,11 +46,20 @@ export function VirtualCardView({
   setPhone,
   email,
   setEmail,
+  organization,
+  setOrganization,
+  title,
+  setTitle,
+  website,
+  setWebsite,
+  address,
+  setAddress,
   vcard,
   qrDataUrl,
   showRaw,
   toggleRaw,
   download,
+  downloadImage,
   copyLink,
   copyVcard,
   shareCard,
@@ -48,11 +68,15 @@ export function VirtualCardView({
   flip,
   toastMessage,
   cancelFlip,
+  viewOnly,
+  heroRef,
 }: Props) {
   return (
     <div className={TOOL_PANEL_CLASS}>
       <h2 className="text-2xl font-bold mb-4 text-gray-800 dark:text-white">Virtual Name Card</h2>
       <div className="space-y-4">
+        {!viewOnly && (
+        <>
         <div>
           {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
           <label htmlFor="full-name" className="block mb-1 text-sm font-medium">Full Name</label>
@@ -86,9 +110,36 @@ export function VirtualCardView({
             className="w-full p-2 border rounded dark:bg-gray-700"
           />
         </div>
+        <div>
+          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+          <label htmlFor="org" className="block mb-1 text-sm font-medium">Organization</label>
+          <input id="org" type="text" value={organization} onChange={(e) => setOrganization(e.target.value)} className="w-full p-2 border rounded dark:bg-gray-700" />
+        </div>
+        <div>
+          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+          <label htmlFor="title" className="block mb-1 text-sm font-medium">Title</label>
+          <input id="title" type="text" value={title} onChange={(e) => setTitle(e.target.value)} className="w-full p-2 border rounded dark:bg-gray-700" />
+        </div>
+        <div>
+          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+          <label htmlFor="website" className="block mb-1 text-sm font-medium">Website</label>
+          <input id="website" type="url" value={website} onChange={(e) => setWebsite(e.target.value)} className="w-full p-2 border rounded dark:bg-gray-700" />
+        </div>
+        <div>
+          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+          <label htmlFor="addr" className="block mb-1 text-sm font-medium">Address</label>
+          <input id="addr" type="text" value={address} onChange={(e) => setAddress(e.target.value)} className="w-full p-2 border rounded dark:bg-gray-700" />
+        </div>
+</>
+)}
         <div className="flex gap-2">
           <button type="button" onClick={download} className="px-3 py-1 bg-blue-500 text-white rounded">Download VCF</button>
-          <button type="button" onClick={copyLink} className="px-3 py-1 bg-blue-500 text-white rounded">Copy Link</button>
+          {!viewOnly && (
+            <button type="button" onClick={copyLink} className="px-3 py-1 bg-blue-500 text-white rounded">Copy Link</button>
+          )}
+          {!viewOnly && (
+            <button type="button" onClick={downloadImage} className="px-3 py-1 bg-blue-500 text-white rounded">Download PNG</button>
+          )}
           <button type="button" onClick={toggleRaw} className="px-3 py-1 bg-gray-300 rounded dark:bg-gray-600 dark:text-white">{showRaw ? 'Hide VCF' : 'Show VCF'}</button>
         </div>
         {showRaw && (
@@ -101,9 +152,14 @@ export function VirtualCardView({
         )}
         <div className="transition-opacity duration-300 delay-150">
           <VirtualCardHero
+            ref={heroRef}
             fullName={fullName}
             phone={phone}
             email={email}
+            organization={organization}
+            title={title}
+            website={website}
+            address={address}
             qrDataUrl={qrDataUrl}
             flipped={isFlipped}
             flip={flip}

--- a/viewmodel/useVirtualCard.ts
+++ b/viewmodel/useVirtualCard.ts
@@ -8,6 +8,7 @@ import {
   encodeContactData,
   decodeContactData,
 } from '../model/virtualCard';
+import { VirtualCardHeroHandle } from '../view/VirtualCardHero';
 
 let qrImport: Promise<typeof import('qrcode')> | null = null;
 const loadQRCode = async () => {
@@ -19,12 +20,18 @@ export const useVirtualCard = () => {
   const [fullName, setFullName] = useState('');
   const [phone, setPhone] = useState('');
   const [email, setEmail] = useState('');
+  const [organization, setOrganization] = useState('');
+  const [title, setTitle] = useState('');
+  const [website, setWebsite] = useState('');
+  const [address, setAddress] = useState('');
   const [vcard, setVcard] = useState('');
   const [qrDataUrl, setQrDataUrl] = useState('');
   const [shareUrl, setShareUrl] = useState('');
   const [showRaw, setShowRaw] = useState(false);
   const [isFlipped, setIsFlipped] = useState(false);
   const [toastMessage, setToastMessage] = useState('');
+  const [viewOnly, setViewOnly] = useState(false);
+  const heroRef = useRef<VirtualCardHeroHandle | null>(null);
   const flipTimer = useRef<number>();
 
   const updateOutputs = async (info: ContactInfo) => {
@@ -50,20 +57,33 @@ export const useVirtualCard = () => {
         setFullName(decoded.fullName || '');
         setPhone(decoded.phone || '');
         setEmail(decoded.email || '');
+        setOrganization(decoded.organization || '');
+        setTitle(decoded.title || '');
+        setWebsite(decoded.website || '');
+        setAddress(decoded.address || '');
+        setViewOnly(true);
       }
     }
   }, []);
 
   useEffect(() => {
-    const info: ContactInfo = { fullName, phone, email };
-    if (fullName || phone || email) {
+    const info: ContactInfo = {
+      fullName,
+      phone,
+      email,
+      organization,
+      title,
+      website,
+      address,
+    };
+    if (fullName || phone || email || organization || title || website || address) {
       updateOutputs(info);
     } else {
       setVcard('');
       setQrDataUrl('');
       setShareUrl('');
     }
-  }, [fullName, phone, email]);
+  }, [fullName, phone, email, organization, title, website, address]);
 
   useEffect(() => {
     if (!toastMessage) return undefined;
@@ -89,6 +109,16 @@ export const useVirtualCard = () => {
     link.download = 'qr.png';
     link.click();
     setToastMessage('QR saved');
+  };
+
+  const downloadImage = async () => {
+    if (!heroRef.current?.root) return;
+    const htmlToImage = await import('html-to-image');
+    const url = await htmlToImage.toPng(heroRef.current.root);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'card.png';
+    link.click();
   };
   const copyLink = async () => {
     if (shareUrl) {
@@ -142,6 +172,14 @@ export const useVirtualCard = () => {
     setPhone,
     email,
     setEmail,
+    organization,
+    setOrganization,
+    title,
+    setTitle,
+    website,
+    setWebsite,
+    address,
+    setAddress,
     vcard,
     qrDataUrl,
     shareUrl,
@@ -149,6 +187,7 @@ export const useVirtualCard = () => {
     toggleRaw,
     download,
     downloadQr,
+    downloadImage,
     copyLink,
     copyVcard,
     shareCard,
@@ -156,6 +195,8 @@ export const useVirtualCard = () => {
     flip,
     cancelFlip,
     toastMessage,
+    viewOnly,
+    heroRef,
   };
 };
 


### PR DESCRIPTION
## Summary
- support organization/title/website/address in contact model
- add view-only mode with base64 deep linking
- render extra info on VirtualCardHero
- allow PNG download of card and hide inputs when viewing shared link
- document updated Virtual Name Card tool

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm audit` *(fails: moderate & low vulnerabilities)*

------
https://chatgpt.com/codex/tasks/task_e_68518cdf9c148329a5138ff954da73f6