### PR TITLE
Improve Home page UI with SEO data

### DIFF
--- a/__tests__/Home.test.tsx
+++ b/__tests__/Home.test.tsx
@@ -1,0 +1,40 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen } from '../src/test-utils/test-utils';
+import Home from '../src/pages/Home';
+// Stub CSS import for Jest
+jest.mock('../src/pages/Home.css', () => ({}), { virtual: true });
+// Simplify navigation components to avoid complex hooks in tests
+jest.mock('../src/design-system', () => {
+  const actual = jest.requireActual('../src/design-system');
+  return {
+    ...actual,
+    TabGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    Tab: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    TabPanel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  };
+});
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+describe('Home page', () => {
+  it('renders hero heading', () => {
+    render(<Home />);
+    const heading = screen.getByRole('heading', { name: /hyper seo/i });
+    expect(heading).toBeInTheDocument();
+  });
+});

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -34,10 +34,21 @@ const Home: React.FC = () => {
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
   const [pinnedTools, setPinnedTools] = useState<Tool[]>([]);
   const [dragIndex, setDragIndex] = useState<number | null>(null);
-  
+
   const allTools = useMemo(() => getTools(), []);
   const categories = useMemo(() => getAllCategories(), []);
   const popularTools = useMemo(() => getPopularTools(), []);
+  const schemaData = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: "MyDebugger",
+    url: "https://mydebugger.vercel.app/",
+    potentialAction: {
+      "@type": "SearchAction",
+      target: "https://mydebugger.vercel.app/?search={search_term_string}",
+      "query-input": "required name=search_term_string"
+    }
+  };
   const observerRef = useRef<IntersectionObserver | null>(null);
   const toolsContainerRef = useRef<HTMLDivElement>(null);
   
@@ -195,8 +206,13 @@ const Home: React.FC = () => {
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:title" content="MyDebugger - Web Developer Tools" />
         <meta name="twitter:description" content="Essential developer toolkit for modern web development" />
+        <meta name="robots" content="index,follow" />
+        <script type="application/ld+json">{JSON.stringify(schemaData)}</script>
       </Helmet>
         <ResponsiveContainer maxWidth="7xl" className="py-6 px-4 sm:px-6">
+        <h1 id="hero-heading" className="text-center text-3xl sm:text-4xl font-extrabold gradient-text mb-6">
+          Developer Tools for Hyper SEO
+        </h1>
         <div className="relative max-w-2xl mx-auto mb-8">
           <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
             <svg className="h-5 w-5 text-primary-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
## Summary
- add structured data script for SEO
- add hero heading with Hyper SEO message
- test Home page for hero heading

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685d54c43ee08329a598d4ec0934cfc9