### PR TITLE
Improve Pentest Suite UI

### DIFF
--- a/src/tools/pentest/page.tsx
+++ b/src/tools/pentest/page.tsx
@@ -23,6 +23,7 @@ const PentestSuitePage: React.FC = () => {
       runTests={vm.runTests}
       runId={vm.runId}
       setClickjacking={vm.setClickjacking}
+      loading={vm.loading}
     />
   );
 };

--- a/view/PentestSuiteView.tsx
+++ b/view/PentestSuiteView.tsx
@@ -4,11 +4,14 @@
 import React, { useEffect, useRef } from 'react';
 import { Badge, BadgeVariant } from '../src/design-system/components/display/Badge';
 import { Button } from '../src/design-system/components/inputs/Button';
+import { Card } from '../src/design-system/components/layout/Card';
+import { CodeBlock } from '../src/design-system/components/display/CodeBlock';
+import { Collapsible } from '../src/design-system/components/layout/Collapsible';
 import { TextInput } from '../src/design-system/components/inputs/TextInput';
 import { SelectInput } from '../src/design-system/components/inputs/SelectInput';
-import { Collapsible } from '../src/design-system/components/layout/Collapsible';
 import { InfoBox } from '../src/design-system/components/display/InfoBox';
 import { TOOL_PANEL_CLASS } from '../src/design-system/foundations/layout';
