### PR TITLE
Fix overflow in vCard preview card

### DIFF
--- a/view/CardPreview.tsx
+++ b/view/CardPreview.tsx
@@ -28,7 +28,7 @@ function CardPreview({
   download,
 }: CardPreviewProps) {
   return (
-    <div className="relative w-full max-w-sm mx-auto border rounded-xl shadow-md bg-white p-6 text-center space-y-2">
+    <div className="relative w-full max-w-sm mx-auto border rounded-xl shadow-md bg-white p-6 pb-16 text-center space-y-2">
       <div className="bg-black text-white text-sm font-semibold py-1 rounded">
         {organization || fullName || 'KOKTAIL'}
       </div>
@@ -97,7 +97,7 @@ function CardPreview({
           </a>
         )}
       </div>
-      <div className="absolute bottom-2 right-4 flex gap-4 text-xl text-gray-500">
+      <div className="absolute bottom-4 right-4 flex gap-4 text-xl text-gray-500">
         <a href="https://github.com" aria-label="GitHub">
           <FaGithub />
         </a>

--- a/view/VirtualCardHero.tsx
+++ b/view/VirtualCardHero.tsx
@@ -52,7 +52,7 @@ const VirtualCardHero = forwardRef<VirtualCardHeroHandle, Props>(({
   return (
     <div
       ref={rootRef}
-      className="relative mx-auto my-6 w-full max-w-sm aspect-[16/10] [perspective:1000px]"
+      className="relative mx-auto my-6 w-full max-w-sm [perspective:1000px]"
     >
       <div
         role="button"


### PR DESCRIPTION
## Summary
- pad `CardPreview` bottom so action icons don't overlap
- let `VirtualCardHero` resize naturally

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685cd80ddae483298dcb133419517fed