### PR TITLE
Improve CSV to Markdown UI

### DIFF
--- a/__tests__/csvtomd.viewmodel.test.ts
+++ b/__tests__/csvtomd.viewmodel.test.ts
@@ -1,0 +1,51 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import useCsvtomd from '../viewmodel/useCsvtomd';
+
+// Mock clipboard API
+const writeTextMock = jest.fn();
+Object.assign(navigator, {
+  clipboard: { writeText: writeTextMock },
+});
+
+describe('useCsvtomd hook', () => {
+  beforeEach(() => {
+    writeTextMock.mockReset();
+  });
+
+  it('parses CSV input and generates markdown', async () => {
+    const { result } = renderHook(() => useCsvtomd());
+    act(() => {
+      result.current.setCsv('name,age\nAlice,30');
+    });
+    await waitFor(() => result.current.headers.length > 0);
+    expect(result.current.headers).toEqual(['name', 'age']);
+    expect(result.current.markdown).toContain('| Alice | 30 |');
+  });
+
+  it('cycles alignment when toggled', () => {
+    const { result } = renderHook(() => useCsvtomd());
+    act(() => {
+      result.current.setCsv('a,b\n1,2');
+    });
+    act(() => {
+      result.current.toggleAlignment(0);
+    });
+    expect(result.current.alignment[0]).toBe('center');
+    act(() => {
+      result.current.toggleAlignment(0);
+    });
+    expect(result.current.alignment[0]).toBe('right');
+  });
+
+  it('copies markdown to clipboard', async () => {
+    const { result } = renderHook(() => useCsvtomd());
+    act(() => {
+      result.current.setCsv('a,b\n1,2');
+    });
+    await waitFor(() => result.current.markdown.length > 0);
+    await act(async () => {
+      await result.current.copyMarkdown();
+    });
+    expect(writeTextMock).toHaveBeenCalledWith(result.current.markdown);
+  });
+});

--- a/src/tools/csvtomd/page.tsx
+++ b/src/tools/csvtomd/page.tsx
@@ -4,10 +4,18 @@
 import React from 'react';
 import useCsvtomd from '../../../viewmodel/useCsvtomd';
 import CsvtomdView from '../../../view/CsvtomdView';
+import { getToolByRoute } from '../index';
+import { ToolLayout } from '../../design-system/components/layout';
 
 const CsvtomdPage: React.FC = () => {
   const vm = useCsvtomd();
-  return <CsvtomdView {...vm} />;
+  const tool = getToolByRoute('/csvtomd');
+
+  return (
+    <ToolLayout tool={tool!} title="CSV to Markdown" description="Convert CSV tables to GitHub-flavored Markdown.">
+      <CsvtomdView {...vm} />
+    </ToolLayout>
+  );
 };
 
 export default CsvtomdPage;

--- a/view/CsvtomdView.tsx
+++ b/view/CsvtomdView.tsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 import { TOOL_PANEL_CLASS } from '../src/design-system/foundations/layout';
+import { Button, SelectInput } from '../src/design-system/components/inputs';
+import { CodeBlock } from '../src/design-system/components/display/CodeBlock';
 
 interface Props {
   csv: string;
@@ -34,71 +36,70 @@ export function CsvtomdView({
   error,
 }: Props) {
   return (
-    <div className={`${TOOL_PANEL_CLASS.replace('p-6', 'p-4')} space-y-4`}>
-      <textarea
-        value={csv}
-        onChange={(e) => setCsv(e.target.value)}
-        rows={6}
-        className="w-full border px-2 py-1 rounded font-mono"
-        placeholder="Paste CSV here"
-      />
-      <div className="flex items-center gap-2 text-sm">
-        <input
-          type="file"
-          accept=".csv,text/csv"
-          onChange={(e) => {
-            const f = e.target.files?.[0];
-            if (f) uploadFile(f);
-          }}
-        />
-        <label htmlFor="delimiter" className="flex items-center gap-1">
-          Delimiter
-          <select
-            id="delimiter"
-            className="border px-1 py-0.5 rounded"
-            value={delimiter}
-            onChange={(e) => setDelimiter(e.target.value)}
-          >
-            <option value=",">,</option>
-            <option value=";">;</option>
-            <option value="\t">Tab</option>
-            <option value="|">|</option>
-          </select>
-        </label>
-      </div>
-      {alignment.length > 0 && (
-        <div className="flex flex-wrap gap-2 text-sm">
-          {alignment.map((a, i) => (
-            <button
-              key={headers[i] || i}
-              type="button"
-              className="border px-2 py-1 rounded"
-              onClick={() => toggleAlignment(i)}
-            >
-              {a}
-            </button>
-          ))}
-        </div>
-      )}
-      {error && <div className="text-red-600">{error}</div>}
-      {markdown && (
-        <>
+    <div className="space-y-4">
+      <div className="grid md:grid-cols-2 gap-4">
+        <div className={`${TOOL_PANEL_CLASS.replace('p-6', 'p-4')} space-y-4`}>
           <textarea
-            readOnly
-            value={markdown}
-            rows={Math.min(10, markdown.split('\n').length + 2)}
-            className="w-full border px-2 py-1 rounded font-mono overflow-auto"
+            value={csv}
+            onChange={(e) => setCsv(e.target.value)}
+            rows={8}
+            className="w-full border px-2 py-1 rounded font-mono"
+            placeholder="Paste CSV here"
           />
-          <div className="flex gap-4 text-sm text-blue-600">
-            <button type="button" className="underline" onClick={copyMarkdown}>
-              Copy Markdown
-            </button>
-            <button type="button" className="underline" onClick={downloadMarkdown}>
-              Download .md
-            </button>
+          <div className="flex items-center gap-2 text-sm">
+            <input
+              type="file"
+              accept=".csv,text/csv"
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                if (f) uploadFile(f);
+              }}
+            />
+            <SelectInput
+              value={delimiter}
+              onChange={setDelimiter}
+              label="Delimiter"
+              options={[
+                { value: ',', label: ',' },
+                { value: ';', label: ';' },
+                { value: '\t', label: 'Tab' },
+                { value: '|', label: '|' },
+              ]}
+              className="w-28"
+            />
           </div>
-        </>
-      )}
+          {alignment.length > 0 && (
+            <div className="flex flex-wrap gap-2 text-sm">
+              {alignment.map((a, i) => (
+                <Button
+                  key={headers[i] || i}
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => toggleAlignment(i)}
+                >
+                  {a}
+                </Button>
+              ))}
+            </div>
+          )}
+          {error && <div className="text-red-600 text-sm">{error}</div>}
+        </div>
+        <div className={`${TOOL_PANEL_CLASS.replace('p-6', 'p-4')} space-y-2`}>
+          {markdown ? (
+            <>
+              <CodeBlock maxHeight="20rem">{markdown}</CodeBlock>
+              <div className="flex gap-2">
+                <Button size="sm" onClick={copyMarkdown}>Copy</Button>
+                <Button size="sm" variant="secondary" onClick={downloadMarkdown}>
+                  Download
+                </Button>
+              </div>
+            </>
+          ) : (
+            <p className="text-sm text-gray-500">Paste CSV to generate Markdown.</p>
+          )}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- enhance CsvtomdPage with ToolLayout
- restyle CsvtomdView using design system components
- add viewmodel tests for Csvtomd hook

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm audit` (reported vulnerabilities)


------
https://chatgpt.com/codex/tasks/task_e_68603e003e808329b5b35501326e3231