### PR TITLE
Add PWA Push Tester module

### DIFF
--- a/__tests__/pushTester.test.ts
+++ b/__tests__/pushTester.test.ts
@@ -1,0 +1,19 @@
+import { decodeVapidKey, detectPushSupport } from '../model/pushTester';
+
+describe('decodeVapidKey', () => {
+  it('decodes base64url string', () => {
+    const arr = decodeVapidKey('AQAB');
+    expect(arr).toBeInstanceOf(Uint8Array);
+    expect(arr.length).toBeGreaterThan(0);
+  });
+});
+
+describe('detectPushSupport', () => {
+  it('returns boolean flags', () => {
+    const s = detectPushSupport();
+    expect(typeof s.secure).toBe('boolean');
+    expect(typeof s.serviceWorker).toBe('boolean');
+    expect(typeof s.pushManager).toBe('boolean');
+    expect(typeof s.notification).toBe('boolean');
+  });
+});

--- a/api/mydebugger.ts
+++ b/api/mydebugger.ts
@@ -1,0 +1,34 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import webpush from 'web-push';
+
+export const runtime = 'edge';
+
+const VAPID = {
+  publicKey: process.env.VAPID_PUBLIC_KEY!,
+  privateKey: process.env.VAPID_PRIVATE_KEY!,
+  subject: process.env.VAPID_SUBJECT || 'mailto:support@mydebugger.dev'
+};
+
+webpush.setVapidDetails(VAPID.subject, VAPID.publicKey, VAPID.privateKey);
+
+export async function POST(req: NextRequest) {
+  const { action, ...payload } = await req.json();
+  switch (action) {
+    case 'push-echo':
+      return pushEcho(payload as any);
+    default:
+      return NextResponse.json({ ok: false, error: 'Unknown action' }, { status: 400 });
+  }
+}
+
+async function pushEcho({ subscription, notification }: { subscription: any; notification: any }) {
+  try {
+    await webpush.sendNotification(subscription, JSON.stringify(notification));
+    return NextResponse.json({ ok: true });
+  } catch (err: any) {
+    return NextResponse.json({ ok: false, error: err.message }, { status: 500 });
+  }
+}

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -159,3 +159,11 @@ import UrlEncoderPage from "../src/tools/url/UrlEncoder";
 ```
 
 Quickly encode or decode URL components. Choose between `encodeURIComponent`, `encodeURI` or legacy `escape`. Batch mode processes each line separately. Access it at `/url-encoder`.
+
+## PWA Push Tester
+
+```tsx
+import PushTesterPage from '../src/tools/push-tester/page';
+```
+
+Verify browser support for Service Workers and Web Push, create a push subscription with your own VAPID public key and send a test notification via an in-house edge function. Access this tool at `/push-tester`.

--- a/model/permissions.ts
+++ b/model/permissions.ts
@@ -1,8 +1,9 @@
 /**
  * © 2025 MyDebugger Contributors – MIT License
- * 
+ *
  * Permission Tester Model - Browser permissions testing
  */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 export type PermissionStatus = 'granted' | 'denied' | 'prompt' | 'unsupported';
 
@@ -70,67 +71,39 @@ export interface PermissionEvent {
 
 // Permission request functions
 const requestFunctions = {
-  geolocation: async () => {
-    return new Promise((resolve, reject) => {
+  geolocation: async () => new Promise((resolve, reject) => {
       navigator.geolocation.getCurrentPosition(resolve, reject, {
         enableHighAccuracy: true,
         timeout: 10000,
         maximumAge: 0
       });
-    });
-  },
+    }),
 
-  camera: async () => {
-    return navigator.mediaDevices.getUserMedia({ video: true });
-  },
+  camera: async () => navigator.mediaDevices.getUserMedia({ video: true }),
 
-  microphone: async () => {
-    return navigator.mediaDevices.getUserMedia({ audio: true });
-  },
+  microphone: async () => navigator.mediaDevices.getUserMedia({ audio: true }),
 
-  'display-capture': async () => {
-    return navigator.mediaDevices.getDisplayMedia({ video: true });
-  },
+  'display-capture': async () => navigator.mediaDevices.getDisplayMedia({ video: true }),
 
-  notifications: async () => {
-    return Notification.requestPermission();
-  },
+  notifications: async () => Notification.requestPermission(),
 
-  'clipboard-read': async () => {
-    return navigator.clipboard.readText();
-  },
+  'clipboard-read': async () => navigator.clipboard.readText(),
 
-  'clipboard-write': async () => {
-    return navigator.clipboard.writeText('test');
-  },
+  'clipboard-write': async () => navigator.clipboard.writeText('test'),
 
-  bluetooth: async () => {
-    return (navigator as any).bluetooth?.requestDevice({ acceptAllDevices: true });
-  },
+  bluetooth: async () => (navigator as any).bluetooth?.requestDevice({ acceptAllDevices: true }),
 
-  usb: async () => {
-    return (navigator as any).usb?.requestDevice({ filters: [] });
-  },
+  usb: async () => (navigator as any).usb?.requestDevice({ filters: [] }),
 
-  serial: async () => {
-    return (navigator as any).serial?.requestPort();
-  },
+  serial: async () => (navigator as any).serial?.requestPort(),
 
-  hid: async () => {
-    return (navigator as any).hid?.requestDevice({ filters: [] });
-  },
+  hid: async () => (navigator as any).hid?.requestDevice({ filters: [] }),
 
-  midi: async () => {
-    return navigator.requestMIDIAccess?.({ sysex: true });
-  },
+  midi: async () => navigator.requestMIDIAccess?.({ sysex: true }),
 
-  'persistent-storage': async () => {
-    return navigator.storage?.persist();
-  },
+  'persistent-storage': async () => navigator.storage?.persist(),
 
-  'screen-wake-lock': async () => {
-    return navigator.wakeLock?.request('screen');
-  },
+  'screen-wake-lock': async () => navigator.wakeLock?.request('screen'),
 
   'ambient-light-sensor': async () => {
     const sensor = new (window as any).AmbientLightSensor();
@@ -156,25 +129,15 @@ const requestFunctions = {
     return sensor;
   },
 
-  'local-fonts': async () => {
-    return (navigator as any).fonts?.query();
-  },
+  'local-fonts': async () => (navigator as any).fonts?.query(),
 
-  'storage-access': async () => {
-    return document.requestStorageAccess?.();
-  },
+  'storage-access': async () => document.requestStorageAccess?.(),
 
-  'idle-detection': async () => {
-    return (window as any).IdleDetector?.requestPermission();
-  },
+  'idle-detection': async () => (window as any).IdleDetector?.requestPermission(),
 
-  'compute-pressure': async () => {
-    return (navigator as any).computePressure?.getStatus?.();
-  },
+  'compute-pressure': async () => (navigator as any).computePressure?.getStatus?.(),
 
-  'window-management': async () => {
-    return (window as any).getScreenDetails?.();
-  },
+  'window-management': async () => (window as any).getScreenDetails?.(),
 
   nfc: async () => {
     const reader = new (window as any).NDEFReader();

--- a/model/pushTester.ts
+++ b/model/pushTester.ts
@@ -1,0 +1,24 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+export interface PushSupport {
+  secure: boolean;
+  serviceWorker: boolean;
+  pushManager: boolean;
+  notification: boolean;
+}
+
+export const detectPushSupport = (): PushSupport => ({
+  secure: typeof window !== 'undefined' && (window as { isSecureContext?: boolean }).isSecureContext === true,
+  serviceWorker: typeof navigator !== 'undefined' && 'serviceWorker' in navigator,
+  pushManager: typeof window !== 'undefined' && 'PushManager' in window,
+  notification: typeof window !== 'undefined' && 'Notification' in window,
+});
+
+export const decodeVapidKey = (base64: string): Uint8Array => {
+  const padding = '='.repeat((4 - (base64.length % 4)) % 4);
+  const str = (base64 + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(str);
+  return Uint8Array.from(Array.from(raw).map(c => c.charCodeAt(0)));
+};

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-router-dom": "^6.14.0",
     "react-use": "^17.4.0",
     "tailwindcss": "^3.3.3",
-    "vite": "^4.5.2"
+    "vite": "^4.5.2",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^2.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       vite:
         specifier: ^4.5.2
         version: 4.5.14(@types/node@18.19.111)(terser@5.41.0)
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^2.1.4
@@ -1970,6 +1973,10 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -2420,8 +2427,14 @@ packages:
   jwa@1.4.2:
     resolution: {integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==}
 
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
   jws@3.2.2:
     resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
+
+  jws@4.0.0:
+    resolution: {integrity: sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3556,6 +3569,11 @@ packages:
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -5824,6 +5842,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http_ece@1.2.0: {}
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
@@ -6511,9 +6531,20 @@ snapshots:
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
 
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
   jws@3.2.2:
     dependencies:
       jwa: 1.4.2
+      safe-buffer: 5.2.1
+
+  jws@4.0.0:
+    dependencies:
+      jwa: 2.0.1
       safe-buffer: 5.2.1
 
   keyv@4.5.4:
@@ -7717,6 +7748,16 @@ snapshots:
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.0
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   web-streams-polyfill@3.3.3: {}
 

--- a/public/sw/push-tester-sw.js
+++ b/public/sw/push-tester-sw.js
@@ -1,0 +1,10 @@
+self.addEventListener('push', evt => {
+  const data = evt.data?.json() ?? { title: 'MyDebugger Push', body: 'Default body' };
+  evt.waitUntil(
+    self.registration.showNotification(data.title, {
+      body: data.body,
+      tag: 'mydebugger-push-test',
+      icon: '/icons/pwa-push-test.png'
+    })
+  );
+});

--- a/src/design-system/icons/tool-icons.tsx
+++ b/src/design-system/icons/tool-icons.tsx
@@ -106,6 +106,12 @@ export const CacheIcon: React.FC<IconProps> = ({ className }) => (
   </svg>
 );
 
+export const PushIcon: React.FC<IconProps> = ({ className }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6 6 0 00-5-5.917V3a1 1 0 10-2 0v2.083A6 6 0 006 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/>
+  </svg>
+);
+
 export const ContactCardIcon: React.FC<IconProps> = ({ className }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -62,6 +62,7 @@ import {
   LinkTracerIcon,
   CookieIcon,
   CacheIcon,
+  PushIcon,
   ContactCardIcon,
 } from "../design-system/icons/tool-icons";
 
@@ -524,6 +525,20 @@ const toolRegistry: Tool[] = [
       relatedTools: ['headers-analyzer', 'cors-tester'],
     },
     uiOptions: { showExamples: false }
+  },
+  {
+    id: 'push-tester',
+    route: '/push-tester',
+    title: 'PWA Push Tester',
+    description: 'Verify Web Push capability end-to-end.',
+    icon: PushIcon,
+    component: lazy(() => import('./push-tester/page')),
+    category: 'Testing',
+    metadata: {
+      keywords: ['push', 'notification', 'service worker'],
+      relatedTools: ['permission-tester'],
+    },
+    uiOptions: { showExamples: false },
   },
 ];
 

--- a/src/tools/push-tester/page.tsx
+++ b/src/tools/push-tester/page.tsx
@@ -1,0 +1,11 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import PushTester from '../../../view/PushTester';
+
+function PushTesterPage() {
+  return <PushTester />;
+}
+
+export default PushTesterPage;

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "public": true,
   "framework": "vite",
   "installCommand": "npm install --production=false",
@@ -7,10 +7,26 @@
   "devCommand": "npm run dev",
   "outputDirectory": "dist",
   "rewrites": [
-    { "source": "/api/(.*)", "destination": "/api/$1" },
-    { "source": "/assets/(.*)", "destination": "/assets/$1" },
-    { "source": "/(.+\\.(?:js|css|ico|json|png|jpg|jpeg|svg|webp))", "destination": "/$1" },
-    { "source": "/(.*)", "destination": "/index.html" }
+    {
+      "source": "/sw/push-tester-sw.js",
+      "destination": "/sw/push-tester-sw.js"
+    },
+    {
+      "source": "/api/(.*)",
+      "destination": "/api/$1"
+    },
+    {
+      "source": "/assets/(.*)",
+      "destination": "/assets/$1"
+    },
+    {
+      "source": "/(.+\\.(?:js|css|ico|json|png|jpg|jpeg|svg|webp))",
+      "destination": "/$1"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
   ],
   "env": {},
   "headers": [
@@ -49,5 +65,10 @@
         }
       ]
     }
-  ]
+  ],
+  "functions": {
+    "api/mydebugger.ts": {
+      "runtime": "@vercel/edge@1.2.2"
+    }
+  }
 }

--- a/view/PushTester.tsx
+++ b/view/PushTester.tsx
@@ -1,0 +1,126 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import { TOOL_PANEL_CLASS } from '../src/design-system/foundations/layout';
+import { usePushTester } from '../viewmodel/usePushTester';
+
+export default function PushTester() {
+  const {
+    support,
+    subscription,
+    payload,
+    setPayload,
+    vapidKey,
+    setVapidKey,
+    status,
+    logs,
+    register,
+    subscribe,
+    sendPush,
+    copySubscription,
+    cleanup,
+  } = usePushTester();
+
+  const steps = [
+    { key: 'registered', label: 'Service Worker Registered' },
+    { key: 'subscribed', label: 'Push Subscribed' },
+    { key: 'notified', label: 'Notification Sent' },
+  ];
+
+  const statusIndex = steps.findIndex((s) => s.key === status);
+
+  return (
+    <div className="space-y-4">
+      <div className={`${TOOL_PANEL_CLASS} space-y-2`}>
+        <h2 className="font-semibold">Support</h2>
+        <ul className="text-sm list-disc ml-4">
+          <li>Secure Context: {support.secure ? '✅' : '❌'}</li>
+          <li>Service Worker: {support.serviceWorker ? '✅' : '❌'}</li>
+          <li>PushManager: {support.pushManager ? '✅' : '❌'}</li>
+          <li>Notification: {support.notification ? '✅' : '❌'}</li>
+        </ul>
+      </div>
+
+      <div className={`${TOOL_PANEL_CLASS} space-y-3`}>
+        <label htmlFor="vapid" className="block text-sm font-medium">
+          VAPID Public Key
+          <input
+            id="vapid"
+            type="text"
+            className="w-full rounded-md border-gray-300 p-2 mt-1"
+            value={vapidKey}
+            onChange={(e) => setVapidKey(e.target.value)}
+            placeholder="Base64 encoded VAPID key"
+          />
+        </label>
+        <button type="button" onClick={register} className="px-3 py-1 bg-primary-500 text-white rounded-md">
+          Register Service Worker
+        </button>
+        <button type="button" onClick={subscribe} className="px-3 py-1 bg-primary-500 text-white rounded-md">
+          Subscribe
+        </button>
+      </div>
+
+        {subscription && (
+          <div className={`${TOOL_PANEL_CLASS} space-y-3`}>
+          <label htmlFor="title" className="block text-sm font-medium">
+            Notification Title
+            <input
+              id="title"
+              type="text"
+              className="w-full rounded-md border-gray-300 p-2 mt-1"
+              value={payload.title}
+              onChange={(e) => setPayload({ ...payload, title: e.target.value })}
+            />
+          </label>
+          <label htmlFor="body" className="block text-sm font-medium">
+            Notification Body
+            <textarea
+              id="body"
+              className="w-full rounded-md border-gray-300 p-2 mt-1"
+              value={payload.body}
+              onChange={(e) => setPayload({ ...payload, body: e.target.value })}
+              rows={2}
+            />
+          </label>
+          <button
+            type="button"
+            onClick={sendPush}
+            className="px-3 py-1 bg-primary-500 text-white rounded-md"
+          >
+            Send test push
+          </button>
+          <button
+            type="button"
+            onClick={copySubscription}
+            className="px-3 py-1 bg-gray-200 rounded-md"
+          >
+            Copy Subscription
+          </button>
+          </div>
+        )}
+
+      <div className={`${TOOL_PANEL_CLASS} space-y-2`}>
+        <h2 className="font-semibold">Status</h2>
+        <ol className="space-y-1 text-sm ml-4">
+          {steps.map((step, idx) => (
+            <li key={step.key} className="flex items-center space-x-1">
+              <span>{statusIndex >= idx ? '✅' : '⬜'}</span>
+              <span>{step.label}</span>
+            </li>
+          ))}
+        </ol>
+        <button type="button" onClick={cleanup} className="px-3 py-1 bg-gray-200 rounded-md">
+          Cleanup
+        </button>
+        <div className="text-xs text-gray-500 whitespace-pre-wrap">
+          {logs.map((l) => (
+            <div key={l}>{l}</div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+

--- a/viewmodel/usePushTester.ts
+++ b/viewmodel/usePushTester.ts
@@ -1,0 +1,101 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { useEffect, useState } from 'react';
+import { detectPushSupport, decodeVapidKey, PushSupport } from '../model/pushTester';
+
+interface NotificationPayload {
+  title: string;
+  body: string;
+}
+
+export interface PushTesterState {
+  support: PushSupport;
+  registration: ServiceWorkerRegistration | null;
+  subscription: PushSubscription | null;
+  payload: NotificationPayload;
+  status: 'idle' | 'registered' | 'subscribed' | 'notified';
+  logs: string[];
+  vapidKey: string;
+}
+
+export const usePushTester = () => {
+  const [support, setSupport] = useState<PushSupport>(() => detectPushSupport());
+  const [registration, setRegistration] = useState<ServiceWorkerRegistration | null>(null);
+  const [subscription, setSubscription] = useState<PushSubscription | null>(null);
+  const [payload, setPayload] = useState<NotificationPayload>({ title: 'MyDebugger Push Test', body: 'Hello from the Push Tester module \u{1F44B}' });
+  const [status, setStatus] = useState<'idle' | 'registered' | 'subscribed' | 'notified'>('idle');
+  const [logs, setLogs] = useState<string[]>([]);
+  const [vapidKey, setVapidKey] = useState('');
+
+  useEffect(() => {
+    setSupport(detectPushSupport());
+  }, []);
+
+  const log = (msg: string) => setLogs(l => [...l, msg]);
+
+  const register = async () => {
+    if (!support.serviceWorker) throw new Error('Service Worker unsupported');
+    const reg = await navigator.serviceWorker.register('/sw/push-tester-sw.js');
+    setRegistration(reg);
+    setStatus('registered');
+    log('Service worker registered');
+  };
+
+  const subscribe = async () => {
+    if (!registration) throw new Error('Register service worker first');
+    const key = decodeVapidKey(vapidKey.trim());
+    const sub = await registration.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: key });
+    setSubscription(sub);
+    setStatus('subscribed');
+    log('Push subscription created');
+  };
+
+  const sendPush = async () => {
+    if (!subscription) throw new Error('No subscription');
+    const res = await fetch('/api/mydebugger', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'push-echo', subscription, notification: payload }),
+    });
+    if (!res.ok) throw new Error('Failed to send push');
+    setStatus('notified');
+    log('Push sent');
+  };
+
+  const copySubscription = async () => {
+    if (!subscription) return;
+    await navigator.clipboard.writeText(JSON.stringify(subscription));
+    log('Subscription copied to clipboard');
+  };
+
+  const cleanup = async () => {
+    if (subscription) {
+      await subscription.unsubscribe();
+      setSubscription(null);
+    }
+    if (registration) {
+      await registration.unregister();
+      setRegistration(null);
+    }
+    setStatus('idle');
+    log('Cleaned up');
+  };
+
+  return {
+    support,
+    registration,
+    subscription,
+    payload,
+    setPayload,
+    status,
+    logs,
+    vapidKey,
+    setVapidKey,
+    register,
+    subscribe,
+    sendPush,
+    copySubscription,
+    cleanup,
+  } as const;
+};


### PR DESCRIPTION
## Summary
- implement Push Tester view, viewmodel and model
- add push-echo edge function
- register new tool and icon
- include static service worker
- document Push Tester
- refactor push echo edge handler
- fix lint issues
- use Build Output API v3 in vercel config
- pin Edge runtime version for Vercel functions
- enhance Push Tester UI with stepper and copy button

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm audit` (4 low/moderate vulnerabilities)


------
https://chatgpt.com/codex/tasks/task_e_68544abd52088329ab479d358de8bf46