### PR TITLE
Add Network Test Suite tool

### DIFF
--- a/__tests__/networkSuite.test.ts
+++ b/__tests__/networkSuite.test.ts
@@ -1,0 +1,50 @@
+import { getTechTier, average, pingSamples, measureDownloadSpeed } from '../model/networkSuite';
+
+describe('getTechTier', () => {
+  it('maps tiers correctly', () => {
+    expect(getTechTier({ effectiveType: '3g' })).toBe('3G');
+    expect(getTechTier({ effectiveType: '4g', downlink: 10 })).toBe('4G');
+    expect(getTechTier({ effectiveType: '4g', downlink: 60 })).toBe('≈5G');
+  });
+});
+
+describe('average', () => {
+  it('computes average', () => {
+    expect(average([1, 2, 3])).toBeCloseTo(2);
+  });
+});
+
+describe('pingSamples', () => {
+  it('returns times for samples', async () => {
+    (global.fetch as any) = jest.fn().mockResolvedValue({});
+    let now = 0;
+    jest.spyOn(performance, 'now').mockImplementation(() => {
+      now += 5;
+      return now;
+    });
+    const res = await pingSamples('https://a.com', 3);
+    expect(res).toHaveLength(2);
+    expect((global.fetch as any)).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('measureDownloadSpeed', () => {
+  it('calculates mbps', async () => {
+    const chunk = new Uint8Array(1024);
+    (global.fetch as any) = jest.fn().mockResolvedValue({
+      body: {
+        getReader() {
+          let done = false;
+          return {
+            read: () => Promise.resolve(done ? { done: true } : ((done = true), { value: chunk, done: false })),
+            cancel: jest.fn(),
+          };
+        },
+      },
+    });
+    const times = [0, 1000];
+    jest.spyOn(performance, 'now').mockImplementation(() => times.shift() ?? 1000);
+    const mbps = await measureDownloadSpeed('https://a.com', 1024);
+    expect(mbps).toBeCloseTo((1024 * 8) / 1_000_000);
+  });
+});

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -28,6 +28,7 @@ Every section starts with an import snippet showing the component location so yo
 - [Virtual Name Card](#virtual-name-card)
 - [Web Permission Tester](#web-permission-tester)
 - [Generate Large Image](#generate-large-image)
+- [Network Test Suite](#network-test-suite)
 
 ## Crypto Lab
 
@@ -209,3 +210,12 @@ import GenerateLargeImagePage from '../src/tools/generate-large-image/page';
 
 Generate dummy image files of 1MB, 5MB or 10MB for testing upload limits. Upload any small JPG or PNG (≤1MB) and expand it right in the browser. Access this tool at `/generate-large-image`.
 The interface now features a drag‑and‑drop upload area, a progress bar for generation and improved layout on larger screens.
+
+## Network Test Suite
+
+```tsx
+import NetworkSuitePage from '../src/tools/networksuit/page';
+```
+
+Run quick network diagnostics entirely in the browser. It detects your connection type and technology tier, measures round-trip ping latency and estimates download throughput using a small test file. Access this tool at `/networksuit`.
+The UI integrates card components with progress bars and badges for a streamlined experience.

--- a/model/networkSuite.ts
+++ b/model/networkSuite.ts
@@ -1,0 +1,92 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+export interface ConnectionInfo {
+  type: 'wifi' | 'cellular' | 'unknown';
+  effectiveType?: string;
+  downlink?: number;
+}
+
+interface NetworkConnection {
+  type?: string;
+  effectiveType?: string;
+  downlink?: number;
+  addEventListener?(type: string, listener: EventListener): void;
+  removeEventListener?(type: string, listener: EventListener): void;
+}
+
+export const getConnectionInfo = (): ConnectionInfo => {
+  const nav = navigator as unknown as { connection?: NetworkConnection };
+  const conn = nav.connection;
+  if (!conn) return { type: 'unknown' };
+  let base: 'wifi' | 'cellular' | 'unknown' = 'unknown';
+  if (conn.type === 'wifi') base = 'wifi';
+  else if (conn.type === 'cellular') base = 'cellular';
+  else if (typeof conn.effectiveType === 'string' && conn.effectiveType.includes('g')) {
+    base = 'cellular';
+  }
+  return {
+    type: base,
+    effectiveType: conn.effectiveType,
+    downlink: conn.downlink,
+  };
+};
+
+export const getTechTier = (info: { effectiveType?: string; downlink?: number }): '3G' | '4G' | '≈5G' => {
+  if (!info.effectiveType) return '3G';
+  if (info.effectiveType === '2g' || info.effectiveType === '3g') return '3G';
+  if (info.downlink !== undefined && info.effectiveType === '4g' && info.downlink >= 50) return '≈5G';
+  return '4G';
+};
+
+export const average = (vals: number[]): number =>
+  vals.reduce((a, b) => a + b, 0) / (vals.length || 1);
+
+export const pingSamples = async (
+  url: string,
+  samples = 5,
+  fetchFn: typeof fetch = fetch
+): Promise<number[]> => {
+  const results: number[] = [];
+  // sequential awaits are intentional
+  // eslint-disable-next-line no-await-in-loop
+  for (let i = 0; i < samples; i += 1) {
+    const start = performance.now();
+    // eslint-disable-next-line no-await-in-loop
+    await fetchFn(url, { mode: 'no-cors', cache: 'no-store' });
+    const dt = performance.now() - start;
+    if (i > 0) results.push(dt);
+  }
+  return results;
+};
+
+export const measureDownloadSpeed = async (
+  url: string,
+  cap = 10 * 1024 * 1024,
+  onProgress?: (bytes: number) => void,
+  fetchFn: typeof fetch = fetch
+): Promise<number> => {
+  const start = performance.now();
+  const res = await fetchFn(url, { cache: 'no-store' });
+  if (!res.body) throw new Error('stream unsupported');
+  const reader = res.body.getReader();
+  let loaded = 0;
+  // eslint-disable-next-line no-constant-condition
+  for (;;) {
+    // eslint-disable-next-line no-await-in-loop
+    const { value, done } = await reader.read();
+    if (done || !value) break;
+    loaded += value.length;
+    if (onProgress) onProgress(loaded);
+    if (loaded >= cap) {
+      try {
+        reader.cancel();
+      } catch {
+        // ignore
+      }
+      break;
+    }
+  }
+  const seconds = (performance.now() - start) / 1000;
+  return (loaded * 8) / (seconds * 1_000_000);
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -554,6 +554,20 @@ const toolRegistry: Tool[] = [
     },
     uiOptions: { showExamples: false }
   },
+  {
+    id: 'network-suit',
+    route: '/networksuit',
+    title: 'Network Test Suite',
+    description: 'Check connection type, ping and download speed.',
+    icon: TestingIcon,
+    component: lazy(() => import('./networksuit/page')),
+    category: 'Testing',
+    metadata: {
+      keywords: ['network', 'ping', 'speed', 'connection'],
+      relatedTools: []
+    },
+    uiOptions: { showExamples: false }
+  },
 ];
 
 export default toolRegistry;

--- a/src/tools/networksuit/index.ts
+++ b/src/tools/networksuit/index.ts
@@ -1,0 +1,5 @@
+// Auto-generated index file
+import NetworkSuitePage from './page';
+
+export { NetworkSuitePage };
+export default NetworkSuitePage;

--- a/src/tools/networksuit/page.tsx
+++ b/src/tools/networksuit/page.tsx
@@ -1,0 +1,20 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import useNetworkSuite from '../../../viewmodel/useNetworkSuite';
+import NetworkSuiteView from '../../../view/NetworkSuiteView';
+import { getToolByRoute } from '../index';
+import { ToolLayout } from '../../design-system/components/layout';
+
+const NetworkSuitePage: React.FC = () => {
+  const vm = useNetworkSuite();
+  const tool = getToolByRoute('/networksuit');
+  return (
+    <ToolLayout tool={tool!}>
+      <NetworkSuiteView {...vm} />
+    </ToolLayout>
+  );
+};
+
+export default NetworkSuitePage;

--- a/view/NetworkSuiteView.tsx
+++ b/view/NetworkSuiteView.tsx
@@ -1,0 +1,119 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import { Button, TextInput } from '../src/design-system/components/inputs';
+import { ProgressBar } from '../src/design-system/components/feedback';
+import { InfoBox, Badge } from '../src/design-system/components/display';
+// eslint-disable-next-line import/no-named-as-default
+import Card from '../src/design-system/components/layout/Card';
+import { UseNetworkSuiteReturn } from '../viewmodel/useNetworkSuite';
+
+export function NetworkSuiteView({
+  connection,
+  tech,
+  offline,
+  pingUrl,
+  setPingUrl,
+  pingResults,
+  pingRunning,
+  avgPing,
+  startPing,
+  speedUrl,
+  setSpeedUrl,
+  speedProgress,
+  speedMbps,
+  speedRunning,
+  startSpeed,
+}: UseNetworkSuiteReturn) {
+  return (
+    <div className="space-y-6">
+      {offline && (
+        <InfoBox variant="error" title="Offline">
+          Network features are unavailable while offline.
+        </InfoBox>
+      )}
+      <div className="flex justify-center">
+        <Button onClick={() => { startPing(); startSpeed(); }}>
+          Run All Tests
+        </Button>
+      </div>
+      <div className="grid md:grid-cols-2 gap-4">
+        <Card isElevated>
+          <Card.Header title="Connection Info" />
+          <Card.Body className="space-y-2">
+            <div className="flex items-center gap-2">
+              <span className="font-medium">Type:</span>
+              <Badge variant="info" pill>{connection.type}</Badge>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="font-medium">Tech:</span>
+              <Badge variant="primary" pill>{tech}</Badge>
+            </div>
+          </Card.Body>
+        </Card>
+        <Card isElevated>
+          <Card.Header title="Ping" />
+          <Card.Body className="space-y-3">
+            <div className="flex gap-2 items-end">
+              <TextInput
+                label="URL"
+                value={pingUrl}
+                onChange={(e) => setPingUrl(e.target.value)}
+                fullWidth
+              />
+              <Button
+                onClick={startPing}
+                isDisabled={pingRunning}
+                isLoading={pingRunning}
+                size="sm"
+              >
+                Start Ping
+              </Button>
+            </div>
+            {pingRunning && (
+              <ProgressBar value={(pingResults.length / 4) * 100} />
+            )}
+            {pingResults.length > 0 && (
+              <div className="text-sm">
+                <p>Avg: {avgPing.toFixed(0)} ms</p>
+                <ul className="list-decimal list-inside">
+                  {pingResults.map((r) => (
+                    <li key={r.toString()}>{r.toFixed(0)} ms</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </Card.Body>
+        </Card>
+        <Card isElevated>
+          <Card.Header title="Download Speed" />
+          <Card.Body className="space-y-3">
+            <div className="flex gap-2 items-end">
+              <TextInput
+                label="File URL"
+                value={speedUrl}
+                onChange={(e) => setSpeedUrl(e.target.value)}
+                fullWidth
+              />
+              <Button
+                onClick={startSpeed}
+                isDisabled={speedRunning}
+                isLoading={speedRunning}
+                size="sm"
+              >
+                Start Test
+              </Button>
+            </div>
+            {speedRunning && <ProgressBar value={speedProgress} />}
+            {speedMbps !== null && (
+              <p className="text-sm">Speed: {speedMbps.toFixed(2)} Mbps</p>
+            )}
+          </Card.Body>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+export default NetworkSuiteView;

--- a/viewmodel/useNetworkSuite.ts
+++ b/viewmodel/useNetworkSuite.ts
@@ -1,0 +1,93 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { useEffect, useState } from 'react';
+import {
+  getConnectionInfo,
+  getTechTier,
+  pingSamples,
+  average,
+  measureDownloadSpeed,
+  ConnectionInfo,
+} from '../model/networkSuite';
+
+export const useNetworkSuite = () => {
+  const [connection, setConnection] = useState<ConnectionInfo>(getConnectionInfo());
+  const [tech, setTech] = useState(getTechTier(connection));
+  const [offline, setOffline] = useState(!navigator.onLine);
+
+  const [pingUrl, setPingUrl] = useState('https://www.google.com/generate_204');
+  const [pingResults, setPingResults] = useState<number[]>([]);
+  const [pingRunning, setPingRunning] = useState(false);
+
+  const [speedUrl, setSpeedUrl] = useState('https://speed.hetzner.de/10MB.bin');
+  const [speedProgress, setSpeedProgress] = useState(0);
+  const [speedMbps, setSpeedMbps] = useState<number | null>(null);
+  const [speedRunning, setSpeedRunning] = useState(false);
+
+  useEffect(() => {
+    const update = () => {
+      const info = getConnectionInfo();
+      setConnection(info);
+      setTech(getTechTier(info));
+    };
+    update();
+    const nav = navigator as unknown as { connection?: { addEventListener?(t: string, l: EventListener): void; removeEventListener?(t: string, l: EventListener): void } };
+    const conn = nav.connection;
+    if (conn?.addEventListener) conn.addEventListener('change', update);
+    const onOnline = () => setOffline(!navigator.onLine);
+    window.addEventListener('online', onOnline);
+    window.addEventListener('offline', onOnline);
+    return () => {
+      if (conn?.removeEventListener) conn.removeEventListener('change', update);
+      window.removeEventListener('online', onOnline);
+      window.removeEventListener('offline', onOnline);
+    };
+  }, []);
+
+  const startPing = async () => {
+    setPingRunning(true);
+    try {
+      const res = await pingSamples(pingUrl);
+      setPingResults(res);
+    } catch {
+      setPingResults([]);
+    }
+    setPingRunning(false);
+  };
+
+  const startSpeed = async () => {
+    setSpeedRunning(true);
+    setSpeedProgress(0);
+    try {
+      const mbps = await measureDownloadSpeed(speedUrl, 10 * 1024 * 1024, (b) => {
+        setSpeedProgress(Math.min(100, (b / (10 * 1024 * 1024)) * 100));
+      });
+      setSpeedMbps(mbps);
+    } catch {
+      setSpeedMbps(null);
+    }
+    setSpeedRunning(false);
+  };
+
+  return {
+    connection,
+    tech,
+    offline,
+    pingUrl,
+    setPingUrl,
+    pingResults,
+    pingRunning,
+    avgPing: average(pingResults),
+    startPing,
+    speedUrl,
+    setSpeedUrl,
+    speedProgress,
+    speedMbps,
+    speedRunning,
+    startSpeed,
+  };
+};
+
+export type UseNetworkSuiteReturn = ReturnType<typeof useNetworkSuite>;
+export default useNetworkSuite;


### PR DESCRIPTION
## Summary
- implement browser-only network diagnostics with ping and download helpers
- expose `useNetworkSuite` hook and `NetworkSuiteView` UI
- register new route `/networksuit`
- document usage in tools guide
- cover model logic with tests
- improve UI using Card layout and InfoBox
- fix duplicate imports in NetworkSuite view

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685e5fc0645083299184f1ab4b320b27