### PR TITLE
Add Metadata Echo tool

### DIFF
--- a/__tests__/metadata.test.ts
+++ b/__tests__/metadata.test.ts
@@ -53,5 +53,22 @@ describe("getAdvancedMetadata", () => {
     expect(adv.battery?.level).toBe(0.5);
     expect(adv.geo?.latitude).toBe(1);
     expect(adv.gpu).toBe("GPU");
+    expect(adv.errors).toEqual({});
+  });
+
+  it("reports errors when APIs are unavailable", async () => {
+    const adv = await getAdvancedMetadata({
+      navigator: {} as any,
+      screen: {} as any,
+      location: {} as any,
+      document: {} as any,
+      window: {} as any,
+      canvas: { getContext: () => null } as any,
+    });
+    expect(adv.connectionType).toBeUndefined();
+    expect(adv.errors.connection).toBeDefined();
+    expect(adv.errors.battery).toBeDefined();
+    expect(adv.errors.geo).toBeDefined();
+    expect(adv.errors.gpu).toBeDefined();
   });
 });

--- a/__tests__/metadata.test.ts
+++ b/__tests__/metadata.test.ts
@@ -1,0 +1,57 @@
+import { getBasicMetadata, getAdvancedMetadata } from "../model/metadata";
+
+describe("getBasicMetadata", () => {
+  it("returns core fields", () => {
+    const meta = getBasicMetadata({
+      navigator: {
+        userAgent: "UA",
+        platform: "Win32",
+        language: "en-US",
+        languages: ["en-US", "en"],
+        cookieEnabled: true,
+        maxTouchPoints: 1,
+      } as any,
+      screen: { width: 1920, height: 1080 } as any,
+      location: { href: "https://example.com" } as any,
+      document: { referrer: "https://ref.com" } as any,
+      window: { devicePixelRatio: 2 } as any,
+    });
+    expect(meta.userAgent).toBe("UA");
+    expect(meta.platform).toBe("Win32");
+    expect(meta.languages).toEqual(["en-US", "en"]);
+    expect(meta.screenResolution).toBe("1920x1080");
+    expect(meta.devicePixelRatio).toBe(2);
+    expect(meta.referrer).toBe("https://ref.com");
+    expect(meta.pageUrl).toBe("https://example.com");
+  });
+});
+
+describe("getAdvancedMetadata", () => {
+  it("returns advanced details when available", async () => {
+    const nav: any = {
+      connection: { effectiveType: "4g", downlink: 1.4 },
+      getBattery: () => Promise.resolve({ level: 0.5, charging: true }),
+      geolocation: {
+        getCurrentPosition: (cb: any) =>
+          cb({ coords: { latitude: 1, longitude: 2, accuracy: 3 } }),
+      },
+    };
+    const gl = {
+      getExtension: () => null,
+      getParameter: () => "GPU",
+    } as any;
+    const adv = await getAdvancedMetadata({
+      navigator: nav,
+      screen: {} as any,
+      location: {} as any,
+      document: {} as any,
+      window: {} as any,
+      canvas: { getContext: () => gl } as any,
+    });
+    expect(adv.connectionType).toBe("4g");
+    expect(adv.downlink).toBe(1.4);
+    expect(adv.battery?.level).toBe(0.5);
+    expect(adv.geo?.latitude).toBe(1);
+    expect(adv.gpu).toBe("GPU");
+  });
+});

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -229,3 +229,4 @@ import MetadataEchoPage from "../src/tools/metadata-echo/page";
 ```
 
 Display client metadata such as user agent, platform, timezone and screen resolution. Optionally load advanced details like network connection, battery status or geolocation. Access it at `/metadata-echo`.
+Unavailable fields show a short error reason instead of being hidden.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -29,6 +29,7 @@ Every section starts with an import snippet showing the component location so yo
 - [Web Permission Tester](#web-permission-tester)
 - [Generate Large Image](#generate-large-image)
 - [Image Compressor](#image-compressor)
+- [Metadata Echo](#metadata-echo)
 
 ## Crypto Lab
 
@@ -159,10 +160,11 @@ import VirtualCardPage from "../src/tools/virtual-card/page";
 Create a shareable contact card completely in-browser. The tool generates a `.vcf` download, QR code, and URL with base64 encoded data that pre-fills the form when opened.
 It now supports organization, title, website and address fields, renders a preview business card and can download the card as a PNG image. Opening a link with `?data=` switches to view-only mode showing just the card.
 Access this tool at `/vcard`.
+
 ## Pre-rendering & SEO Meta Tester
 
 ```tsx
