### PR TITLE
Relax Generate Large Image upload limit

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -206,4 +206,4 @@ Verify browser support for Service Workers and Web Push, create a push subscript
 import GenerateLargeImagePage from '../src/tools/generate-large-image/page';
 ```
 
-Generate dummy image files of 1MB, 5MB or 10MB for testing upload limits. Upload any small JPG or PNG (≤200KB) and expand it right in the browser. Access this tool at `/generate-large-image`.
+Generate dummy image files of 1MB, 5MB or 10MB for testing upload limits. Upload any small JPG or PNG (≤1MB) and expand it right in the browser. Access this tool at `/generate-large-image`.

--- a/view/GenerateLargeImageView.tsx
+++ b/view/GenerateLargeImageView.tsx
@@ -45,7 +45,7 @@ function GenerateLargeImageView({
         onDragOver={(e) => e.preventDefault()}
       >
         <label htmlFor="file" className={`block text-sm font-medium ${dropClasses}`}>
-          Upload Image (≤200KB)
+          Upload Image (≤1MB)
           <input id="file" type="file" accept="image/jpeg,image/png" onChange={handleFile} className="mt-2" />
           <p className="text-xs text-gray-500">Drag & drop or click to select</p>
         </label>

--- a/viewmodel/useGenerateLargeImage.ts
+++ b/viewmodel/useGenerateLargeImage.ts
@@ -35,8 +35,8 @@ export const useGenerateLargeImage = () => {
       setError('Only JPG or PNG images allowed');
       return;
     }
-    if (f.size > 200 * 1024) {
-      setError('Image must be 200KB or smaller');
+    if (f.size > 1 * 1024 * 1024) {
+      setError('Image must be 1MB or smaller');
       return;
     }
     setError('');


### PR DESCRIPTION
## Summary
- allow images up to 1MB in the generate large image tool

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm audit`

------
https://chatgpt.com/codex/tasks/task_e_685ccfaaafa48329a631d24b65bde6d1