### PR TITLE
Add Image Compressor tool

### DIFF
--- a/__tests__/imageCompressor.test.ts
+++ b/__tests__/imageCompressor.test.ts
@@ -1,0 +1,7 @@
+import { reduceColorDepth } from '../model/imageCompressor';
+
+test('reduceColorDepth quantizes pixel data', () => {
+  const data = new Uint8ClampedArray([10, 20, 30, 255, 250, 240, 230, 255]);
+  reduceColorDepth(data, 4); // 4 bits -> 16 levels
+  expect(Array.from(data)).toEqual([0, 16, 16, 255, 240, 240, 224, 255]);
+});

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -28,6 +28,7 @@ Every section starts with an import snippet showing the component location so yo
 - [Virtual Name Card](#virtual-name-card)
 - [Web Permission Tester](#web-permission-tester)
 - [Generate Large Image](#generate-large-image)
+- [Image Compressor](#image-compressor)
 
 ## Crypto Lab
 
@@ -209,3 +210,13 @@ import GenerateLargeImagePage from '../src/tools/generate-large-image/page';
 
 Generate dummy image files of 1MB, 5MB or 10MB for testing upload limits. Upload any small JPG or PNG (≤1MB) and expand it right in the browser. Access this tool at `/generate-large-image`.
 The interface now features a drag‑and‑drop upload area, a progress bar for generation and improved layout on larger screens.
+
+## Image Compressor
+
+```tsx
+import ImageCompressorPage from '../src/tools/image-compressor/page';
+```
+
+Compress JPG or PNG files entirely in the browser. Choose a target file size in kilobytes,
+resize the resolution or reduce color depth before downloading the optimized image.
+The tool also reveals the Base64 representation of the compressed output. Access it at `/image-compressor`.

--- a/model/imageCompressor.ts
+++ b/model/imageCompressor.ts
@@ -1,0 +1,110 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+export interface CompressOptions {
+  scale?: number; // scale factor 1.0 = original
+  colorDepth?: number; // bits per channel
+  targetSizeKB?: number; // desired max size in KB
+  mimeType?: 'image/jpeg' | 'image/png';
+}
+
+export interface ImageInfo {
+  width: number;
+  height: number;
+  sizeKB: number;
+}
+
+export interface CompressedResult {
+  blob: Blob;
+  base64: string;
+  info: ImageInfo;
+}
+
+/* eslint-disable no-param-reassign */
+export const reduceColorDepth = (data: Uint8ClampedArray, bits: number): void => {
+  const levels = 2 ** bits;
+  const step = 256 / levels;
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = Math.floor(data[i] / step) * step;
+    data[i + 1] = Math.floor(data[i + 1] / step) * step;
+    data[i + 2] = Math.floor(data[i + 2] / step) * step;
+  }
+};
+/* eslint-enable no-param-reassign */
+
+const blobToBase64 = (blob: Blob): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
+
+const loadImage = (file: File | Blob): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(img);
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('Failed to load image'));
+    };
+    img.src = url;
+  });
+
+const canvasToBlob = (
+  canvas: HTMLCanvasElement,
+  type: string,
+  quality: number,
+): Promise<Blob> =>
+  new Promise((resolve) => {
+    canvas.toBlob((b) => resolve(b as Blob), type, quality);
+  });
+
+export const compressImage = async (
+  file: File,
+  opts: CompressOptions = {},
+): Promise<CompressedResult> => {
+  const {
+    scale = 1,
+    colorDepth = 8,
+    targetSizeKB = 50,
+    mimeType = 'image/jpeg',
+  } = opts;
+
+  const img = await loadImage(file);
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.round(img.width * scale);
+  canvas.height = Math.round(img.height * scale);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas not supported');
+  ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+  const imgData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  reduceColorDepth(imgData.data, colorDepth);
+  ctx.putImageData(imgData, 0, 0);
+
+  let quality = 0.92;
+  let blob = await canvasToBlob(canvas, mimeType, quality);
+  /* eslint-disable no-await-in-loop */
+  while (blob.size > targetSizeKB * 1024 && quality > 0.1) {
+    quality -= 0.05;
+    blob = await canvasToBlob(canvas, mimeType, quality);
+  }
+  /* eslint-enable no-await-in-loop */
+  const base64 = await blobToBase64(blob);
+  return {
+    blob,
+    base64,
+    info: {
+      width: canvas.width,
+      height: canvas.height,
+      sizeKB: Math.round(blob.size / 1024),
+    },
+  };
+};
+
+export default compressImage;

--- a/src/design-system/icons/tool-icons.tsx
+++ b/src/design-system/icons/tool-icons.tsx
@@ -129,3 +129,21 @@ export const ContactCardIcon: React.FC<IconProps> = ({ className }) => (
   </svg>
 );
 
