### PR TITLE
Add Generate Large Image tool

### DIFF
--- a/__tests__/imagePadding.test.ts
+++ b/__tests__/imagePadding.test.ts
@@ -1,0 +1,9 @@
+import { expandImageWithJunk } from '../src/tools/ImagePaddingUtils';
+
+test('expandImageWithJunk pads blob to requested size', () => {
+  const data = new Uint8Array(10);
+  const blob = new Blob([data], { type: 'image/png' });
+  const padded = expandImageWithJunk(blob, 0.001); // ~1KB
+  expect(padded.size).toBe(1048);
+  expect(padded.type).toBe('image/png');
+});

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -27,6 +27,7 @@ Every section starts with an import snippet showing the component location so yo
 - [URL Encoder / Decoder](#url-encoder--decoder)
 - [Virtual Name Card](#virtual-name-card)
 - [Web Permission Tester](#web-permission-tester)
+- [Generate Large Image](#generate-large-image)
 
 ## Crypto Lab
 
@@ -196,3 +197,11 @@ import PushTesterPage from '../src/tools/push-tester/page';
 
 Verify browser support for Service Workers and Web Push, create a push subscription with your own VAPID public key and send a test notification via an in-house edge function. Access this tool at `/push-tester`.
 
+
+## Generate Large Image
+
+```tsx
+import GenerateLargeImagePage from '../src/tools/generate-large-image/page';
+```
+
+Generate dummy image files of 1MB, 5MB or 10MB for testing upload limits. Upload any small JPG or PNG (≤200KB) and expand it right in the browser. Access this tool at `/generate-large-image`.

--- a/src/tools/ImagePaddingUtils.ts
+++ b/src/tools/ImagePaddingUtils.ts
@@ -1,0 +1,14 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+export function expandImageWithJunk(blob: Blob, targetSizeMB: number): Blob {
+  const currentSize = blob.size;
+  const targetBytes = targetSizeMB * 1024 * 1024;
+  if (targetBytes <= currentSize) {
+    return blob;
+  }
+  const paddingSize = targetBytes - currentSize;
+  const junk = new Uint8Array(paddingSize).fill(65); // ASCII 'A'
+  return new Blob([blob, junk], { type: blob.type });
+}

--- a/src/tools/generate-large-image/index.ts
+++ b/src/tools/generate-large-image/index.ts
@@ -1,0 +1,4 @@
+import GenerateLargeImagePage from './page';
+
+export { GenerateLargeImagePage };
+export default GenerateLargeImagePage;

--- a/src/tools/generate-large-image/page.tsx
+++ b/src/tools/generate-large-image/page.tsx
@@ -1,0 +1,20 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import { getToolByRoute } from '../index';
+import { ToolLayout } from '../../design-system/components/layout';
+import GenerateLargeImageView from '../../../view/GenerateLargeImageView';
+import { useGenerateLargeImage } from '../../../viewmodel/useGenerateLargeImage';
+
+const GenerateLargeImagePage: React.FC = () => {
+  const vm = useGenerateLargeImage();
+  const tool = getToolByRoute('/generate-large-image');
+  return (
+    <ToolLayout tool={tool!}>
+      <GenerateLargeImageView {...vm} />
+    </ToolLayout>
+  );
+};
+
+export default GenerateLargeImagePage;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -540,6 +540,20 @@ const toolRegistry: Tool[] = [
     },
     uiOptions: { showExamples: false },
   },
+  {
+    id: "generate-large-image",
+    route: "/generate-large-image",
+    title: "Generate Large Image",
+    description: "Create dummy images for upload testing.",
+    icon: UtilitiesIcon,
+    component: lazy(() => import("./generate-large-image/page")),
+    category: "Testing",
+    metadata: {
+      keywords: ["image", "upload", "test", "dummy"],
+      relatedTools: []
+    },
+    uiOptions: { showExamples: false }
+  },
 ];
 
 export default toolRegistry;

--- a/view/GenerateLargeImageView.tsx
+++ b/view/GenerateLargeImageView.tsx
@@ -1,0 +1,161 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React, { ChangeEvent, DragEvent } from 'react';
+import { TOOL_PANEL_CLASS } from '../src/design-system/foundations/layout';
+import { UseGenerateLargeImageReturn } from '../viewmodel/useGenerateLargeImage';
+
+const dropClasses = 'border-2 border-dashed border-gray-300 p-4 rounded-md text-center';
+
+function GenerateLargeImageView({
+  previewUrl,
+  file,
+  width,
+  height,
+  sizeKB,
+  targetSizeMB,
+  setTargetSizeMB,
+  format,
+  setFormat,
+  autoDownload,
+  setAutoDownload,
+  preserveResolution,
+  setPreserveResolution,
+  progress,
+  outputUrl,
+  outputSize,
+  error,
+  onFile,
+  generate,
+}: UseGenerateLargeImageReturn) {
+  const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) onFile(e.target.files[0]);
+  };
+
+  const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    if (e.dataTransfer.files && e.dataTransfer.files[0]) onFile(e.dataTransfer.files[0]);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div
+        className={`${TOOL_PANEL_CLASS} space-y-2`}
+        onDrop={handleDrop}
+        onDragOver={(e) => e.preventDefault()}
+      >
+        <label htmlFor="file" className={`block text-sm font-medium ${dropClasses}`}>
+          Upload Image (≤200KB)
+          <input id="file" type="file" accept="image/jpeg,image/png" onChange={handleFile} className="mt-2" />
+          <p className="text-xs text-gray-500">Drag & drop or click to select</p>
+        </label>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        {file && (
+          <div className="text-sm space-y-2">
+            <p>Name: {file.name}</p>
+            <p>Resolution: {width} × {height}</p>
+            <p>Size: {sizeKB} KB</p>
+            {previewUrl && (
+              <img src={previewUrl} alt="preview" className="max-h-40 rounded" />
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className={`${TOOL_PANEL_CLASS} space-y-2`}>
+        <label htmlFor="target-size" className="block text-sm font-medium">
+          Target size (MB)
+          <select
+            id="target-size"
+            value={targetSizeMB}
+            onChange={(e) => setTargetSizeMB(parseFloat(e.target.value))}
+            className="border p-2 rounded-md w-full"
+          >
+            <option value={1}>1MB</option>
+            <option value={5}>5MB</option>
+            <option value={10}>10MB</option>
+          </select>
+        </label>
+        <input
+          id="target-size-custom"
+          type="number"
+          min={0}
+          step={0.1}
+          value={targetSizeMB}
+          onChange={(e) => setTargetSizeMB(parseFloat(e.target.value))}
+          className="border p-2 rounded-md w-full"
+        />
+
+        <div className="space-x-3">
+          <label htmlFor="format-jpg" className="inline-flex items-center space-x-1">
+            <input
+              id="format-jpg"
+              type="radio"
+              checked={format === 'jpg'}
+              onChange={() => setFormat('jpg')}
+            />
+            <span>JPG</span>
+          </label>
+          <label htmlFor="format-png" className="inline-flex items-center space-x-1">
+            <input
+              id="format-png"
+              type="radio"
+              checked={format === 'png'}
+              onChange={() => setFormat('png')}
+            />
+            <span>PNG</span>
+          </label>
+        </div>
+
+        <label htmlFor="auto-download" className="inline-flex items-center space-x-2">
+          <input
+            id="auto-download"
+            type="checkbox"
+            checked={autoDownload}
+            onChange={(e) => setAutoDownload(e.target.checked)}
+          />
+          <span>Auto-download after generation</span>
+        </label>
+
+        <label htmlFor="preserve-res" className="inline-flex items-center space-x-2">
+          <input
+            id="preserve-res"
+            type="checkbox"
+            checked={preserveResolution}
+            onChange={(e) => setPreserveResolution(e.target.checked)}
+          />
+          <span>Preserve original resolution (no resize)</span>
+        </label>
+
+        <button
+          className="mt-2 px-4 py-2 bg-primary-600 text-white rounded-md"
+          type="button"
+          onClick={generate}
+        >
+          Generate
+        </button>
+        {progress > 0 && (
+          <p className="text-sm">Generating... {progress}%</p>
+        )}
+        {outputUrl && (
+          <div className="text-sm">
+            <p>Target size: {targetSizeMB} MB</p>
+            <p>
+              Output size: {(outputSize / (1024 * 1024)).toFixed(2)} MB{' '}
+              {Math.abs(outputSize - targetSizeMB * 1024 * 1024) <= targetSizeMB * 1024 * 0.05 ? '✅' : '⚠️'}
+            </p>
+            <a
+              href={outputUrl}
+              download={file ? `${file.name.replace(/\.[^.]+$/, '')}_${targetSizeMB}MB.${format}` : `dummy_${targetSizeMB}MB.${format}`}
+              className="underline text-primary-600"
+            >
+              Download file
+            </a>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default GenerateLargeImageView;

--- a/viewmodel/useGenerateLargeImage.ts
+++ b/viewmodel/useGenerateLargeImage.ts
@@ -1,0 +1,117 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { useState } from 'react';
+import { expandImageWithJunk } from '../src/tools/ImagePaddingUtils';
+
+export const useGenerateLargeImage = () => {
+  const [file, setFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState('');
+  const [width, setWidth] = useState(0);
+  const [height, setHeight] = useState(0);
+  const [sizeKB, setSizeKB] = useState(0);
+  const [targetSizeMB, setTargetSizeMB] = useState(1);
+  const [format, setFormat] = useState<'jpg' | 'png'>('jpg');
+  const [autoDownload, setAutoDownload] = useState(false);
+  const [preserveResolution, setPreserveResolution] = useState(true);
+  const [progress, setProgress] = useState(0);
+  const [outputUrl, setOutputUrl] = useState<string | null>(null);
+  const [outputSize, setOutputSize] = useState(0);
+  const [error, setError] = useState('');
+
+  const reset = () => {
+    setPreviewUrl('');
+    setWidth(0);
+    setHeight(0);
+    setSizeKB(0);
+    setOutputUrl(null);
+    setOutputSize(0);
+    setProgress(0);
+  };
+
+  const onFile = (f: File) => {
+    reset();
+    if (!['image/jpeg', 'image/png'].includes(f.type)) {
+      setError('Only JPG or PNG images allowed');
+      return;
+    }
+    if (f.size > 200 * 1024) {
+      setError('Image must be 200KB or smaller');
+      return;
+    }
+    setError('');
+    setFile(f);
+    setSizeKB(Math.round(f.size / 1024));
+    const url = URL.createObjectURL(f);
+    setPreviewUrl(url);
+    const img = new Image();
+    img.onload = () => {
+      setWidth(img.width);
+      setHeight(img.height);
+    };
+    img.src = url;
+  };
+
+  const generate = async () => {
+    if (!file) return;
+    setProgress(10);
+    const img = new Image();
+    img.src = previewUrl;
+    await new Promise((res) => {
+      img.onload = () => res(null);
+    });
+    const canvas = document.createElement('canvas');
+    canvas.width = img.width;
+    canvas.height = img.height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Canvas not supported');
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+    setProgress(50);
+    const blob: Blob = await new Promise((resolve) => {
+      if (format === 'jpg') {
+        canvas.toBlob((b) => resolve(b as Blob), 'image/jpeg', 0.8);
+      } else {
+        canvas.toBlob((b) => resolve(b as Blob), 'image/png');
+      }
+    });
+    let finalBlob = blob;
+    if (blob.size < targetSizeMB * 1024 * 1024) {
+      finalBlob = expandImageWithJunk(blob, targetSizeMB);
+    }
+    const url = URL.createObjectURL(finalBlob);
+    setOutputUrl(url);
+    setOutputSize(finalBlob.size);
+    setProgress(100);
+    if (autoDownload) {
+      const a = document.createElement('a');
+      a.href = url;
+      const base = file.name.replace(/\.[^.]+$/, '');
+      a.download = `${base}_${targetSizeMB}MB.${format}`;
+      a.click();
+    }
+  };
+
+  return {
+    file,
+    previewUrl,
+    width,
+    height,
+    sizeKB,
+    targetSizeMB,
+    setTargetSizeMB,
+    format,
+    setFormat,
+    autoDownload,
+    setAutoDownload,
+    preserveResolution,
+    setPreserveResolution,
+    progress,
+    outputUrl,
+    outputSize,
+    error,
+    onFile,
+    generate,
+  };
+};
+
+export type UseGenerateLargeImageReturn = ReturnType<typeof useGenerateLargeImage>;


### PR DESCRIPTION
## Summary
- implement image padding helper
- add Generate Large Image viewmodel and view
- register new tool route and docs
- include unit test for padding helper
- fix lint issues and update tests

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685990d5c7348329a2a25dfb7ad80c70