### PR TITLE
Add API simulator integration

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -28,6 +28,7 @@ Every section starts with an import snippet showing the component location so yo
 - [Virtual Name Card](#virtual-name-card)
 - [Web Permission Tester](#web-permission-tester)
 - [Generate Large Image](#generate-large-image)
+- [API Simulator](#api-simulator)
 
 ## Crypto Lab
 
@@ -209,3 +210,11 @@ import GenerateLargeImagePage from '../src/tools/generate-large-image/page';
 
 Generate dummy image files of 1MB, 5MB or 10MB for testing upload limits. Upload any small JPG or PNG (≤1MB) and expand it right in the browser. Access this tool at `/generate-large-image`.
 The interface now features a drag‑and‑drop upload area, a progress bar for generation and improved layout on larger screens.
+
+## API Simulator
+
+```html
+<!-- pages/index.html -->
+```
+
+Simulate API responses entirely in the browser. Encode JSON to Base64, adjust delay and status codes, or enable random error injection. A preset dropdown lets you instantly load common scenarios. The page also generates a ready-to-run cURL command. Access it at `/api-simulator` when deployed to Vercel or served locally.

--- a/pages/api/simulate.js
+++ b/pages/api/simulate.js
@@ -1,0 +1,40 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+export default async function handler(req, res) {
+  const input = req.method === 'GET' ? req.query : req.body;
+  const data = input.data || '';
+  const delayMin = parseInt(input.delay_min, 10) || 0;
+  const delayMax = parseInt(input.delay_max, 10) || delayMin;
+  const forceStatus = input.force_status ? parseInt(input.force_status, 10) : undefined;
+  const simulateError = input.simulate_error === 'true' || input.simulate_error === true;
+
+  let decoded;
+  let error;
+
+  try {
+    const json = Buffer.from(data, 'base64').toString('utf8');
+    decoded = JSON.parse(json);
+  } catch (err) {
+    error = 'Invalid base64 JSON';
+  }
+
+  const delayMs = Math.floor(Math.random() * (delayMax - delayMin + 1)) + delayMin;
+  await new Promise(r => setTimeout(r, delayMs));
+
+  let status = 200;
+  if (simulateError && !forceStatus) {
+    const rand = Math.random();
+    if (rand < 0.2) status = 500;
+    else if (rand < 0.3) status = 400;
+  }
+  if (forceStatus) {
+    status = forceStatus;
+  }
+
+  const body = error || status >= 400
+    ? { delay_ms: delayMs, status_code: status, error: error || 'Simulated server error' }
+    : { delay_ms: delayMs, status_code: status, decoded };
+
+  res.status(status).json(body);
+}

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,0 +1,309 @@
+<!-- © 2025 MyDebugger Contributors – MIT License -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>API Simulator – Encode & Mock Base64 JSON</title>
+  <meta name="description" content="Simulate API responses by encoding JSON into Base64, setting HTTP status, and random delays. Test with cURL or live preview.">
+  <meta name="robots" content="noindex, nofollow">
+  <link rel="icon" href="/favicon.svg">
+  <link rel="canonical" href="https://mydebugger.com/api-simulator">
+  <style>
+    body {font-family: Arial, Helvetica, sans-serif; margin: 20px; line-height: 1.5; color: #222;}
+    label {font-weight: bold; margin-top: 12px; display: block;}
+    textarea, input[type="number"], select {width: 100%; margin-top: 4px; padding: 6px; box-sizing: border-box;}
+    textarea[readonly] {background: #f8f9fa;}
+    fieldset {border: 1px solid #ccc; padding: 12px; margin-top: 16px;}
+    fieldset legend {font-weight: bold;}
+    .grid {display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 12px;}
+    button {margin-top: 8px; padding: 8px 12px; cursor: pointer;}
+    button:disabled {opacity: 0.6; cursor: not-allowed;}
+    .toast {color: #fff; background: #333; padding: 4px 8px; border-radius: 4px; display: none; margin-left: 8px;}
+    .valid {color: #28a745;}
+    .invalid {color: #dc3545;}
+    pre {background: #f3f3f3; padding: 10px; border-radius: 4px; overflow: auto; max-height: 300px;}
+    @media (max-width: 768px) {button, textarea, input, select {width: 100%;}}
+  </style>
+</head>
+<body>
+  <h1>API Simulator</h1>
+  <label for="presetSelector">🧪 Test Case Preset:</label>
+  <select id="presetSelector">
+    <option value="">-- Select a preset --</option>
+  </select>
+  <label for="jsonInput">JSON Input</label>
+  <textarea id="jsonInput" placeholder='{"status":"success","data":{"user":"Jirad"}}'></textarea>
+  <div id="jsonStatus" role="status" aria-live="polite" class="invalid">Invalid JSON</div>
+  <button id="encodeBtn">Encode</button>
+  <label for="base64Output">Base64 Preview</label>
+  <textarea id="base64Output" readonly></textarea>
+  <button id="copyB64">📋 Copy Base64<span id="b64Toast" class="toast" role="status" aria-live="assertive">Copied!</span></button>
+
+  <fieldset>
+    <legend>Request Configuration</legend>
+    <div class="grid">
+      <div>
+        <label for="method">HTTP Method</label>
+        <select id="method">
+          <option value="POST">POST</option>
+          <option value="GET">GET</option>
+        </select>
+      </div>
+      <div>
+        <label for="delayMin">Delay Min (ms)</label>
+        <input type="number" id="delayMin" value="300" min="0">
+      </div>
+      <div>
+        <label for="delayMax">Delay Max (ms)</label>
+        <input type="number" id="delayMax" value="1500" min="0">
+      </div>
+      <div>
+        <label for="forceStatus">Force HTTP Status</label>
+        <input type="number" id="forceStatus" value="200" min="100" max="599">
+      </div>
+      <div>
+        <label><input type="checkbox" id="simulateError"> Enable 20% random 4xx/5xx errors</label>
+      </div>
+    </div>
+  </fieldset>
+  <button id="simulateBtn">🔄 Simulate Now</button>
+
+  <h2>Generated cURL</h2>
+  <pre id="curlCmd"></pre>
+  <button id="copyCurl">📋 Copy cURL<span id="curlToast" class="toast" role="status" aria-live="assertive">Copied!</span></button>
+
+  <h2>Response</h2>
+  <pre id="response" aria-live="polite"></pre>
+
+  <script>
+    const presetSelector = document.getElementById('presetSelector');
+    const jsonInput = document.getElementById('jsonInput');
+    const base64Output = document.getElementById('base64Output');
+    const methodEl = document.getElementById('method');
+    const delayMinEl = document.getElementById('delayMin');
+    const delayMaxEl = document.getElementById('delayMax');
+    const forceStatusEl = document.getElementById('forceStatus');
+    const simulateErrorEl = document.getElementById('simulateError');
+    const curlCmdEl = document.getElementById('curlCmd');
+    const responseEl = document.getElementById('response');
+    const jsonStatus = document.getElementById('jsonStatus');
+    const b64Toast = document.getElementById('b64Toast');
+    const curlToast = document.getElementById('curlToast');
+    const simulateBtn = document.getElementById('simulateBtn');
+    let jsonValid = false;
+
+    const presets = [
+      {
+        id: 'ok_basic',
+        label: '✅ 200 OK – Basic success',
+        json: '{"status":"ok","message":"Success"}',
+        method: 'POST',
+        delay_min: 300,
+        delay_max: 800,
+        force_status: 200,
+        simulate_error: false
+      },
+      {
+        id: 'unauthorized_401',
+        label: '🧑‍💻 401 Unauthorized',
+        json: '{"error":"Unauthorized","code":401}',
+        method: 'GET',
+        delay_min: 100,
+        delay_max: 300,
+        force_status: 401,
+        simulate_error: false
+      },
+      {
+        id: 'server_500',
+        label: '💥 500 Internal Server Error',
+        json: '{"error":"Internal Server Error","trace_id":"XYZ123"}',
+        method: 'POST',
+        delay_min: 1000,
+        delay_max: 2000,
+        force_status: 500,
+        simulate_error: false
+      },
+      {
+        id: 'delayed_user_data',
+        label: '⏳ Delayed 200 with user data',
+        json: '{"status":"success","data":{"user":{"id":1,"name":"Jirad"}}}',
+        method: 'POST',
+        delay_min: 2000,
+        delay_max: 3000,
+        force_status: 200,
+        simulate_error: false
+      },
+      {
+        id: 'random_error_sim',
+        label: '🎲 Randomized Error Sim',
+        json: '{"status":"maybe","note":"Simulate random 4xx/5xx ~20%"}',
+        method: 'POST',
+        delay_min: 500,
+        delay_max: 1500,
+        force_status: 200,
+        simulate_error: true
+      },
+      {
+        id: 'not_found_404',
+        label: '📭 404 Not Found',
+        json: '{"error":"Resource not found","status":404}',
+        method: 'GET',
+        delay_min: 300,
+        delay_max: 700,
+        force_status: 404,
+        simulate_error: false
+      },
+      {
+        id: 'slow_auth_timeout',
+        label: '🐢 Slow Timeout-like (200)',
+        json: '{"status":"auth_ok","load":"complete","duration_ms":4200}',
+        method: 'POST',
+        delay_min: 4000,
+        delay_max: 5000,
+        force_status: 200,
+        simulate_error: false
+      },
+      {
+        id: 'retry_later_503',
+        label: '📴 503 Retry Later',
+        json: '{"error":"Service Unavailable","retry_after":60}',
+        method: 'POST',
+        delay_min: 300,
+        delay_max: 500,
+        force_status: 503,
+        simulate_error: false
+      },
+      {
+        id: 'forbidden_403',
+        label: '🚫 403 Forbidden',
+        json: '{"error":"Forbidden access","reason":"no-permission"}',
+        method: 'GET',
+        delay_min: 200,
+        delay_max: 400,
+        force_status: 403,
+        simulate_error: false
+      }
+    ];
+
+    presets.forEach(p => {
+      const option = document.createElement('option');
+      option.value = p.id;
+      option.textContent = p.label;
+      presetSelector.appendChild(option);
+    });
+
+    function showToast(el) {
+      el.style.display = 'inline-block';
+      setTimeout(() => { el.style.display = 'none'; }, 2000);
+    }
+
+    function validateJson() {
+      try {
+        JSON.parse(jsonInput.value);
+        jsonStatus.textContent = '✅ Valid JSON';
+        jsonStatus.className = 'valid';
+        jsonValid = true;
+      } catch {
+        jsonStatus.textContent = '❌ Invalid JSON';
+        jsonStatus.className = 'invalid';
+        jsonValid = false;
+      }
+    }
+    validateJson();
+    jsonInput.addEventListener('input', validateJson);
+
+    function encodeBase64() {
+      if (!jsonValid) {
+        alert('Invalid JSON');
+        return;
+      }
+      base64Output.value = btoa(jsonInput.value);
+      updateCurl();
+    }
+
+    function updateCurl() {
+      const data = base64Output.value;
+      const params = new URLSearchParams({
+        data,
+        delay_min: delayMinEl.value,
+        delay_max: delayMaxEl.value,
+        force_status: forceStatusEl.value,
+        simulate_error: simulateErrorEl.checked
+      });
+      const url = methodEl.value === 'GET'
+        ? `/api/simulate?${params.toString()}`
+        : '/api/simulate';
+      const curl = methodEl.value === 'GET'
+        ? `curl \"${url}\"`
+        : `curl -X POST -H 'Content-Type: application/json' -d '${JSON.stringify({
+            data,
+            delay_min: Number(delayMinEl.value),
+            delay_max: Number(delayMaxEl.value),
+            force_status: forceStatusEl.value ? Number(forceStatusEl.value) : undefined,
+            simulate_error: simulateErrorEl.checked
+          })}' \"${url}\"`;
+      curlCmdEl.textContent = curl;
+    }
+
+    document.getElementById('encodeBtn').addEventListener('click', encodeBase64);
+
+    document.getElementById('copyB64').addEventListener('click', () => {
+      navigator.clipboard.writeText(base64Output.value);
+      showToast(b64Toast);
+    });
+
+    presetSelector.addEventListener('change', () => {
+      const selectedId = presetSelector.value;
+      const preset = presets.find(p => p.id === selectedId);
+      if (!preset) return;
+      jsonInput.value = preset.json;
+      methodEl.value = preset.method;
+      delayMinEl.value = preset.delay_min;
+      delayMaxEl.value = preset.delay_max;
+      forceStatusEl.value = preset.force_status;
+      simulateErrorEl.checked = preset.simulate_error;
+      validateJson();
+      encodeBase64();
+    });
+
+    ['change', 'input'].forEach(evt => {
+      methodEl.addEventListener(evt, updateCurl);
+      delayMinEl.addEventListener(evt, updateCurl);
+      delayMaxEl.addEventListener(evt, updateCurl);
+      forceStatusEl.addEventListener(evt, updateCurl);
+      simulateErrorEl.addEventListener(evt, updateCurl);
+      base64Output.addEventListener(evt, updateCurl);
+    });
+
+    document.getElementById('simulateBtn').addEventListener('click', async () => {
+      updateCurl();
+      simulateBtn.disabled = true;
+      const original = simulateBtn.textContent;
+      simulateBtn.textContent = '⏳ Sending request...';
+      const url = methodEl.value === 'GET' ? curlCmdEl.textContent.match(/"(.*)"$/)[1] : '/api/simulate';
+      const opts = methodEl.value === 'GET' ? {} : {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          data: base64Output.value,
+          delay_min: Number(delayMinEl.value),
+          delay_max: Number(delayMaxEl.value),
+          force_status: forceStatusEl.value ? Number(forceStatusEl.value) : undefined,
+          simulate_error: simulateErrorEl.checked
+        })
+      };
+      const res = await fetch(url, opts);
+      const data = await res.json();
+      responseEl.textContent = JSON.stringify(data, null, 2);
+      simulateBtn.textContent = original;
+      simulateBtn.disabled = false;
+    });
+
+    document.getElementById('copyCurl').addEventListener('click', () => {
+      navigator.clipboard.writeText(curlCmdEl.textContent);
+      showToast(curlToast);
+    });
+  </script>
+</body>
+</html>

--- a/src/tools/api-simulator/index.ts
+++ b/src/tools/api-simulator/index.ts
@@ -1,0 +1,4 @@
+import ApiSimulatorPage from './page';
+
+export { ApiSimulatorPage };
+export default ApiSimulatorPage;

--- a/src/tools/api-simulator/page.tsx
+++ b/src/tools/api-simulator/page.tsx
@@ -1,0 +1,21 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import { getToolByRoute } from '../index';
+import { ToolLayout } from '../../design-system/components/layout';
+
+const ApiSimulatorPage: React.FC = () => {
+  const tool = getToolByRoute('/api-simulator');
+  return (
+    <ToolLayout tool={tool!} title="API Simulator" description="Encode JSON, simulate delays and statuses." showRelatedTools>
+      <iframe
+        src="/api-simulator"
+        title="API Simulator"
+        className="w-full h-[80vh] border border-gray-200 rounded-lg"
+      />
+    </ToolLayout>
+  );
+};
+
+export default ApiSimulatorPage;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -554,6 +554,20 @@ const toolRegistry: Tool[] = [
     },
     uiOptions: { showExamples: false }
   },
+  {
+    id: 'api-simulator',
+    route: '/api-simulator',
+    title: 'API Simulator',
+    description: 'Encode JSON to Base64 and test API responses.',
+    icon: TestingIcon,
+    component: lazy(() => import('./api-simulator/page')),
+    category: 'Testing',
+    metadata: {
+      keywords: ['api', 'testing', 'mock', 'delay', 'status'],
+      relatedTools: ['headers-analyzer', 'cors-tester']
+    },
+    uiOptions: { showExamples: false }
+  },
 ];
 
 export default toolRegistry;

--- a/vercel-build.js
+++ b/vercel-build.js
@@ -1,7 +1,7 @@
 // Simple build script for Vercel (ESM)
 import { execSync } from 'child_process';
-import path from 'path';
 import fs from 'fs';
+import path from 'path';
 
 console.log('Starting Vercel build process...');
 console.log(`Node version: ${process.version}`);
@@ -15,7 +15,15 @@ try {
   // Run the build
   console.log('Running build command...');
   execSync('npx vite build', { stdio: 'inherit' });
-  
+
+  // Copy static pages directory for API simulator
+  const srcPages = path.join('.', 'pages');
+  const destPages = path.join('.', 'dist', 'pages');
+  if (fs.existsSync(srcPages)) {
+    fs.cpSync(srcPages, destPages, { recursive: true });
+    console.log('Copied pages directory to dist');
+  }
+
   console.log('Build completed successfully');
 } catch (error) {
   console.error('Build failed:', error);

--- a/vercel.json
+++ b/vercel.json
@@ -7,8 +7,10 @@
   "devCommand": "npm run dev",
   "outputDirectory": "dist",
   "rewrites": [
+    { "source": "/api/simulate", "destination": "/pages/api/simulate.js" },
     { "source": "/api/(.*)", "destination": "/api/$1" },
     { "source": "/assets/(.*)", "destination": "/assets/$1" },
+    { "source": "/api-simulator", "destination": "/pages/index.html" },
     { "source": "/(.+\\.(?:js|css|ico|json|png|jpg|jpeg|svg|webp))", "destination": "/$1" },
     { "source": "/(.*)", "destination": "/index.html" }
   ],
@@ -17,36 +19,21 @@
     {
       "source": "/(assets|_next|static)/(.*)\\.(js)",
       "headers": [
-        {
-          "key": "Content-Type",
-          "value": "application/javascript; charset=utf-8"
-        },
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=31536000, immutable"
-        }
+        { "key": "Content-Type", "value": "application/javascript; charset=utf-8" },
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
       ]
     },
     {
       "source": "/assets/(.*)\\.(js)",
       "headers": [
-        {
-          "key": "Content-Type",
-          "value": "application/javascript; charset=utf-8"
-        },
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=31536000, immutable"
-        }
+        { "key": "Content-Type", "value": "application/javascript; charset=utf-8" },
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
       ]
     },
     {
       "source": "/assets/(.*)",
       "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=31536000, immutable"
-        }
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- include API simulator static page in build output
- map /api-simulator to new static tool and expose API endpoint
- register API simulator in tool registry with iframe wrapper
- document updated route in tools guide

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `pnpm typecheck` *(fails: node_modules missing)*
- `pnpm test -- --coverage` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_685d99d4114883298cabc39a1dd17cb9