+export const ImageCompressIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M4 16l4-4 4 4m8-8l-4 4-4-4"
+    />
+    <rect width="16" height="12" x="4" y="6" rx="2" ry="2" />
+  </svg>
+);
+

--- a/src/tools/image-compressor/index.ts
+++ b/src/tools/image-compressor/index.ts
@@ -1,0 +1,4 @@
+import ImageCompressorPage from './page';
+
+export { ImageCompressorPage };
+export default ImageCompressorPage;

--- a/src/tools/image-compressor/page.tsx
+++ b/src/tools/image-compressor/page.tsx
@@ -1,0 +1,20 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import { getToolByRoute } from '../index';
+import { ToolLayout } from '../../design-system/components/layout';
+import ImageCompressorView from '../../../view/ImageCompressorView';
+import { useImageCompressor } from '../../../viewmodel/useImageCompressor';
+
+const ImageCompressorPage: React.FC = () => {
+  const vm = useImageCompressor();
+  const tool = getToolByRoute('/image-compressor');
+  return (
+    <ToolLayout tool={tool!} title="Image Compressor" description="Compress images entirely in the browser." showRelatedTools>
+      <ImageCompressorView {...vm} />
+    </ToolLayout>
+  );
+};
+
+export default ImageCompressorPage;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -64,6 +64,7 @@ import {
   CacheIcon,
   PushIcon,
   ContactCardIcon,
+  ImageCompressIcon,
 } from "../design-system/icons/tool-icons";
 
 // Category definitions with icons for consistent UI
@@ -551,6 +552,20 @@ const toolRegistry: Tool[] = [
     metadata: {
       keywords: ["image", "upload", "test", "dummy"],
       relatedTools: []
+    },
+    uiOptions: { showExamples: false }
+  },
+  {
+    id: "image-compressor",
+    route: "/image-compressor",
+    title: "Image Compressor",
+    description: "Resize and compress images client-side.",
+    icon: ImageCompressIcon,
+    component: lazy(() => import("./image-compressor/page")),
+    category: "Utilities",
+    metadata: {
+      keywords: ["image", "compress", "resize", "optimize"],
+      relatedTools: ["generate-large-image"]
     },
     uiOptions: { showExamples: false }
   },

