### PR TITLE
Refine API Request Repeater UI and tests

### DIFF
--- a/__tests__/apiRepeater.test.ts
+++ b/__tests__/apiRepeater.test.ts
@@ -1,0 +1,26 @@
+import { parseCurl } from '../model/apiRepeater';
+
+describe('api repeater model', () => {
+  it('parses curl command with single quotes', () => {
+    const curl = "curl -X POST 'https://api.example.com/data' -H 'Authorization: Bearer abc' -H 'Content-Type: application/json' -d '{\"value\":42}'";
+    const res = parseCurl(curl);
+    expect(res.method).toBe('POST');
+    expect(res.url).toBe('https://api.example.com/data');
+    expect(res.headers).toEqual({
+      Authorization: 'Bearer abc',
+      'Content-Type': 'application/json',
+    });
+    expect(res.body).toBe('{"value":42}');
+  });
+
+  it('parses curl command with double quotes', () => {
+    const curl = "curl -X PUT 'https://api.example.com/update' -H 'Accept: application/json' -d '{\"id\":1}'";
+    const res = parseCurl(curl);
+    expect(res.method).toBe('PUT');
+    expect(res.url).toBe('https://api.example.com/update');
+    expect(res.headers).toEqual({
+      Accept: 'application/json',
+    });
+    expect(res.body).toBe('{"id":1}');
+  });
+});