-import PreRenderingTesterPage from '../src/tools/pre-rendering-tester/page';
+import PreRenderingTesterPage from "../src/tools/pre-rendering-tester/page";
 ```
 
 Analyze how Googlebot, Bingbot, FacebookBot and real browsers render your page metadata. Fetch HTML snapshots, compare title, description and H1 consistency, then export results or raw markup for further debugging.
@@ -170,7 +172,7 @@ Analyze how Googlebot, Bingbot, FacebookBot and real browsers render your page m
 ## Fetch & Render Tool
 
 ```tsx
-import FetchRenderPage from '../src/tools/fetch-render/page';
+import FetchRenderPage from "../src/tools/fetch-render/page";
 ```
 
 Simulate JavaScript rendering in a sandboxed iframe. Set a timeout before capture, inspect console output and export the rendered DOM to clipboard or file for further analysis.
@@ -196,16 +198,15 @@ Quickly encode or decode URL components. Choose between `encodeURIComponent`, `e
 ## PWA Push Tester
 
 ```tsx
-import PushTesterPage from '../src/tools/push-tester/page';
+import PushTesterPage from "../src/tools/push-tester/page";
 ```
 
 Verify browser support for Service Workers and Web Push, create a push subscription with your own VAPID public key and send a test notification via an in-house edge function. Access this tool at `/push-tester`.
 
-
 ## Generate Large Image
 
 ```tsx
-import GenerateLargeImagePage from '../src/tools/generate-large-image/page';
+import GenerateLargeImagePage from "../src/tools/generate-large-image/page";
 ```
 
 Generate dummy image files of 1MB, 5MB or 10MB for testing upload limits. Upload any small JPG or PNG (≤1MB) and expand it right in the browser. Access this tool at `/generate-large-image`.
@@ -214,9 +215,17 @@ The interface now features a drag‑and‑drop upload area, a progress bar for g
 ## Image Compressor
 
 ```tsx
-import ImageCompressorPage from '../src/tools/image-compressor/page';
+import ImageCompressorPage from "../src/tools/image-compressor/page";
 ```
 
 Compress JPG or PNG files entirely in the browser. Choose a target file size in kilobytes,
 resize the resolution or reduce color depth before downloading the optimized image.
 The tool also reveals the Base64 representation of the compressed output. Access it at `/image-compressor`.
+
+## Metadata Echo
+
+```tsx
+import MetadataEchoPage from "../src/tools/metadata-echo/page";
+```
+
+Display client metadata such as user agent, platform, timezone and screen resolution. Optionally load advanced details like network connection, battery status or geolocation. Access it at `/metadata-echo`.