+import PreviewIframe from './PreviewIframe';
 import { ValidationStatus } from '../model/pentest';
 
 interface Props {
@@ -32,6 +35,7 @@ interface Props {
   runTests: () => void;
   runId: number;
   setClickjacking: (s: ValidationStatus) => void;
+  loading: boolean;
 }
 
 const statusColor: Record<ValidationStatus, BadgeVariant> = {
@@ -55,29 +59,36 @@ export function PentestSuiteView({
   runTests,
   runId,
   setClickjacking,
+  loading,
 }: Props) {
-  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const hasEvent = useRef(false);
 
   useEffect(() => {
-    if (!results.clickjacking || !iframeRef.current) {
-      return undefined;
-    }
+    hasEvent.current = false;
     const timer = setTimeout(() => {
-      if (results.clickjacking === 'inconclusive') {
+      if (!hasEvent.current && results.clickjacking === 'inconclusive') {
         setClickjacking('passed');
       }
     }, 3000);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [results.clickjacking, runId, setClickjacking]);
+    return () => clearTimeout(timer);
+  }, [runId, results.clickjacking, setClickjacking]);
 
   const handleLoad = () => {
+    hasEvent.current = true;
     setClickjacking('failed');
   };
   const handleError = () => {
+    hasEvent.current = true;
     setClickjacking('passed');
   };
+
+  const statuses = [
+    results.https?.status,
+    results.cors?.status,
+    results.openRedirect?.status,
+    results.xss?.status,
+    results.clickjacking,
+  ].filter(Boolean) as ValidationStatus[];
 
   const renderBadge = (s?: ValidationStatus) =>
     s ? <Badge variant={statusColor[s]}>{s}</Badge> : <span className="text-gray-500">-</span>;
@@ -91,157 +102,173 @@ export function PentestSuiteView({
           onChange={(e) => setUrl(e.target.value)}
           fullWidth
           list="pentest-history"
+          autoFocus
+          clearable
+          placeholder="https://example.com"
         />
         <datalist id="pentest-history">
           {history.map((h) => (
             <option key={h} value={h} />
           ))}
         </datalist>
-        <Button onClick={runTests}>Run All Tests</Button>
+        <Button onClick={runTests} isLoading={loading} disabled={loading}>
+          Run All Tests
+        </Button>
       </div>
+
+      {Object.keys(results).length > 0 && (
+        <div className="flex gap-2 text-sm">
+          <Badge variant="success">🟢 {statuses.filter((s) => s === 'passed').length} Passed</Badge>
+          <Badge variant="warning">🟡 {statuses.filter((s) => s === 'inconclusive').length} Inconclusive</Badge>
+          <Badge variant="danger">🔴 {statuses.filter((s) => s === 'failed').length} Failed</Badge>
+        </div>
+      )}
 
       <div className="grid gap-6 md:grid-cols-2">
         {/* Clickjacking */}
-        <div className={`relative space-y-3 ${TOOL_PANEL_CLASS.replace('p-6', 'p-5')}`}>
-          <h2 className="text-lg font-bold">Clickjacking Validator</h2>
-          {url && (
-            <iframe
-              ref={iframeRef}
-              src={url}
-              sandbox=""
-              onLoad={handleLoad}
-              onError={handleError}
-              className="w-full h-72 border"
-              title="clickjacking-test"
-            />
-          )}
-          <p className="text-sm text-gray-500">Tests if this site blocks iframe embedding.</p>
-          {results.clickjacking && (
-            <Badge
-              variant={statusColor[results.clickjacking]}
-              className="absolute top-4 right-4"
-            >
-              {results.clickjacking}
-            </Badge>
-          )}
-          {results.clickjacking && results.clickjacking !== 'inconclusive' && (
-            <Collapsible title="Logs" className="mt-2">
-              <div className="bg-gray-50 dark:bg-gray-900 rounded-md border border-gray-200 dark:border-gray-700 text-sm p-3 font-mono text-gray-800 dark:text-gray-200">
-                {results.clickjacking}
-              </div>
-            </Collapsible>
-          )}
-        </div>
+        <Card isElevated>
+          <Card.Header
+            title={
+              <span className="flex items-center gap-2">
+                🛡️ <span>Clickjacking Validator</span>
+              </span>
+            }
+            actions={
+              results.clickjacking && (
+                <Badge variant={statusColor[results.clickjacking]}>
+                  {results.clickjacking}
+                </Badge>
+              )
+            }
+          />
+          <Card.Body className="space-y-3">
+            {url && (
+              <PreviewIframe
+                src={url}
+                className="w-full h-72 border"
+                title="clickjacking-test"
+                onAllowed={handleLoad}
+                onBlocked={handleError}
+              />
+            )}
+            <p className="text-sm text-gray-500">Tests if this site blocks iframe embedding.</p>
+            {results.clickjacking && results.clickjacking !== 'inconclusive' && (
+              <Collapsible title="Logs" className="mt-2">
+                <CodeBlock>{results.clickjacking}</CodeBlock>
+              </Collapsible>
+            )}
+          </Card.Body>
+        </Card>
 
         {/* HTTPS Redirect */}
-        <div className={`relative space-y-3 ${TOOL_PANEL_CLASS.replace('p-6', 'p-5')}`}>
-          <h2 className="text-lg font-bold">HTTPS Redirect Checker</h2>
-          <p className="text-sm text-gray-400">Detects if http:// redirects to https://</p>
-          {results.https && (
-            <Badge
-              variant={statusColor[results.https.status]}
-              className="absolute top-4 right-4"
-            >
-              {results.https.status}
-            </Badge>
-          )}
-          {results.https?.details && (
-            <Collapsible title="Logs" className="mt-2">
-              <div className="bg-gray-50 dark:bg-gray-900 rounded-md border border-gray-200 dark:border-gray-700 text-sm p-3 font-mono text-gray-800 dark:text-gray-200">
-                {results.https.details}
-              </div>
-            </Collapsible>
-          )}
-          {httpUrl && (
-            <a href={httpUrl} target="_blank" rel="noopener noreferrer" className="text-blue-600 text-sm">Open HTTP Version</a>
-          )}
-        </div>
+        <Card isElevated>
+          <Card.Header
+            title={<span className="flex items-center gap-2">🔁 <span>HTTPS Redirect Checker</span></span>}
+            actions={
+              results.https && (
+                <Badge variant={statusColor[results.https.status]}>
+                  {results.https.status}
+                </Badge>
+              )
+            }
+          />
+          <Card.Body className="space-y-3">
+            <p className="text-sm text-gray-400">Detects if http:// redirects to https://</p>
+            {results.https?.details && (
+              <Collapsible title="Logs" className="mt-2">
+                <CodeBlock>{results.https.details}</CodeBlock>
+              </Collapsible>
+            )}
+            {httpUrl && (
+              <a href={httpUrl} target="_blank" rel="noopener noreferrer" className="text-blue-600 text-sm">Open HTTP Version</a>
+            )}
+          </Card.Body>
+        </Card>
 
         {/* Open Redirect */}
-        <div className={`relative space-y-3 ${TOOL_PANEL_CLASS.replace('p-6', 'p-5')}`}>
-          <h2 className="text-lg font-bold">Open Redirect Detector</h2>
-          <SelectInput
-            value={redirectParam}
-            onChange={setRedirectParam}
-            options={[
-              { value: 'redirect', label: 'redirect' },
-              { value: 'next', label: 'next' },
-              { value: 'url', label: 'url' },
-              { value: 'to', label: 'to' },
-            ]}
-            className="w-40"
+        <Card isElevated>
+          <Card.Header
+            title={<span className="flex items-center gap-2">🚚 <span>Open Redirect Detector</span></span>}
+            actions={
+              results.openRedirect && (
+                <Badge variant={statusColor[results.openRedirect.status]}>
+                  {results.openRedirect.status}
+                </Badge>
+              )
+            }
           />
-          {redirectUrl && (
-            <iframe src={redirectUrl} sandbox="" className="w-full h-64 border" title="open-redirect-test" />
-          )}
-          <p className="text-sm text-gray-400">Checks common redirect parameters.</p>
-          {results.openRedirect && (
-            <Badge
-              variant={statusColor[results.openRedirect.status]}
-              className="absolute top-4 right-4"
-            >
-              {results.openRedirect.status}
-            </Badge>
-          )}
-          {results.openRedirect?.details && (
-            <Collapsible title="Logs" className="mt-2">
-              <div className="bg-gray-50 dark:bg-gray-900 rounded-md border border-gray-200 dark:border-gray-700 text-sm p-3 font-mono text-gray-800 dark:text-gray-200">
-                {results.openRedirect.details}
-              </div>
-            </Collapsible>
-          )}
-        </div>
+          <Card.Body className="space-y-3">
+            <SelectInput
+              value={redirectParam}
+              onChange={setRedirectParam}
+              options={[
+                { value: 'redirect', label: 'redirect' },
+                { value: 'next', label: 'next' },
+                { value: 'url', label: 'url' },
+                { value: 'to', label: 'to' },
+              ]}
+              className="w-40"
+            />
+            {redirectUrl && (
+              <PreviewIframe src={redirectUrl} className="w-full h-64 border" title="open-redirect-test" />
+            )}
+            <p className="text-sm text-gray-400">Checks common redirect parameters.</p>
+            {results.openRedirect?.details && (
+              <Collapsible title="Logs" className="mt-2">
+                <CodeBlock>{results.openRedirect.details}</CodeBlock>
+              </Collapsible>
+            )}
+          </Card.Body>
+        </Card>
 
         {/* XSS Reflection */}
-        <div className={`relative space-y-3 ${TOOL_PANEL_CLASS.replace('p-6', 'p-5')}`}>
-          <h2 className="text-lg font-bold">XSS Reflection Tester</h2>
-          <TextInput
-            label="Payload"
-            value={xssPayload}
-            onChange={(e) => setXssPayload(e.target.value)}
-            fullWidth
+        <Card isElevated>
+          <Card.Header
+            title={<span className="flex items-center gap-2">⚠️ <span>XSS Reflection Tester</span></span>}
+            actions={
+              results.xss && (
+                <Badge variant={statusColor[results.xss.status]}>{results.xss.status}</Badge>
+              )
+            }
           />
-          {xssUrl && (
-            <iframe src={xssUrl} sandbox="" className="w-full h-64 border" title="xss-test" />
-          )}
-          <p className="text-sm text-gray-400">Injects a basic payload via query string.</p>
-          {results.xss && (
-            <Badge
-              variant={statusColor[results.xss.status]}
-              className="absolute top-4 right-4"
-            >
-              {results.xss.status}
-            </Badge>
-          )}
-          {results.xss?.details && (
-            <Collapsible title="Logs" className="mt-2">
-              <div className="bg-gray-50 dark:bg-gray-900 rounded-md border border-gray-200 dark:border-gray-700 text-sm p-3 font-mono text-gray-800 dark:text-gray-200">
-                {results.xss.details}
-              </div>
-            </Collapsible>
-          )}
-        </div>
+          <Card.Body className="space-y-3">
+            <TextInput
+              label="Payload"
+              value={xssPayload}
+              onChange={(e) => setXssPayload(e.target.value)}
+              fullWidth
+            />
+            {xssUrl && (
+              <PreviewIframe src={xssUrl} className="w-full h-64 border" title="xss-test" />
+            )}
+            <p className="text-sm text-gray-400">Injects a basic payload via query string.</p>
+            {results.xss?.details && (
+              <Collapsible title="Logs" className="mt-2">
+                <CodeBlock>{results.xss.details}</CodeBlock>
+              </Collapsible>
+            )}
+          </Card.Body>
+        </Card>
 
         {/* CORS */}
-        <div className={`relative space-y-3 ${TOOL_PANEL_CLASS.replace('p-6', 'p-5')}`}>
-          <h2 className="text-lg font-bold">CORS Validator</h2>
-          <p className="text-sm text-gray-400">Attempts cross-origin fetch to the target.</p>
-          {results.cors && (
-            <Badge
-              variant={statusColor[results.cors.status]}
-              className="absolute top-4 right-4"
-            >
-              {results.cors.status}
-            </Badge>
-          )}
-          {results.cors?.details && (
-            <Collapsible title="Logs" className="mt-2">
-              <div className="bg-gray-50 dark:bg-gray-900 rounded-md border border-gray-200 dark:border-gray-700 text-sm p-3 font-mono text-gray-800 dark:text-gray-200">
-                {results.cors.details}
-              </div>
-            </Collapsible>
-          )}
-        </div>
+        <Card isElevated>
+          <Card.Header
+            title={<span className="flex items-center gap-2">🌐 <span>CORS Validator</span></span>}
+            actions={
+              results.cors && (
+                <Badge variant={statusColor[results.cors.status]}>{results.cors.status}</Badge>
+              )
+            }
+          />
+          <Card.Body className="space-y-3">
+            <p className="text-sm text-gray-400">Attempts cross-origin fetch to the target.</p>
+            {results.cors?.details && (
+              <Collapsible title="Logs" className="mt-2">
+                <CodeBlock>{results.cors.details}</CodeBlock>
+              </Collapsible>
+            )}
+          </Card.Body>
+        </Card>
       </div>
 
       {Object.keys(results).length > 0 && (
@@ -275,6 +302,9 @@ export function PentestSuiteView({
       <InfoBox variant="warning" title="Aggressive tests">
         Some validators use iframes and redirects which may trigger network requests. Manual review is recommended for XSS payloads.
       </InfoBox>
+      <div className="text-sm text-right text-gray-500 dark:text-gray-400">
+        🧪 4/4 Tests Available | 🧩 Coming Soon: CSRF, CORS, CSP Scanner
+      </div>
     </div>
   );
 };

--- a/view/PreviewIframe.tsx
+++ b/view/PreviewIframe.tsx
@@ -1,0 +1,54 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+/* eslint-disable react/jsx-props-no-spreading, react/require-default-props */
+import React, { useState, useEffect } from 'react';
+
+export interface PreviewIframeProps
+  extends Omit<React.IframeHTMLAttributes<HTMLIFrameElement>, 'onLoad' | 'onError'> {
+  /** Callback when preview blocked due to X-Frame-Options */
+  onBlocked?: () => void;
+  /** Callback when preview allowed */
+  onAllowed?: () => void;
+  /** Title for the iframe element */
+  title?: string;
+}
+
+function PreviewIframe({ onBlocked, onAllowed, title = 'preview', ...rest }: PreviewIframeProps) {
+  const [blocked, setBlocked] = useState(false);
+
+  useEffect(() => {
+    setBlocked(false);
+  }, [rest.src]);
+
+  const handleError = () => {
+    setBlocked(true);
+    if (onBlocked) onBlocked();
+  };
+
+  const handleLoad = () => {
+    if (onAllowed) onAllowed();
+  };
+
+  return (
+    <>
+      {!blocked && (
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        <iframe
+          {...rest}
+          title={title}
+          sandbox=""
+          onLoad={handleLoad}
+          onError={handleError}
+        />
+      )}
+      {blocked && (
+        <div className="p-3 text-sm bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
+          X-Frame-Options prevents preview
+        </div>
+      )}
+    </>
+  );
+}
+
+export default PreviewIframe;

--- a/viewmodel/usePentestSuite.ts
+++ b/viewmodel/usePentestSuite.ts
@@ -32,6 +32,7 @@ export const usePentestSuite = () => {
   const [xssPayload, setXssPayload] = useState('<img src=x onerror=alert(1)>');
   const [history, setHistory] = useState<string[]>([]);
   const [runId, setRunId] = useState(0);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     const saved = localStorage.getItem('MyDebugger:pentest-history');
@@ -48,17 +49,22 @@ export const usePentestSuite = () => {
 
   const runTests = async () => {
     if (!url) return;
-    const target = normalizeUrl(url.trim());
-    saveHistory(target);
-    setRunId((id) => id + 1);
-    setRedirectUrl(buildRedirectTestUrl(target, redirectParam));
-    setXssUrl(buildXssTestUrl(target, xssPayload));
-    setHttpUrl(target.replace(/^https:/, 'http:'));
-    const https = await checkHttpsRedirect(target);
-    const cors = await checkCors(target);
-    const openRedirect = await checkOpenRedirect(target, redirectParam);
-    const xss = await checkXssReflection(target, xssPayload);
-    setResults({ https, cors, openRedirect, xss, clickjacking: 'inconclusive' });
+    setLoading(true);
+    try {
+      const target = normalizeUrl(url.trim());
+      saveHistory(target);
+      setRunId((id) => id + 1);
+      setRedirectUrl(buildRedirectTestUrl(target, redirectParam));
+      setXssUrl(buildXssTestUrl(target, xssPayload));
+      setHttpUrl(target.replace(/^https:/, 'http:'));
+      const https = await checkHttpsRedirect(target);
+      const cors = await checkCors(target);
+      const openRedirect = await checkOpenRedirect(target, redirectParam);
+      const xss = await checkXssReflection(target, xssPayload);
+      setResults({ https, cors, openRedirect, xss, clickjacking: 'inconclusive' });
+    } finally {
+      setLoading(false);
+    }
   };
 
   const setClickjacking = (status: ValidationStatus) => {
@@ -80,6 +86,7 @@ export const usePentestSuite = () => {
     history,
     runId,
     setClickjacking,
+    loading,
   };
 };
 


### PR DESCRIPTION
## Summary
- add loading state to pentest suite view model
- add PreviewIframe component with X-Frame-Options fallback
- redesign PentestSuiteView using Card layout and summary bar
- wire `loading` prop through pentest route

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68519073e3308329aa920624884aad15