### PR TITLE
Add WebSocket simulator tool

### DIFF
--- a/__tests__/websocketSimulator.test.ts
+++ b/__tests__/websocketSimulator.test.ts
@@ -1,0 +1,21 @@
+import { TextDecoder, TextEncoder } from 'util';
+import { parseCurl, textToHex, hexToText } from '../model/websocketSimulator';
+
+// Node <19 lacks TextEncoder/TextDecoder globally
+(global as any).TextEncoder = TextEncoder;
+(global as any).TextDecoder = TextDecoder;
+
+describe('websocket simulator model', () => {
+  it('parses curl command', () => {
+    const res = parseCurl("curl 'wss://a.com' -H 'Origin: https://b.com'");
+    expect(res.url).toBe('wss://a.com');
+    expect(res.origin).toBe('https://b.com');
+  });
+
+  it('converts text to hex and back', () => {
+    const hex = textToHex('hi');
+    expect(hex).toBe('68 69');
+    const text = hexToText(hex);
+    expect(text).toBe('hi');
+  });
+});

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -32,6 +32,7 @@ Every section starts with an import snippet showing the component location so yo
 - [Network Test Suite](#network-test-suite)
 - [Image Compressor](#image-compressor)
 - [Metadata Echo](#metadata-echo)
+- [WebSocket Simulator](#websocket-simulator)
 
 ## Crypto Lab
 
@@ -248,3 +249,14 @@ import MetadataEchoPage from "../src/tools/metadata-echo/page";
 
 Display client metadata such as user agent, platform, timezone and screen resolution. Optionally load advanced details like network connection, battery status or geolocation. Access it at `/metadata-echo`.
 Unavailable fields show a short error reason instead of being hidden.
+
+## WebSocket Simulator
+
+```tsx
+import WebsocketSimulatorPage from "../src/tools/websocket-simulator";
+```
+
+Paste a `curl wss://...` command and emulate NATS-style PUB messages in the browser. 
+Input payloads in text or HEX, queue multiple messages and transmit on a set interval. 
+Sent and received data are logged live and can be exported as a `.txt` file. 
+The last used profile is saved to `localStorage` for convenience.

--- a/model/websocketSimulator.ts
+++ b/model/websocketSimulator.ts
@@ -1,0 +1,40 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+export interface ParsedCurl {
+  url: string;
+  origin: string;
+}
+
+export const parseCurl = (curlText: string): ParsedCurl => {
+  const urlMatch = curlText.match(/curl\s+'(wss?:\/\/[^']+)'/);
+  const originMatch = curlText.match(/-H\s+'Origin:\s+([^']+)'/);
+  return {
+    url: urlMatch?.[1] ?? '',
+    origin: originMatch?.[1] ?? '',
+  };
+};
+
+export const textToHex = (text: string): string =>
+  Array.from(new TextEncoder().encode(text))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join(' ');
+
+export const hexToText = (hex: string): string => {
+  const clean = hex.replace(/\s+/g, '');
+  const bytes = new Uint8Array(
+    clean.match(/.{1,2}/g)?.map((byte) => parseInt(byte, 16)) || []
+  );
+  return new TextDecoder().decode(bytes);
+};
+
+export const exportLogs = (logs: string[]): void => {
+  const blob = new Blob([logs.join('\n')], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `ws_log_${new Date().toISOString()}.txt`;
+  a.click();
+  URL.revokeObjectURL(url);
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -620,6 +620,20 @@ const toolRegistry: Tool[] = [
     },
     uiOptions: { showExamples: false },
   },
+  {
+    id: "websocket-simulator",
+    route: "/websocket-simulator",
+    title: "WebSocket Simulator",
+    description: "Send PUB messages over WebSocket at intervals.",
+    icon: UtilitiesIcon,
+    component: lazy(() => import("./websocket-simulator/page")),
+    category: "Utilities",
+    metadata: {
+      keywords: ["websocket", "nats", "testing", "binary"],
+      relatedTools: [],
+    },
+    uiOptions: { showExamples: false },
+  },
 ];
 
 export default toolRegistry;

--- a/src/tools/websocket-simulator/index.ts
+++ b/src/tools/websocket-simulator/index.ts
@@ -1,0 +1,4 @@
+import WebsocketSimulatorPage from './page';
+
+export { WebsocketSimulatorPage };
+export default WebsocketSimulatorPage;

--- a/src/tools/websocket-simulator/page.tsx
+++ b/src/tools/websocket-simulator/page.tsx
@@ -1,0 +1,13 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import useWebsocketSimulator from '../../../viewmodel/useWebsocketSimulator';
+import WebsocketSimulatorView from '../../../view/WebsocketSimulatorView';
+
+const WebsocketSimulatorPage: React.FC = () => {
+  const vm = useWebsocketSimulator();
+  return <WebsocketSimulatorView {...vm} />;
+};
+
+export default WebsocketSimulatorPage;

--- a/view/WebsocketSimulatorView.tsx
+++ b/view/WebsocketSimulatorView.tsx
@@ -1,0 +1,112 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import { TOOL_PANEL_CLASS } from '../src/design-system/foundations/layout';
+import type useWebsocketSimulator from '../viewmodel/useWebsocketSimulator';
+
+interface Props extends ReturnType<typeof useWebsocketSimulator> {}
+
+export function WebsocketSimulatorView({
+  curl,
+  setCurl,
+  payload,
+  setPayload,
+  payloads,
+  addPayload,
+  removePayload,
+  hexMode,
+  toggleMode,
+  delay,
+  setDelay,
+  logs,
+  connect,
+  start,
+  stop,
+  clearLogs,
+  saveProfile,
+  exportLogFile,
+}: Props) {
+  return (
+    <div className={TOOL_PANEL_CLASS}>
+      <header className="mb-4">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">WebSocket PUB Simulator</h1>
+      </header>
+      <textarea
+        className="w-full border p-2 mb-2 rounded"
+        rows={3}
+        placeholder="curl 'wss://example.com' -H 'Origin: https://site.com'"
+        value={curl}
+        onChange={(e) => setCurl(e.target.value)}
+      />
+      <div className="flex gap-2 mb-2">
+        <button type="button" className="px-3 py-1 bg-primary-500 text-white rounded" onClick={connect}>
+          Connect
+        </button>
+        <button type="button" className="px-3 py-1 bg-primary-500 text-white rounded" onClick={start}>
+          Start
+        </button>
+        <button type="button" className="px-3 py-1 bg-primary-500 text-white rounded" onClick={stop}>
+          Stop
+        </button>
+        <button type="button" className="px-3 py-1 bg-gray-200 rounded" onClick={clearLogs}>
+          Clear Logs
+        </button>
+        <button type="button" className="px-3 py-1 bg-gray-200 rounded" onClick={saveProfile}>
+          Save Profile
+        </button>
+        <button type="button" className="px-3 py-1 bg-gray-200 rounded" onClick={exportLogFile}>
+          Export Logs
+        </button>
+      </div>
+      <div className="flex items-center gap-2 mb-2">
+        <input
+          type="number"
+          className="border p-1 w-24"
+          value={delay}
+          onChange={(e) => setDelay(Number(e.target.value))}
+        />
+        <label htmlFor="hex-toggle" className="flex items-center gap-1">
+          <input
+            id="hex-toggle"
+            type="checkbox"
+            checked={hexMode}
+            onChange={toggleMode}
+          />
+          HEX
+        </label>
+      </div>
+      <textarea
+        className="w-full border p-2 mb-2 rounded"
+        rows={3}
+        value={payload}
+        onChange={(e) => setPayload(e.target.value)}
+      />
+      <button type="button" className="px-3 py-1 bg-primary-500 text-white rounded mb-2" onClick={addPayload}>
+        Add Payload
+      </button>
+      <ul className="mb-4 space-y-1">
+        {payloads.map((p) => (
+          <li key={p} className="flex items-center gap-2 text-sm">
+            <span className="flex-1 break-all">{p}</span>
+            <button type="button" className="text-red-600" onClick={() => removePayload(payloads.indexOf(p))}>
+              remove
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="h-64 overflow-y-auto border p-2 rounded text-sm bg-gray-50 dark:bg-gray-900/20">
+        {logs.map((l) => (
+          <div key={l.time} className="break-all">
+            <span className="mr-2 text-xs text-gray-500">
+              {new Date(l.time).toLocaleTimeString()} {l.direction} ({l.size}b)
+            </span>
+            {l.text}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default WebsocketSimulatorView;

--- a/view/WebsocketSimulatorView.tsx
+++ b/view/WebsocketSimulatorView.tsx
@@ -20,6 +20,7 @@ export function WebsocketSimulatorView({
   delay,
   setDelay,
   logs,
+  error,
   connect,
   start,
   stop,
@@ -32,6 +33,11 @@ export function WebsocketSimulatorView({
       <header className="mb-4">
         <h1 className="text-2xl font-bold text-gray-900 dark:text-white">WebSocket PUB Simulator</h1>
       </header>
+      {error && (
+        <div role="alert" className="mb-2 rounded-md bg-red-50 p-2 text-red-600">
+          {error}
+        </div>
+      )}
       <textarea
         className="w-full border p-2 mb-2 rounded"
         rows={3}

--- a/viewmodel/useWebsocketSimulator.ts
+++ b/viewmodel/useWebsocketSimulator.ts
@@ -1,0 +1,140 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  parseCurl,
+  textToHex,
+  hexToText,
+  exportLogs,
+} from '../model/websocketSimulator';
+
+export interface WsLogEntry {
+  direction: 'send' | 'recv';
+  text: string;
+  size: number;
+  time: number;
+}
+
+const profileKey = 'ws-pub-sim-profile';
+
+const useWebsocketSimulator = () => {
+  const [curl, setCurl] = useState('');
+  const [url, setUrl] = useState('');
+  const [origin, setOrigin] = useState('');
+  const [payload, setPayload] = useState('');
+  const [payloads, setPayloads] = useState<string[]>([]);
+  const [hexMode, setHexMode] = useState(false);
+  const [delay, setDelay] = useState(100);
+  const [logs, setLogs] = useState<WsLogEntry[]>([]);
+  const wsRef = useRef<WebSocket | null>(null);
+  const timerRef = useRef<number>();
+  const indexRef = useRef(0);
+
+  useEffect(() => {
+    const loaded = localStorage.getItem(profileKey);
+    if (loaded) {
+      try {
+        const profile = JSON.parse(loaded);
+        setCurl(profile.curl);
+        const parsed = parseCurl(profile.curl);
+        setUrl(parsed.url);
+        setOrigin(parsed.origin);
+        setPayloads(profile.payloads || []);
+        setDelay(profile.delay || 100);
+      } catch {
+        // ignore
+      }
+    }
+  }, []);
+
+  const connect = useCallback(() => {
+    if (wsRef.current) wsRef.current.close();
+    const parsed = parseCurl(curl);
+    setUrl(parsed.url);
+    setOrigin(parsed.origin);
+    if (!parsed.url) return;
+    const ws = new WebSocket(parsed.url, []);
+    wsRef.current = ws;
+    ws.onmessage = (ev) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        setLogs((l) => [
+          { direction: 'recv', text: reader.result as string, size: (reader.result as string).length, time: Date.now() },
+          ...l,
+        ]);
+      };
+      reader.readAsText(ev.data);
+    };
+    ws.onclose = () => {
+      window.clearInterval(timerRef.current);
+    };
+  }, [curl]);
+
+  const start = useCallback(() => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    window.clearInterval(timerRef.current);
+    timerRef.current = window.setInterval(() => {
+      if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+      const p = payloads[indexRef.current];
+      const bytes = hexMode ? new Uint8Array(p.split(/\s+/).map((b) => parseInt(b, 16))) : new TextEncoder().encode(p);
+      wsRef.current.send(bytes);
+      setLogs((l) => [
+        { direction: 'send', text: p, size: bytes.length, time: Date.now() },
+        ...l,
+      ]);
+      indexRef.current = (indexRef.current + 1) % payloads.length;
+    }, delay);
+  }, [payloads, delay, hexMode]);
+
+  const stop = useCallback(() => {
+    window.clearInterval(timerRef.current);
+  }, []);
+
+  const addPayload = () => {
+    setPayloads((p) => [...p, payload]);
+    setPayload('');
+  };
+  const removePayload = (i: number) => {
+    setPayloads((p) => p.filter((_, idx) => idx !== i));
+  };
+
+  const saveProfile = () => {
+    localStorage.setItem(profileKey, JSON.stringify({ curl, payloads, delay }));
+  };
+
+  const clearLogs = () => setLogs([]);
+
+  const exportLogFile = () => exportLogs(logs.map((l) => `${new Date(l.time).toISOString()} ${l.direction} ${l.text}`));
+
+  const toggleMode = () => {
+    setHexMode((m) => !m);
+    setPayload((p) => (hexMode ? textToHex(p) : hexToText(p)));
+  };
+
+  return {
+    curl,
+    setCurl,
+    url,
+    origin,
+    payload,
+    setPayload,
+    payloads,
+    addPayload,
+    removePayload,
+    hexMode,
+    toggleMode,
+    delay,
+    setDelay,
+    logs,
+    connect,
+    start,
+    stop,
+    clearLogs,
+    saveProfile,
+    exportLogFile,
+  };
+};
+
+export default useWebsocketSimulator;


### PR DESCRIPTION
## Summary
- implement WebSocket simulator model for parsing curl commands and hex conversions
- create viewmodel and view for managing connections and logs
- add `/tools/websocket-simulator` route and registry entry
- document new tool and add unit tests

## Checklist
- [x] **Model** `/model/websocketSimulator.ts`
- [x] **ViewModel** `/viewmodel/useWebsocketSimulator.ts`
- [x] **View** `/view/WebsocketSimulatorView.tsx`
- [x] **Route** `/tools/websocket-simulator/page.tsx`
- [x] **Tests** `__tests__/websocketSimulator.test.ts`
- [x] **Docs** updated `docs/tools.md`


------
https://chatgpt.com/codex/tasks/task_e_685fac992a988329b803cdab64953711