### PR TITLE
Fix permission tester preview & add test notifications

### DIFF
--- a/view/PermissionCard.tsx
+++ b/view/PermissionCard.tsx
@@ -22,6 +22,7 @@ interface PermissionCardProps {
   codeSnippet: string;
   isLoading: boolean;
   permissionData?: unknown;
+  onTestNotification?: () => void;
 }
 
 // Helper function to get OS-specific reset instructions
@@ -59,7 +60,8 @@ function PermissionCard({
   onCopyCode,
   codeSnippet,
   isLoading,
-  permissionData = undefined
+  permissionData = undefined,
+  onTestNotification
 }: PermissionCardProps) {
   const [showCode, setShowCode] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
@@ -92,11 +94,25 @@ function PermissionCard({
     setShowPreview(false);
   };
 
+  // Clean up active streams or sensors when component unmounts
+  useEffect(() => () => {
+    if (permissionData instanceof MediaStream) {
+      permissionData.getTracks().forEach(track => track.stop());
+    }
+    if (showPreview) setShowPreview(false);
+  }, [permissionData, showPreview]);
+
   const renderLivePreview = () => {
     if (!permissionData || !showPreview) return null;
 
     switch (permissionInfo.name) {
       case 'camera':
+        if (permissionData instanceof MediaStream) {
+          return <CameraPreview stream={permissionData} onStop={handleStopPreview} />;
+        }
+        break;
+
+      case 'display-capture':
         if (permissionData instanceof MediaStream) {
           return <CameraPreview stream={permissionData} onStop={handleStopPreview} />;
         }
@@ -273,9 +289,9 @@ function PermissionCard({
         {/* Actions */}
         <div className="flex gap-2 pt-4 border-t border-gray-200 dark:border-gray-700">
           {status === 'prompt' || status === 'unsupported' ? (
-            <Button 
-              onClick={handleRequest} 
-              disabled={isLoading || status === 'unsupported'}
+            <Button
+              onClick={handleRequest}
+              disabled={isLoading}
               variant="primary"
               size="sm"
             >
@@ -306,8 +322,8 @@ function PermissionCard({
             </Button>
           )}
           
-          <Button 
-            variant="ghost" 
+          <Button
+            variant="ghost"
             size="sm"
             onClick={() => {
               const resetUrl = getResetInstructionsUrl();
@@ -315,12 +331,18 @@ function PermissionCard({
             }}
           >
             Reset
-          </Button>        </div>
+          </Button>
+          {permissionInfo.name === 'notifications' && status === 'granted' && onTestNotification && (
+            <Button variant="ghost" size="sm" onClick={onTestNotification}>
+              Test Push
+            </Button>
+          )}
+        </div>
       </div>
     </Card>
   );
 }
 
-PermissionCard.defaultProps = { permissionData: undefined };
+PermissionCard.defaultProps = { permissionData: undefined, onTestNotification: undefined };
 
 export default PermissionCard;

--- a/view/PermissionTesterView.tsx
+++ b/view/PermissionTesterView.tsx
@@ -24,7 +24,8 @@ function PermissionTesterView({
   clearEvents,
   getCodeSnippet,
   isLoading,
-  getPermissionData
+  getPermissionData,
+  testNotification
 }: PermissionTesterViewProps) {
   
   return (
@@ -97,6 +98,11 @@ function PermissionTesterView({
                   codeSnippet={getCodeSnippet(permission.permission.name)}
                   isLoading={isLoading(permission.permission.name)}
                   permissionData={getPermissionData(permission.permission.name)}
+                  onTestNotification={
+                    permission.permission.name === 'notifications'
+                      ? testNotification
+                      : undefined
+                  }
                 />
               ))}
             </div>

--- a/viewmodel/usePermissionTester.ts
+++ b/viewmodel/usePermissionTester.ts
@@ -24,6 +24,7 @@ export interface UsePermissionTesterReturn {
   copyCodeSnippet: (permissionName: string) => Promise<void>;
   copyEventLog: () => Promise<void>;
   clearEvents: () => void;
+  testNotification: () => void;
   getCodeSnippet: (permissionName: string) => string;
   isLoading: (permissionName: string) => boolean;
   getPermissionData: (permissionName: string) => unknown;
@@ -189,6 +190,31 @@ const usePermissionTester = (): UsePermissionTesterReturn => {
     ));
   }, [addEvent]);
 
+  const testNotification = useCallback(() => {
+    if (Notification.permission !== 'granted') {
+      addEvent(createPermissionEvent(
+        'notifications',
+        'error',
+        'Notification permission not granted'
+      ));
+      return;
+    }
+    try {
+      // eslint-disable-next-line no-new
+      new Notification('MyDebugger', {
+        body: 'Test notification from Permission Tester'
+      });
+      addEvent(createPermissionEvent(
+        'notifications',
+        'request',
+        'Test notification sent'
+      ));
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Notification error';
+      addEvent(createPermissionEvent('notifications', 'error', msg));
+    }
+  }, [addEvent]);
+
   const getCodeSnippet = useCallback((permissionName: string): string => {
     const permission = PERMISSIONS.find(p => p.name === permissionName);
     return permission ? generateCodeSnippet(permission) : '';
@@ -226,6 +252,7 @@ const usePermissionTester = (): UsePermissionTesterReturn => {
     copyCodeSnippet,
     copyEventLog,
     clearEvents,
+    testNotification,
     getCodeSnippet,
     isLoading,
     getPermissionData


### PR DESCRIPTION
## Summary
- enable requesting unsupported permissions
- add display-capture preview
- allow testing notifications via new button
- clean up streams/sensors when permission cards unmount

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68544f011bec8329baf2f91a747f370c