### PR TITLE
Improve virtual card preview design

### DIFF
--- a/__tests__/virtualCard.test.ts
+++ b/__tests__/virtualCard.test.ts
@@ -1,4 +1,4 @@
-import { generateVCard, encodeContactData, decodeContactData } from '../model/virtualCard';
+import { generateVCard, encodeContactData, decodeContactData, getInitials } from '../model/virtualCard';
 
 describe('generateVCard', () => {
   it('creates a minimal vcard', () => {
@@ -34,5 +34,19 @@ describe('encodeContactData/decodeContactData', () => {
 
   it('returns null on invalid input', () => {
     expect(decodeContactData('!nv4l!d')).toBeNull();
+  });
+});
+
+describe('getInitials', () => {
+  it('returns initials for full name', () => {
+    expect(getInitials('John Doe')).toBe('JD');
+  });
+
+  it('handles single word name', () => {
+    expect(getInitials('Plato')).toBe('P');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(getInitials('')).toBe('');
   });
 });

--- a/model/virtualCard.ts
+++ b/model/virtualCard.ts
@@ -46,3 +46,14 @@ export const decodeContactData = (encoded: string): ContactInfo | null => {
     return null;
   }
 };
+
+export const getInitials = (fullName: string): string => {
+  if (!fullName) return '';
+  return fullName
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((w) => w[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+};

--- a/view/CardPreview.tsx
+++ b/view/CardPreview.tsx
@@ -1,0 +1,115 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import { FiPhone, FiMail, FiGlobe, FiMapPin } from 'react-icons/fi';
+import { FaGithub, FaLinkedin, FaFacebook } from 'react-icons/fa';
+import { getInitials } from '../model/virtualCard';
+
+interface CardPreviewProps {
+  fullName: string;
+  title: string;
+  organization: string;
+  phone: string;
+  email: string;
+  website: string;
+  address: string;
+  download: () => void;
+}
+
+function CardPreview({
+  fullName,
+  title,
+  organization,
+  phone,
+  email,
+  website,
+  address,
+  download,
+}: CardPreviewProps) {
+  return (
+    <div className="relative w-full max-w-sm mx-auto border rounded-xl shadow-md bg-white p-6 text-center space-y-2">
+      <div className="bg-black text-white text-sm font-semibold py-1 rounded">
+        {organization || fullName || 'KOKTAIL'}
+      </div>
+      <div className="flex flex-col items-center space-y-1">
+        <div className="w-16 h-16 rounded-full bg-gray-200 flex items-center justify-center text-2xl font-bold text-gray-700">
+          {getInitials(fullName) || '?'}
+        </div>
+        <h2 className="text-lg font-bold text-gray-800">{fullName || 'Your Name'}</h2>
+        {title && <p className="text-sm italic text-gray-600">{title}</p>}
+        {organization && <p className="text-sm text-gray-500">{organization}</p>}
+      </div>
+      <hr className="my-2" />
+      <div className="text-sm text-gray-600 space-y-1 text-left">
+        {phone && (
+          <p className="flex items-center gap-2">
+            <FiPhone /> <span>{phone}</span>
+          </p>
+        )}
+        {email && (
+          <p className="flex items-center gap-2">
+            <FiMail /> <span>{email}</span>
+          </p>
+        )}
+        {website && (
+          <p className="flex items-center gap-2">
+            <FiGlobe /> <span>{website}</span>
+          </p>
+        )}
+        {address && (
+          <p className="flex items-center gap-2">
+            <FiMapPin /> <span>{address}</span>
+          </p>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={download}
+        className="mt-3 px-4 py-2 rounded-full bg-red-600 text-white w-full max-w-xs"
+      >
+        Save Contact
+      </button>
+      <div className="flex justify-center gap-3 pt-4 text-red-600 text-xl">
+        {phone && (
+          <a href={`tel:${phone}`} aria-label="Call">
+            <FiPhone />
+          </a>
+        )}
+        {email && (
+          <a href={`mailto:${email}`} aria-label="Email">
+            <FiMail />
+          </a>
+        )}
+        {website && (
+          <a href={website} target="_blank" rel="noopener noreferrer" aria-label="Website">
+            <FiGlobe />
+          </a>
+        )}
+        {address && (
+          <a
+            href={`https://maps.google.com/?q=${encodeURIComponent(address)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Location"
+          >
+            <FiMapPin />
+          </a>
+        )}
+      </div>
+      <div className="absolute bottom-2 right-4 flex gap-4 text-xl text-gray-500">
+        <a href="https://github.com" aria-label="GitHub">
+          <FaGithub />
+        </a>
+        <a href="https://linkedin.com" aria-label="LinkedIn">
+          <FaLinkedin />
+        </a>
+        <a href="https://facebook.com" aria-label="Facebook">
+          <FaFacebook />
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export default CardPreview;

--- a/view/VirtualCardHero.tsx
+++ b/view/VirtualCardHero.tsx
@@ -2,6 +2,7 @@
  * © 2025 MyDebugger Contributors – MIT License
  */
 import React, { forwardRef, useImperativeHandle, useRef } from 'react';
+import CardPreview from './CardPreview';
 
 const clsx = (...c: Array<string | false | null | undefined>) => c.filter(Boolean).join(' ');
 
@@ -19,7 +20,6 @@ interface Props {
   download: () => void;
   downloadQr: () => void;
   copyVcard: () => void;
-  shareCard: () => void;
   onInteract: () => void;
 }
 
@@ -42,7 +42,6 @@ const VirtualCardHero = forwardRef<VirtualCardHeroHandle, Props>(({
   download,
   downloadQr,
   copyVcard,
-  shareCard,
   onInteract,
 }, ref) => {
   const rootRef = useRef<HTMLDivElement>(null);
@@ -51,7 +50,10 @@ const VirtualCardHero = forwardRef<VirtualCardHeroHandle, Props>(({
   useImperativeHandle(ref, () => ({ showQr: () => flip(true), root: rootRef.current }));
 
   return (
-    <div ref={rootRef} className="relative mx-auto my-6 w-72 h-96 [perspective:1000px]">
+    <div
+      ref={rootRef}
+      className="relative mx-auto my-6 w-full max-w-sm aspect-[16/10] [perspective:1000px]"
+    >
       <div
         role="button"
         tabIndex={0}
@@ -69,49 +71,22 @@ const VirtualCardHero = forwardRef<VirtualCardHeroHandle, Props>(({
       >
         <div
           className={clsx(
-            'absolute inset-0 flex flex-col items-center justify-center rounded-2xl shadow-xl',
+            'absolute inset-0 flex items-center justify-center rounded-2xl shadow-xl',
             'bg-white dark:bg-gray-800 [backface-visibility:hidden] motion-reduce:[backface-visibility:visible]',
             'transition-opacity duration-300',
             flipped && 'opacity-0 motion-reduce:opacity-100',
           )}
         >
-          <div className="w-24 h-24 rounded-full bg-gray-200 dark:bg-gray-700 shadow mb-4" />
-          <p className="text-xl font-semibold text-gray-800 dark:text-white">{fullName || 'Your Name'}</p>
-          {title && <p className="text-gray-600 dark:text-gray-300 text-sm">{title}</p>}
-          {organization && <p className="text-gray-600 dark:text-gray-300 text-sm">{organization}</p>}
-          {phone && <p className="text-gray-600 dark:text-gray-300 text-sm">{phone}</p>}
-          {email && <p className="text-gray-600 dark:text-gray-300 text-sm">{email}</p>}
-          {website && (
-            <a href={website} className="text-primary-600 dark:text-primary-400 text-sm" target="_blank" rel="noopener noreferrer">
-              {website}
-            </a>
-          )}
-          {address && <p className="text-gray-600 dark:text-gray-300 text-sm text-center">{address}</p>}
-          <div className="flex gap-3 mt-4">
-            {phone && (
-              <a
-                href={`tel:${phone}`}
-                className="flex items-center gap-1 px-3 py-1 text-sm bg-primary-600 text-white rounded focus:outline-none"
-              >
-                📞 Call
-              </a>
-            )}
-            {email && (
-              <a
-                href={`mailto:${email}`}
-                className="flex items-center gap-1 px-3 py-1 text-sm bg-primary-600 text-white rounded focus:outline-none"
-              >
-                ✉️ Email
-              </a>
-            )}
-            <button
-              type="button"
-              onClick={() => { shareCard(); onInteract(); }}
-              className="flex items-center gap-1 px-3 py-1 text-sm bg-primary-600 text-white rounded focus:outline-none"
-            >
-              🔗 Share
-            </button>
-          </div>
+          <CardPreview
+            fullName={fullName}
+            phone={phone}
+            email={email}
+            organization={organization}
+            title={title}
+            website={website}
+            address={address}
+            download={download}
+          />
         </div>
         <div
           className={clsx(

--- a/view/VirtualCardView.tsx
+++ b/view/VirtualCardView.tsx
@@ -2,7 +2,6 @@
  * © 2025 MyDebugger Contributors – MIT License
  */
 import React from 'react';
-import { TOOL_PANEL_CLASS } from '../src/design-system/foundations/layout';
 import VirtualCardHero, { VirtualCardHeroHandle } from './VirtualCardHero';
 import VirtualCardActions from './VirtualCardActions';
 
@@ -72,9 +71,10 @@ export function VirtualCardView({
   heroRef,
 }: Props) {
   return (
-    <div className={TOOL_PANEL_CLASS}>
-      <h2 className="text-2xl font-bold mb-4 text-gray-800 dark:text-white">Virtual Name Card</h2>
-      <div className="space-y-4">
+    <div className="w-full min-h-screen bg-gray-50 px-4 py-10">
+      <h2 className="text-2xl font-bold mb-4 text-center text-gray-800 dark:text-white">Virtual Name Card</h2>
+      <div className="max-w-6xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-8 items-start">
+        <div className="space-y-4">
         {!viewOnly && (
         <>
         <div>
@@ -150,30 +150,32 @@ export function VirtualCardView({
             {toastMessage}
           </div>
         )}
-        <div className="transition-opacity duration-300 delay-150">
-          <VirtualCardHero
-            ref={heroRef}
-            fullName={fullName}
-            phone={phone}
-            email={email}
-            organization={organization}
-            title={title}
-            website={website}
-            address={address}
-            qrDataUrl={qrDataUrl}
-            flipped={isFlipped}
-            flip={flip}
-            download={download}
-            downloadQr={downloadQr}
-            copyVcard={copyVcard}
-            shareCard={shareCard}
-            onInteract={cancelFlip}
-          />
-          <VirtualCardActions
-            download={download}
-            shareCard={shareCard}
-            showQr={() => flip(true)}
-          />
+      </div>
+        <div className="flex justify-center lg:justify-end">
+          <div className="transition-opacity duration-300 delay-150 max-w-sm">
+            <VirtualCardHero
+              ref={heroRef}
+              fullName={fullName}
+              phone={phone}
+              email={email}
+              organization={organization}
+              title={title}
+              website={website}
+              address={address}
+              qrDataUrl={qrDataUrl}
+              flipped={isFlipped}
+              flip={flip}
+              download={download}
+              downloadQr={downloadQr}
+              copyVcard={copyVcard}
+              onInteract={cancelFlip}
+            />
+            <VirtualCardActions
+              download={download}
+              shareCard={shareCard}
+              showQr={() => flip(true)}
+            />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add `CardPreview` component with branding bar and contact actions
- use `CardPreview` inside `VirtualCardHero`
- switch hero aspect ratio to `16/10` for realistic card proportions
- keep responsive two-column layout in `VirtualCardView`

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm audit` *(4 vulnerabilities: 3 low, 1 moderate)*

------
https://chatgpt.com/codex/tasks/task_e_68519588c9508329857262f692c54213