--- a/model/metadata.ts
+++ b/model/metadata.ts
@@ -1,0 +1,140 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ *
+ * Client metadata collection helpers
+ */
+
+export interface BasicMetadata {
+  userAgent: string;
+  platform: string;
+  language: string;
+  languages: string[];
+  screenResolution: string;
+  devicePixelRatio: number;
+  timezoneOffset: number;
+  timezone: string;
+  cookiesEnabled: boolean;
+  touchSupport: boolean;
+  referrer: string;
+  pageUrl: string;
+}
+
+export interface BatteryInfo {
+  level: number;
+  charging: boolean;
+}
+
+export interface GeoInfo {
+  latitude: number;
+  longitude: number;
+  accuracy: number;
+}
+
+export interface AdvancedMetadata {
+  connectionType?: string;
+  downlink?: number;
+  battery?: BatteryInfo;
+  geo?: GeoInfo;
+  gpu?: string;
+}
+
+interface ConnectionLike {
+  effectiveType?: string;
+  downlink?: number;
+}
+
+interface Env {
+  navigator: Navigator & {
+    connection?: ConnectionLike;
+    getBattery?: () => Promise<{ level: number; charging: boolean }>;
+  };
+  screen: Screen;
+  location: Location;
+  document: Document;
+  window: Window;
+  canvas?: HTMLCanvasElement;
+}
+
+const defaultEnv = (): Env => ({
+  navigator,
+  screen: window.screen,
+  location: window.location,
+  document,
+  window,
+});
+
+export const getBasicMetadata = (env: Partial<Env> = {}): BasicMetadata => {
+  const e = { ...defaultEnv(), ...env } as Env;
+  return {
+    userAgent: e.navigator.userAgent,
+    platform: e.navigator.platform,
+    language: e.navigator.language,
+    languages: Array.from(e.navigator.languages),
+    screenResolution: `${e.screen.width}x${e.screen.height}`,
+    devicePixelRatio: e.window.devicePixelRatio,
+    timezoneOffset: new Date().getTimezoneOffset(),
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    cookiesEnabled: e.navigator.cookieEnabled,
+    touchSupport: "ontouchstart" in e.window && e.navigator.maxTouchPoints > 0,
+    referrer: e.document.referrer,
+    pageUrl: e.location.href,
+  };
+};
+
+export const getAdvancedMetadata = async (
+  env: Partial<Env> = {},
+): Promise<AdvancedMetadata> => {
+  const e = { ...defaultEnv(), ...env } as Env;
+  const adv: AdvancedMetadata = {};
+
+  const conn = e.navigator.connection;
+  if (conn) {
+    adv.connectionType = conn.effectiveType;
+    adv.downlink = conn.downlink;
+  }
+
+  if (typeof e.navigator.getBattery === "function") {
+    try {
+      const battery = await e.navigator.getBattery();
+      adv.battery = { level: battery.level, charging: battery.charging };
+    } catch {
+      // ignore
+    }
+  }
+
+  if (e.navigator.geolocation?.getCurrentPosition) {
+    try {
+      const pos = await new Promise<GeolocationPosition>((resolve, reject) => {
+        e.navigator.geolocation.getCurrentPosition(resolve, reject);
+      });
+      adv.geo = {
+        latitude: pos.coords.latitude,
+        longitude: pos.coords.longitude,
+        accuracy: pos.coords.accuracy,
+      };
+    } catch {
+      // user denied
+    }
+  }
+
+  try {
+    const canvas = env.canvas ?? document.createElement("canvas");
+    const gl =
+      (canvas.getContext("webgl") as WebGLRenderingContext | null) ||
+      (canvas.getContext("experimental-webgl") as WebGLRenderingContext | null);
+    if (gl) {
+      const info = gl.getExtension("WEBGL_debug_renderer_info");
+      if (info) {
+        const vendor = gl.getParameter(info.UNMASKED_VENDOR_WEBGL);
+        const renderer = gl.getParameter(info.UNMASKED_RENDERER_WEBGL);
+        adv.gpu = `${vendor} ${renderer}`;
+      } else {
+        adv.gpu = gl.getParameter((gl as WebGLRenderingContext).RENDERER);
+      }
+    }
+  } catch {
+    // ignore
+  }
+
+  return adv;
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -473,71 +473,80 @@ const toolRegistry: Tool[] = [
     uiOptions: { showExamples: false },
   },
   {
-    id: 'pre-rendering-tester',
-    route: '/pre-rendering-tester',
-    title: 'Pre-rendering & SEO Meta Tester',
+    id: "pre-rendering-tester",
+    route: "/pre-rendering-tester",
+    title: "Pre-rendering & SEO Meta Tester",
     description:
-      'Test how Googlebot, Bingbot, Facebook, and real users see your web content — including title, description and H1 rendering.',
+      "Test how Googlebot, Bingbot, Facebook, and real users see your web content — including title, description and H1 rendering.",
     icon: TestingIcon,
-    component: lazy(() => import('./pre-rendering-tester/page')),
-    category: 'Testing',
+    component: lazy(() => import("./pre-rendering-tester/page")),
+    category: "Testing",
     metadata: {
-      keywords: ['seo', 'prerender', 'crawler', 'meta description', 'user-agent'],
-      relatedTools: ['fetch-render'],
+      keywords: [
+        "seo",
+        "prerender",
+        "crawler",
+        "meta description",
+        "user-agent",
+      ],
+      relatedTools: ["fetch-render"],
     },
-    uiOptions: { showExamples: false }
-  },  {
-    id: 'fetch-render',
-    route: '/fetch-render',
-    title: 'Fetch & Render',
-    description: 'Emulate JS rendering and capture DOM.',
-    icon: TestingIcon,
-    component: lazy(() => import('./fetch-render/page')),
-    category: 'Testing',
-    metadata: {
-      keywords: ['seo', 'render', 'javascript', 'dom snapshot'],
-      relatedTools: ['pre-rendering-tester'],
-    },
-    uiOptions: { showExamples: false }
+    uiOptions: { showExamples: false },
   },
   {
-    id: 'permission-tester',
-    route: '/permission-tester',
-    title: 'Web Permission Tester',
-    description: 'Request, inspect, and test browser permissions with live previews and code snippets.',
+    id: "fetch-render",
+    route: "/fetch-render",
+    title: "Fetch & Render",
+    description: "Emulate JS rendering and capture DOM.",
+    icon: TestingIcon,
+    component: lazy(() => import("./fetch-render/page")),
+    category: "Testing",
+    metadata: {
+      keywords: ["seo", "render", "javascript", "dom snapshot"],
+      relatedTools: ["pre-rendering-tester"],
+    },
+    uiOptions: { showExamples: false },
+  },
+  {
+    id: "permission-tester",
+    route: "/permission-tester",
+    title: "Web Permission Tester",
+    description:
+      "Request, inspect, and test browser permissions with live previews and code snippets.",
     icon: SecurityIcon,
-    component: lazy(() => import('./permission-tester/page')),
-    category: 'Testing',
+    component: lazy(() => import("./permission-tester/page")),
+    category: "Testing",
     isNew: true,
     metadata: {
       keywords: [
-        'permissions',
-        'browser permissions',
-        'geolocation',
-        'camera',
-        'microphone',
-        'notifications',
-        'clipboard',
-        'api testing',
-        'web api',
-        'permission state'
+        "permissions",
+        "browser permissions",
+        "geolocation",
+        "camera",
+        "microphone",
+        "notifications",
+        "clipboard",
+        "api testing",
+        "web api",
+        "permission state",
       ],
-      learnMoreUrl: 'https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API',
-      relatedTools: ['headers-analyzer', 'cors-tester'],
+      learnMoreUrl:
+        "https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API",
+      relatedTools: ["headers-analyzer", "cors-tester"],
     },
-    uiOptions: { showExamples: false }
+    uiOptions: { showExamples: false },
   },
   {
-    id: 'push-tester',
-    route: '/push-tester',
-    title: 'PWA Push Tester',
-    description: 'Verify Web Push capability end-to-end.',
+    id: "push-tester",
+    route: "/push-tester",
+    title: "PWA Push Tester",
+    description: "Verify Web Push capability end-to-end.",
     icon: PushIcon,
-    component: lazy(() => import('./push-tester/page')),
-    category: 'Testing',
+    component: lazy(() => import("./push-tester/page")),
+    category: "Testing",
     metadata: {
-      keywords: ['push', 'notification', 'service worker'],
-      relatedTools: ['permission-tester'],
+      keywords: ["push", "notification", "service worker"],
+      relatedTools: ["permission-tester"],
     },
     uiOptions: { showExamples: false },
   },
@@ -551,9 +560,9 @@ const toolRegistry: Tool[] = [
     category: "Testing",
     metadata: {
       keywords: ["image", "upload", "test", "dummy"],
-      relatedTools: []
+      relatedTools: [],
     },
-    uiOptions: { showExamples: false }
+    uiOptions: { showExamples: false },
   },
   {
     id: "image-compressor",
@@ -565,9 +574,23 @@ const toolRegistry: Tool[] = [
     category: "Utilities",
     metadata: {
       keywords: ["image", "compress", "resize", "optimize"],
-      relatedTools: ["generate-large-image"]
+      relatedTools: ["generate-large-image"],
     },
-    uiOptions: { showExamples: false }
+    uiOptions: { showExamples: false },
+  },
+  {
+    id: "metadata-echo",
+    route: "/metadata-echo",
+    title: "Metadata Echo",
+    description: "Display browser metadata for debugging.",
+    icon: UtilitiesIcon,
+    component: lazy(() => import("./metadata-echo/page")),
+    category: "Utilities",
+    metadata: {
+      keywords: ["browser", "metadata", "user agent", "device"],
+      relatedTools: [],
+    },
+    uiOptions: { showExamples: false },
   },
 ];
 
@@ -577,7 +600,7 @@ export default toolRegistry;
 // Returns the list of tools shown on the Home screen
 // JWT Toolkit remains available via direct route but is hidden from listings
 export const getTools = (): Tool[] =>
-  toolRegistry.filter((tool) => tool.id !== 'jwt-toolkit');
+  toolRegistry.filter((tool) => tool.id !== "jwt-toolkit");
 
 // Helper functions to work with the tool registry
 export const getToolByRoute = (route: string): Tool | undefined =>
@@ -602,9 +625,11 @@ export const getRelatedTools = (toolId: string): Tool[] => {
 export const getPopularTools = (): Tool[] =>
   getTools().filter((tool) => tool.isPopular);
 
-export const getNewTools = (): Tool[] => getTools().filter((tool) => tool.isNew);
+export const getNewTools = (): Tool[] =>
+  getTools().filter((tool) => tool.isNew);
 
-export const getBetaTools = (): Tool[] => getTools().filter((tool) => tool.isBeta);
+export const getBetaTools = (): Tool[] =>
+  getTools().filter((tool) => tool.isBeta);
 
 export const getAllTools = (): Tool[] => {
   return toolRegistry;

--- a/src/tools/metadata-echo/index.ts
+++ b/src/tools/metadata-echo/index.ts
@@ -1,0 +1,4 @@
+import MetadataEchoPage from "./page";
+
+export { MetadataEchoPage };
+export default MetadataEchoPage;

--- a/src/tools/metadata-echo/page.tsx
+++ b/src/tools/metadata-echo/page.tsx
@@ -1,0 +1,24 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from "react";
+import { getToolByRoute } from "../index";
+import { ToolLayout } from "../../design-system/components/layout";
+import MetadataEchoView from "../../../view/MetadataEchoView";
+import useMetadataEcho from "../../../viewmodel/useMetadataEcho";
+
+const MetadataEchoPage: React.FC = () => {
+  const vm = useMetadataEcho();
+  const tool = getToolByRoute("/metadata-echo");
+  return (
+    <ToolLayout
+      tool={tool!}
+      title="Metadata Echo"
+      description="Display browser metadata for debugging."
+    >
+      <MetadataEchoView {...vm} />
+    </ToolLayout>
+  );
+};
+
+export default MetadataEchoPage;

--- a/view/MetadataEchoView.tsx
+++ b/view/MetadataEchoView.tsx
@@ -1,0 +1,75 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from "react";
+import type { UseMetadataEchoReturn } from "../viewmodel/useMetadataEcho";
+import { TOOL_PANEL_CLASS } from "../src/design-system/foundations/layout";
+
+const row = (label: string, value: React.ReactNode) => (
+  <tr className="border-t last:border-b">
+    <th className="text-left py-2 pr-4 font-medium text-gray-700 dark:text-gray-300">
+      {label}
+    </th>
+    <td className="py-2 break-all text-gray-900 dark:text-gray-100">{value}</td>
+  </tr>
+);
+
+function MetadataEchoView({
+  basic,
+  advanced,
+  loading,
+  loadAdvanced,
+}: UseMetadataEchoReturn) {
+  if (!basic) return null;
+  return (
+    <div className="space-y-6">
+      <div className={TOOL_PANEL_CLASS}>
+        <h2 className="text-2xl font-bold mb-4">Client Metadata</h2>
+        <table className="w-full text-sm">
+          <tbody>
+            {row("User Agent", basic.userAgent)}
+            {row("Platform", basic.platform)}
+            {row("Language", basic.language)}
+            {row("Languages", basic.languages.join(", "))}
+            {row("Screen Resolution", basic.screenResolution)}
+            {row("Device Pixel Ratio", basic.devicePixelRatio)}
+            {row("Timezone Offset", basic.timezoneOffset)}
+            {row("Timezone", basic.timezone)}
+            {row("Cookies Enabled", String(basic.cookiesEnabled))}
+            {row("Touch Support", String(basic.touchSupport))}
+            {row("Referrer", basic.referrer || "N/A")}
+            {row("Page URL", basic.pageUrl)}
+            {advanced?.connectionType &&
+              row("Connection", advanced.connectionType)}
+            {advanced?.downlink && row("Downlink", `${advanced.downlink} Mbps`)}
+            {advanced?.battery &&
+              row(
+                "Battery",
+                `${Math.round(advanced.battery.level * 100)}% ${advanced.battery.charging ? "charging" : "discharging"}`,
+              )}
+            {advanced?.geo &&
+              row(
+                "Location",
+                `${advanced.geo.latitude.toFixed(4)}, ${advanced.geo.longitude.toFixed(4)} ±${advanced.geo.accuracy}m`,
+              )}
+            {advanced?.gpu && row("GPU", advanced.gpu)}
+          </tbody>
+        </table>
+        {!advanced && (
+          <div className="text-right mt-4">
+            <button
+              type="button"
+              onClick={loadAdvanced}
+              disabled={loading}
+              className="px-3 py-1 rounded-md text-white bg-primary-500 hover:bg-primary-600 disabled:opacity-50"
+            >
+              {loading ? "Loading…" : "Load Advanced Metadata"}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default MetadataEchoView;

--- a/view/MetadataEchoView.tsx
+++ b/view/MetadataEchoView.tsx
@@ -39,20 +39,33 @@ function MetadataEchoView({
             {row("Touch Support", String(basic.touchSupport))}
             {row("Referrer", basic.referrer || "N/A")}
             {row("Page URL", basic.pageUrl)}
-            {advanced?.connectionType &&
-              row("Connection", advanced.connectionType)}
-            {advanced?.downlink && row("Downlink", `${advanced.downlink} Mbps`)}
-            {advanced?.battery &&
+            {advanced &&
+              row(
+                "Connection",
+                advanced.connectionType ?? advanced.errors.connection ?? "N/A",
+              )}
+            {advanced &&
+              row(
+                "Downlink",
+                advanced.downlink !== undefined
+                  ? `${advanced.downlink} Mbps`
+                  : advanced.errors.connection ?? "N/A",
+              )}
+            {advanced &&
               row(
                 "Battery",
-                `${Math.round(advanced.battery.level * 100)}% ${advanced.battery.charging ? "charging" : "discharging"}`,
+                advanced.battery
+                  ? `${Math.round(advanced.battery.level * 100)}% ${advanced.battery.charging ? "charging" : "discharging"}`
+                  : advanced.errors.battery ?? "N/A",
               )}
-            {advanced?.geo &&
+            {advanced &&
               row(
                 "Location",
-                `${advanced.geo.latitude.toFixed(4)}, ${advanced.geo.longitude.toFixed(4)} ±${advanced.geo.accuracy}m`,
+                advanced.geo
+                  ? `${advanced.geo.latitude.toFixed(4)}, ${advanced.geo.longitude.toFixed(4)} ±${advanced.geo.accuracy}m`
+                  : advanced.errors.geo ?? "N/A",
               )}
-            {advanced?.gpu && row("GPU", advanced.gpu)}
+            {advanced && row("GPU", advanced.gpu ?? advanced.errors.gpu ?? "N/A")}
           </tbody>
         </table>
         {!advanced && (

--- a/viewmodel/useMetadataEcho.ts
+++ b/viewmodel/useMetadataEcho.ts
@@ -1,0 +1,38 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { useEffect, useState } from "react";
+import {
+  getBasicMetadata,
+  getAdvancedMetadata,
+  BasicMetadata,
+  AdvancedMetadata,
+} from "../model/metadata";
+
+export interface UseMetadataEchoReturn {
+  basic: BasicMetadata | null;
+  advanced: AdvancedMetadata | null;
+  loading: boolean;
+  loadAdvanced: () => Promise<void>;
+}
+
+const useMetadataEcho = (): UseMetadataEchoReturn => {
+  const [basic, setBasic] = useState<BasicMetadata | null>(null);
+  const [advanced, setAdvanced] = useState<AdvancedMetadata | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setBasic(getBasicMetadata());
+  }, []);
+
+  const loadAdvanced = async () => {
+    setLoading(true);
+    const adv = await getAdvancedMetadata();
+    setAdvanced(adv);
+    setLoading(false);
+  };
+
+  return { basic, advanced, loading, loadAdvanced };
+};
+
+export default useMetadataEcho;


### PR DESCRIPTION
## Summary
- add client metadata model functions
- add Metadata Echo viewmodel and view
- register Metadata Echo tool and document usage
- include tests for metadata utilities

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm audit`

------
https://chatgpt.com/codex/tasks/task_e_685eab33035c8329a0c7fab9ecea67de