--- a/__tests__/useApiRepeater.test.ts
+++ b/__tests__/useApiRepeater.test.ts
@@ -1,0 +1,69 @@
+import { renderHook, act } from '@testing-library/react';
+import useApiRepeater from '../viewmodel/useApiRepeater';
+import * as model from '../model/apiRepeater';
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  (global.fetch as any) = jest.fn(() => Promise.resolve({
+    status: 200,
+    text: () => Promise.resolve('ok'),
+  }));
+  localStorage.clear();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.resetAllMocks();
+});
+
+test('start sends repeated requests', async () => {
+  const { result } = renderHook(() => useApiRepeater());
+  act(() => {
+    result.current.setCurl("curl 'https://api.example.com'");
+    result.current.setDelay(100);
+  });
+  act(() => {
+    result.current.parse();
+    result.current.start();
+  });
+
+  await act(async () => {
+    jest.advanceTimersByTime(100);
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+
+  expect((global.fetch as jest.Mock).mock.calls.length).toBe(1);
+  expect(result.current.reqLogs.length).toBe(1);
+  expect(result.current.resLogs.length).toBe(1);
+
+  act(() => result.current.stop());
+  await act(async () => {
+    jest.advanceTimersByTime(200);
+  });
+  expect((global.fetch as jest.Mock).mock.calls.length).toBe(1);
+});
+
+test('saveProfile stores curl and delay', () => {
+  const { result } = renderHook(() => useApiRepeater());
+  act(() => {
+    result.current.setCurl('curl https://a.com');
+    result.current.setDelay(50);
+  });
+  act(() => {
+    result.current.saveProfile();
+  });
+  const stored = JSON.parse(localStorage.getItem('api-repeater-profile') || '{}');
+  expect(stored).toEqual({ curl: 'curl https://a.com', delay: 50 });
+});
+
+test('exportLogFile delegates to model', () => {
+  const spy = jest.spyOn(model, 'exportLogs').mockImplementation(() => {});
+  const { result } = renderHook(() => useApiRepeater());
+  act(() => {
+    result.current.exportLogFile();
+  });
+  expect(spy).toHaveBeenCalled();
+});
+

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -29,6 +29,7 @@ Every section starts with an import snippet showing the component location so yo
 - [Web Permission Tester](#web-permission-tester)
 - [Generate Large Image](#generate-large-image)
 - [API Simulator](#api-simulator)
+- [API Request Repeater](#api-request-repeater)
 - [Network Test Suite](#network-test-suite)
 - [Image Compressor](#image-compressor)
 - [Metadata Echo](#metadata-echo)
@@ -262,6 +263,14 @@ The interface now features a drag‑and‑drop upload area, a progress bar for g
 ```
 
 Simulate API responses entirely in the browser. Encode JSON to Base64, adjust delay and status codes, or enable random error injection. A preset dropdown lets you instantly load common scenarios. The page also generates a ready-to-run cURL command. Access it at `/api-simulator` when deployed to Vercel or served locally.
+
+## API Request Repeater
+
+```tsx
+import ApiTestPage from "../src/tools/api-test/page";
+```
+
+Paste a full HTTP `curl` command, set a delay and repeatedly send the request using `fetch` in the browser. Requests and responses are logged live and can be exported to a `.txt` file. Access this tool at `/api-test`.
 
 ## Network Test Suite
 

--- a/model/apiRepeater.ts
+++ b/model/apiRepeater.ts
@@ -1,0 +1,102 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+export interface ParsedHttpCurl {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body: string | null;
+}
+
+/**
+ * Parse a curl command containing an HTTP request.
+ * Supports -X, -H and -d/--data flags using single or double quotes.
+ */
+export const parseCurl = (curlText: string): ParsedHttpCurl => {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < curlText.length; i += 1) {
+    const ch = curlText[i];
+    if (quote) {
+      if (ch === '\\' && curlText[i + 1] === quote) {
+        current += quote;
+        i += 1;
+      } else if (ch === quote) {
+        tokens.push(current);
+        current = '';
+        quote = null;
+      } else {
+        current += ch;
+      }
+    } else if (ch === '"' || ch === "'") {
+      quote = ch;
+    } else if (/\s/.test(ch)) {
+      if (current) {
+        tokens.push(current);
+        current = '';
+      }
+    } else {
+      current += ch;
+    }
+  }
+  if (current) tokens.push(current);
+  if (tokens[0] !== 'curl') {
+    throw new Error('Invalid curl command: must start with curl');
+  }
+
+  let method = 'GET';
+  let url = '';
+  const headers: Record<string, string> = {};
+  let body: string | null = null;
+
+  for (let i = 1; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    switch (token) {
+      case '-X':
+        method = tokens[i + 1]
+          ? tokens[i + 1].replace(/^['"]|['"]$/g, '').toUpperCase()
+          : 'GET';
+        i += 1;
+        break;
+      case '-H': {
+        const header = tokens[i + 1];
+        i += 1;
+        if (header) {
+          const clean = header.replace(/^['"]|['"]$/g, '');
+          const [key, ...rest] = clean.split(':');
+          headers[key.trim()] = rest.join(':').trim();
+        }
+        break;
+      }
+      case '-d':
+      case '--data':
+      case '--data-raw':
+      case '--data-binary':
+        body = tokens[i + 1]
+          ? tokens[i + 1].replace(/^['"]|['"]$/g, '').replace(/\\"/g, '"')
+          : null;
+        i += 1;
+        break;
+      default:
+        if (!token.startsWith('-') && !url) {
+          url = token.replace(/^['"]|['"]$/g, '');
+        }
+    }
+  }
+
+  if (!url) throw new Error('Invalid curl command: missing URL');
+  return { method, url, headers, body };
+};
+
+export const exportLogs = (logs: string[]): void => {
+  const blob = new Blob([logs.join('\n')], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `api_log_${new Date().toISOString()}.txt`;
+  a.click();
+  URL.revokeObjectURL(url);
+};
+

--- a/src/tools/api-test/index.ts
+++ b/src/tools/api-test/index.ts
@@ -1,0 +1,4 @@
+import ApiTestPage from './page';
+
+export { ApiTestPage };
+export default ApiTestPage;

--- a/src/tools/api-test/page.tsx
+++ b/src/tools/api-test/page.tsx
@@ -1,0 +1,20 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import { getToolByRoute } from '../index';
+import { ToolLayout } from '../../design-system/components/layout';
+import useApiRepeater from '../../../viewmodel/useApiRepeater';
+import ApiRepeaterView from '../../../view/ApiRepeaterView';
+
+const ApiTestPage: React.FC = () => {
+  const vm = useApiRepeater();
+  const tool = getToolByRoute('/api-test');
+  return (
+    <ToolLayout tool={tool!}>
+      <ApiRepeaterView {...vm} />
+    </ToolLayout>
+  );
+};
+
+export default ApiTestPage;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -579,6 +579,21 @@ const toolRegistry: Tool[] = [
   uiOptions: { showExamples: false }
 },
   {
+    id: 'api-test',
+    route: '/api-test',
+    title: 'API Request Repeater',
+    description: 'Repeat HTTP requests from a curl command.',
+    icon: TestingIcon,
+    component: lazy(() => import('./api-test/page')),
+    category: 'Testing',
+    isNew: true,
+    metadata: {
+      keywords: ['curl', 'http', 'testing', 'repeater'],
+      relatedTools: ['api-simulator', 'websocket-simulator']
+    },
+    uiOptions: { showExamples: false }
+  },
+  {
     id: 'network-suit',
     route: '/networksuit',
     title: 'Network Test Suite',

--- a/view/ApiRepeaterView.tsx
+++ b/view/ApiRepeaterView.tsx
@@ -1,0 +1,105 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import { TOOL_PANEL_CLASS } from '../src/design-system/foundations/layout';
+import { Button, TextInput } from '../src/design-system/components/inputs';
+import { InfoBox } from '../src/design-system/components/display';
+// eslint-disable-next-line import/no-named-as-default
+import Card from '../src/design-system/components/layout/Card';
+import type useApiRepeater from '../viewmodel/useApiRepeater';
+
+interface Props extends ReturnType<typeof useApiRepeater> {}
+
+export function ApiRepeaterView({
+  curl,
+  setCurl,
+  delay,
+  setDelay,
+  parsed,
+  reqLogs,
+  resLogs,
+  running,
+  error,
+  parse,
+  start,
+  stop,
+  clearLogs,
+  saveProfile,
+  exportLogFile,
+}: Props) {
+  React.useEffect(() => { parse(); }, [curl, parse]);
+
+  return (
+    <div className={`${TOOL_PANEL_CLASS} space-y-4`}>
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+        API Request Repeater
+      </h1>
+      {error && (
+        <InfoBox variant="error" title="Parse Error">
+          {error}
+        </InfoBox>
+      )}
+      <label htmlFor="curl" className="sr-only">
+        Curl Command
+        <textarea
+          id="curl"
+          className="w-full border p-2 rounded mb-2 dark:bg-gray-700 dark:text-gray-200"
+          rows={3}
+          placeholder="curl -X GET 'https://api.example.com'"
+          value={curl}
+          onChange={(e) => setCurl(e.target.value)}
+        />
+      </label>
+      <TextInput
+        id="delay"
+        label="Delay (ms)"
+        type="number"
+        value={delay}
+        onChange={(e) => setDelay(Number(e.target.value))}
+        fullWidth
+      />
+      {parsed && (
+        <Card isElevated>
+          <Card.Header title="Parsed Request" />
+          <Card.Body>
+            <pre className="text-sm overflow-auto max-h-40">
+{JSON.stringify(parsed, null, 2)}
+            </pre>
+          </Card.Body>
+        </Card>
+      )}
+      <div className="flex flex-wrap gap-2">
+        <Button onClick={start} isDisabled={running}>Start</Button>
+        <Button onClick={stop} variant="secondary" isDisabled={!running}>Stop</Button>
+        <Button variant="outline" onClick={clearLogs}>Clear Logs</Button>
+        <Button variant="outline" onClick={saveProfile}>Save Profile</Button>
+        <Button variant="outline" onClick={exportLogFile}>Export Logs</Button>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Card isElevated>
+          <Card.Header title="Requests" />
+          <Card.Body>
+            <div className="h-48 overflow-y-auto text-sm space-y-1">
+              {reqLogs.map((l) => (
+                <div key={l} className="break-all">{l}</div>
+              ))}
+            </div>
+          </Card.Body>
+        </Card>
+        <Card isElevated>
+          <Card.Header title="Responses" />
+          <Card.Body>
+            <div className="h-48 overflow-y-auto text-sm space-y-1">
+              {resLogs.map((l) => (
+                <div key={l} className="break-all">{l}</div>
+              ))}
+            </div>
+          </Card.Body>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+export default ApiRepeaterView;

--- a/viewmodel/useApiRepeater.ts
+++ b/viewmodel/useApiRepeater.ts
@@ -1,0 +1,105 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { parseCurl, exportLogs, ParsedHttpCurl } from '../model/apiRepeater';
+
+const profileKey = 'api-repeater-profile';
+
+const useApiRepeater = () => {
+  const [curl, setCurl] = useState('');
+  const [delay, setDelay] = useState(1000);
+  const [parsed, setParsed] = useState<ParsedHttpCurl | null>(null);
+  const [reqLogs, setReqLogs] = useState<string[]>([]);
+  const [resLogs, setResLogs] = useState<string[]>([]);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const timerRef = useRef<number>();
+
+  useEffect(() => {
+    const stored = localStorage.getItem(profileKey);
+    if (stored) {
+      try {
+        const profile = JSON.parse(stored);
+        setCurl(profile.curl || '');
+        setDelay(profile.delay || 1000);
+        if (profile.curl) setParsed(parseCurl(profile.curl));
+      } catch {
+        // ignore malformed profile
+      }
+    }
+  }, []);
+
+  const parse = useCallback(() => {
+    try {
+      const p = parseCurl(curl);
+      setParsed(p);
+      setError(null);
+      return p;
+    } catch (e) {
+      setParsed(null);
+      setError((e as Error).message);
+      return null;
+    }
+  }, [curl]);
+
+  const start = useCallback(() => {
+    const p = parsed || parse();
+    if (!p) return;
+    window.clearInterval(timerRef.current);
+    timerRef.current = window.setInterval(async () => {
+      const startTime = performance.now();
+      setReqLogs(l => [`${new Date().toISOString()} ➜ ${p.method} ${p.url}`, ...l]);
+      try {
+        const res = await fetch(p.url, {
+          method: p.method,
+          headers: p.headers,
+          body: p.body || undefined,
+        });
+        const text = await res.text();
+        const dur = Math.round(performance.now() - startTime);
+        setResLogs(l => [`${new Date().toISOString()} ⇐ ${res.status} in ${dur}ms ${text}`, ...l]);
+      } catch (err) {
+        const dur = Math.round(performance.now() - startTime);
+        setResLogs(l => [`${new Date().toISOString()} ✖ error in ${dur}ms ${(err as Error).message}`, ...l]);
+      }
+    }, delay);
+    setRunning(true);
+  }, [delay, parsed, parse]);
+
+  const stop = useCallback(() => {
+    window.clearInterval(timerRef.current);
+    setRunning(false);
+  }, []);
+
+  const clearLogs = () => {
+    setReqLogs([]);
+    setResLogs([]);
+  };
+
+  const saveProfile = () => {
+    localStorage.setItem(profileKey, JSON.stringify({ curl, delay }));
+  };
+
+  const exportLogFile = () => exportLogs([...reqLogs, '---', ...resLogs]);
+
+  return {
+    curl,
+    setCurl,
+    delay,
+    setDelay,
+    parsed,
+    reqLogs,
+    resLogs,
+    running,
+    error,
+    parse,
+    start,
+    stop,
+    clearLogs,
+    saveProfile,
+    exportLogFile,
+  };
+};
+
+export default useApiRepeater;


### PR DESCRIPTION
## Summary
- improve API Request Repeater view to use design-system components
- add unit tests for the `useApiRepeater` hook

## Checklist
- [x] **Model** `/model/apiRepeater.ts`
- [x] **ViewModel** `/viewmodel/useApiRepeater.ts`
- [x] **View** `/view/ApiRepeaterView.tsx`
- [x] **Route** `/tools/api-test/page.tsx`
- [x] **Tests** `/__tests__/useApiRepeater.test.ts`
- [x] **Docs** `/docs/tools.md`

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test -- --coverage`
- `pnpm audit`

------
https://chatgpt.com/codex/tasks/task_e_6860391bb67c8329a2df058a5fa23096