--- a/view/ImageCompressorView.tsx
+++ b/view/ImageCompressorView.tsx
@@ -1,0 +1,152 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React, { ChangeEvent, DragEvent } from 'react';
+import { TOOL_PANEL_CLASS } from '../src/design-system/foundations/layout';
+import { UseImageCompressorReturn } from '../viewmodel/useImageCompressor';
+
+const dropClasses = 'border-2 border-dashed border-gray-300 p-6 rounded-md text-center bg-gray-50 dark:bg-gray-700 hover:border-primary-400 dark:hover:border-primary-500 transition-colors';
+
+function ImageCompressorView({
+  info,
+  targetSize,
+  setTargetSize,
+  scale,
+  setScale,
+  colorDepth,
+  setColorDepth,
+  result,
+  onFile,
+  compress,
+  loading,
+}: UseImageCompressorReturn) {
+  const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) onFile(e.target.files[0]);
+  };
+
+  const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    if (e.dataTransfer.files && e.dataTransfer.files[0]) onFile(e.dataTransfer.files[0]);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="grid md:grid-cols-2 gap-4">
+        <div
+          className={`${TOOL_PANEL_CLASS} space-y-2`}
+          onDrop={handleDrop}
+          onDragOver={(e) => e.preventDefault()}
+        >
+          <label htmlFor="file" className={`block text-sm font-medium ${dropClasses}`}> 
+            Select Image
+            <input
+              id="file"
+              type="file"
+              accept="image/jpeg,image/png"
+              onChange={handleFile}
+              className="mt-2"
+            />
+            <p className="text-xs text-gray-500">Drag & drop or click to select</p>
+          </label>
+          {info && (
+            <div className="text-sm space-y-1">
+              <p>Resolution: {info.width} × {info.height}</p>
+              <p>Size: {info.sizeKB} kB</p>
+            </div>
+          )}
+        </div>
+        <div className={`${TOOL_PANEL_CLASS} space-y-2`}>
+          <label htmlFor="target-size" className="block text-sm font-medium">
+            Target size (kB)
+            <input
+              id="target-size"
+              type="number"
+              min={1}
+              value={targetSize}
+              onChange={(e) => setTargetSize(parseInt(e.target.value, 10))}
+              className="border p-2 rounded-md w-full"
+            />
+          </label>
+          <div className="space-y-1">
+            <p className="font-medium text-sm">Resolution</p>
+            <div className="space-x-2 text-sm">
+              {([1, 0.7, 0.5] as number[]).map((s) => (
+                <label key={s} htmlFor={`scale-${s}`} className="inline-flex items-center space-x-1">
+                  <input
+                    id={`scale-${s}`}
+                    type="radio"
+                    checked={scale === s}
+                    onChange={() => setScale(s)}
+                  />
+                  <span>x{s}</span>
+                </label>
+              ))}
+              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+              <label className="inline-flex items-center space-x-1">
+                <input
+                  type="radio"
+                  checked={![1,0.7,0.5].includes(scale)}
+                  onChange={() => {}}
+                />
+                <span className="sr-only">Custom scale</span>
+                <input
+                  type="number"
+                  value={scale}
+                  step={0.1}
+                  min={0.1}
+                  onChange={(e) => setScale(parseFloat(e.target.value))}
+                  className="border p-1 w-16"
+                />
+              </label>
+            </div>
+          </div>
+          <label htmlFor="color" className="block text-sm font-medium">
+            Color depth (bits per channel)
+            <select
+              id="color"
+              value={colorDepth}
+              onChange={(e) => setColorDepth(parseInt(e.target.value, 10))}
+              className="border p-2 rounded-md w-full"
+            >
+              <option value={8}>8</option>
+              <option value={6}>6</option>
+              <option value={4}>4</option>
+            </select>
+          </label>
+          <button
+            className="px-4 py-2 bg-primary-600 text-white rounded-md"
+            type="button"
+            onClick={compress}
+            disabled={loading}
+          >
+            {loading ? 'Compressing...' : 'Compress'}
+          </button>
+          {result && (
+            <div className="text-sm space-y-1">
+              <p>New size: {result.info.sizeKB} kB</p>
+              <p>Resolution: {result.info.width} × {result.info.height}</p>
+              <a
+                href={URL.createObjectURL(result.blob)}
+                download="compressed.jpg"
+                className="underline text-primary-600"
+              >
+                Download image
+              </a>
+              <details className="mt-2">
+                <summary className="cursor-pointer">Base64</summary>
+                <textarea
+                  readOnly
+                  className="w-full mt-1 p-1 border rounded text-xs"
+                  rows={4}
+                  value={result.base64}
+                />
+              </details>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ImageCompressorView;

--- a/viewmodel/useImageCompressor.ts
+++ b/viewmodel/useImageCompressor.ts
@@ -1,0 +1,57 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { useState } from 'react';
+import compressImageFn, {
+  CompressOptions,
+  CompressedResult,
+  ImageInfo,
+} from '../model/imageCompressor';
+
+export const useImageCompressor = () => {
+  const [file, setFile] = useState<File | null>(null);
+  const [info, setInfo] = useState<ImageInfo | null>(null);
+  const [targetSize, setTargetSize] = useState(50);
+  const [scale, setScale] = useState(1);
+  const [colorDepth, setColorDepth] = useState(8);
+  const [result, setResult] = useState<CompressedResult | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const onFile = (f: File) => {
+    setFile(f);
+    setResult(null);
+    const url = URL.createObjectURL(f);
+    const img = new Image();
+    img.onload = () => {
+      setInfo({ width: img.width, height: img.height, sizeKB: Math.round(f.size / 1024) });
+      URL.revokeObjectURL(url);
+    };
+    img.src = url;
+  };
+
+  const compress = async () => {
+    if (!file) return;
+    setLoading(true);
+    const opts: CompressOptions = { targetSizeKB: targetSize, scale, colorDepth };
+    const res = await compressImageFn(file, opts);
+    setResult(res);
+    setLoading(false);
+  };
+
+  return {
+    file,
+    info,
+    targetSize,
+    setTargetSize,
+    scale,
+    setScale,
+    colorDepth,
+    setColorDepth,
+    result,
+    onFile,
+    compress,
+    loading,
+  };
+};
+
+export type UseImageCompressorReturn = ReturnType<typeof useImageCompressor>;


### PR DESCRIPTION
## Summary
- implement client-side image compression logic
- add ImageCompressor page, view and hook
- expose ImageCompressIcon and register new tool
- document Image Compressor in tools guide
- test color depth reduction utility

## Checklist
- [x] Model `/model/imageCompressor.ts`
- [x] ViewModel `/viewmodel/useImageCompressor.ts`
- [x] View `/view/ImageCompressorView.tsx`
- [x] Route `/tools/image-compressor/page.tsx`
- [x] Tests `/__tests__/imageCompressor.test.ts`
- [x] Docs `/docs/tools.md`


------
https://chatgpt.com/codex/tasks/task_e_685e6259af188329b7bc34f6ed77b32a