### PR TITLE
Improve CORS tester UI and add server preflight mode

### DIFF
--- a/__tests__/cors.test.ts
+++ b/__tests__/cors.test.ts
@@ -39,6 +39,15 @@ describe('runCorsPreflight', () => {
     const res = await runCorsPreflight('https://api.com', 'GET', {});
     expect(res.response.type).toBe('opaque');
   });
+
+  it('calls server mode when specified', async () => {
+    (global.fetch as any) = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({ test: true }) })
+    );
+    const res = await runCorsPreflight('https://api.com', 'GET', {}, 'server');
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain('cors-preflight');
+    expect(res).toEqual({ test: true });
+  });
 });
 
 describe('analyzeCors', () => {

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -92,8 +92,7 @@ The Header Scanner fetches a URL and analyzes common security headers like CSP, 
 import CorsTesterPage from "../src/tools/cors-tester";
 ```
 
-Use the CORS Tester to simulate preflight requests and inspect the `Access-Control-*` headers returned by a server. Enter a target URL, HTTP method and custom headers to see how the server responds and whether your origin is permitted.
-Common CORS mistakes are highlighted with inline tips and a list of browsers that would block the request. You can quickly add preset headers from a dropdown and copy a generated `curl` command to reproduce the request locally.
+The CORS Tester is a full-featured debugger for cross-origin issues. Enter a URL, choose the HTTP method and build headers in key/value or JSON format. Toggle between browser mode and a server-side curl simulation. Results are shown with color-coded badges, a header diff table and quick configuration tips. You can expand the raw request and copy a generated `curl` command for backend testing.
 
 ## Dynamic Link Tracker
 

--- a/model/cors.ts
+++ b/model/cors.ts
@@ -24,7 +24,8 @@ export interface CorsResult {
 export const runCorsPreflight = async (
   url: string,
   method: string,
-  headers: Record<string, string>
+  headers: Record<string, string>,
+  mode: 'browser' | 'server' = 'browser'
 ): Promise<CorsResult> => {
   const { origin } = window.location;
   const requestHeaders: Record<string, string> = {
@@ -37,6 +38,15 @@ export const runCorsPreflight = async (
   }
 
   try {
+    if (mode === 'server') {
+      const res = await fetch('/api/utility-tools?tool=cors-preflight', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url, method, headers }),
+      });
+      if (!res.ok) throw new Error('Server request failed');
+      return await res.json();
+    }
     const res = await fetch(url, {
       method: 'OPTIONS',
       mode: 'cors',

--- a/viewmodel/useCorsTester.ts
+++ b/viewmodel/useCorsTester.ts
@@ -19,6 +19,7 @@ const presets: Record<string, Record<string, string>> = {
 export const useCorsTester = () => {
   const [url, setUrl] = useState('');
   const [method, setMethod] = useState('GET');
+  const [mode, setMode] = useState<'browser' | 'server'>('browser');
   const [headerJson, setHeaderJson] = useState('{}');
   const [result, setResult] = useState<CorsResult | null>(null);
   const [analysis, setAnalysis] = useState<CorsAnalysis | null>(null);
@@ -36,7 +37,7 @@ export const useCorsTester = () => {
       return;
     }
     try {
-      const res = await runCorsPreflight(url, method, headers);
+      const res = await runCorsPreflight(url, method, headers, mode);
       setResult(res);
       setAnalysis(analyzeCors(res, window.location.origin, headers));
     } catch (e: unknown) {
@@ -72,6 +73,8 @@ export const useCorsTester = () => {
     setUrl,
     method,
     setMethod,
+    mode,
+    setMode,
     headerJson,
     setHeaderJson,
     addPreset,


### PR DESCRIPTION
## Summary
- redesign CORS tester view with format toggle and mode selector
- add server-side preflight API handler
- support server mode in model and viewmodel
- update documentation for new workflow
- extend cors tests

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm audit`

------
https://chatgpt.com/codex/tasks/task_e_68518e05996083298106e9ab31a1c5ed