### PR TITLE
Add multi-format QR generation

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -179,7 +179,7 @@ Simulate JavaScript rendering in a sandboxed iframe. Set a timeout before captur
 import QRCodeGeneratorPage from "../src/tools/qrcode/QRCodeGenerator";
 ```
 
-Generate QR codes for any URL or mobile deep link. The tool auto-encodes query parameters, shows a real-time preview and lets you open or share the link instantly. Choose from ten visual presets, tweak dot/eye styles, gradients and upload a center logo. Export your QR in **PNG**, **SVG** or **PDF**. Access it at `/qrcode`.
+Generate QR codes for links or other data types like plain text, phone numbers, Wi-Fi credentials, geographic coordinates and calendar events. The tool auto-encodes URLs, shows a real-time preview and lets you open or share the link instantly. Choose from ten visual presets, tweak dot/eye styles, gradients and upload a center logo. Export your QR in **PNG**, **SVG** or **PDF**. Access it at `/qrcode`.
 
 This generator now ships with **40 curated style presets** for instant visual theming. Choose a preset to apply matching colors in one click.
 


### PR DESCRIPTION
## Summary
- extend QR generator with selectable types
- support text, phone, WiFi, geo and calendar codes
- document new QR code capabilities
- type QR generator and remove ts-nocheck

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685c1d9ff4048329b298fa966d28d859