### PR TITLE
Add JSON converter tool

### DIFF
--- a/__tests__/jsonConverter.test.ts
+++ b/__tests__/jsonConverter.test.ts
@@ -7,7 +7,7 @@ test('parseJson returns array', () => {
 });
 
 test('convertJsonToCsv flattens when enabled', () => {
-  const csv = convertJsonToCsv(sample, { flatten: true, header: true, eol: '\n' });
+  const csv = convertJsonToCsv(sample, { flatten: true, includeHeader: true, eol: '\n' });
   expect(csv.trim()).toBe('a,b.c\n1,2');
 });
 

--- a/__tests__/jsonConverter.test.ts
+++ b/__tests__/jsonConverter.test.ts
@@ -1,0 +1,16 @@
+import { parseJson, convertJsonToCsv } from '../model/jsonConverter';
+
+const sample = '[{"a":1,"b":{"c":2}}]';
+
+test('parseJson returns array', () => {
+  expect(parseJson(sample)).toEqual([{ a: 1, b: { c: 2 } }]);
+});
+
+test('convertJsonToCsv flattens when enabled', () => {
+  const csv = convertJsonToCsv(sample, { flatten: true, header: true, eol: '\n' });
+  expect(csv.trim()).toBe('a,b.c\n1,2');
+});
+
+test('parseJson throws on invalid input', () => {
+  expect(() => parseJson('bad')).toThrow('Invalid JSON input');
+});

--- a/__tests__/jsonConverter.test.ts
+++ b/__tests__/jsonConverter.test.ts
@@ -11,6 +11,18 @@ test('convertJsonToCsv flattens when enabled', () => {
   expect(csv.trim()).toBe('a,b.c\n1,2');
 });
 
+test('convertJsonToCsv respects delimiter and date format', () => {
+  const data = '[{"date":"2025-01-01","val":2}]';
+  const csv = convertJsonToCsv(data, {
+    flatten: true,
+    delimiter: ';',
+    dateFormat: 'YYYY',
+    includeHeader: true,
+    eol: '\n',
+  });
+  expect(csv.trim()).toBe('date;val\n2025;2');
+});
+
 test('parseJson throws on invalid input', () => {
   expect(() => parseJson('bad')).toThrow('Invalid JSON input');
 });

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -351,3 +351,6 @@ import JsonConverterPage from "../src/tools/json-converter/page";
 Paste or upload JSON data and convert it into CSV or Excel. You can flatten
 nested objects, include a header row and choose LF or CRLF line endings. Copy
 the output or download it as `.csv` or `.xlsx` at `/json-converter`.
+Large files over 10MB are rejected with an error. While parsing big JSON you
+will see a spinner, and only the first 50 rows are previewed when data exceeds
+10k entries.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -348,9 +348,10 @@ Markdown can be copied or downloaded as a `.md` file. Access this tool at
 import JsonConverterPage from "../src/tools/json-converter/page";
 ```
 
-Paste or upload JSON data and convert it into CSV or Excel. You can flatten
-nested objects, include a header row and choose LF or CRLF line endings. Copy
-the output or download it as `.csv` or `.xlsx` at `/json-converter`.
-Large files over 10MB are rejected with an error. While parsing big JSON you
-will see a spinner, and only the first 50 rows are previewed when data exceeds
-10k entries.
+Paste or upload JSON data and convert it into CSV or Excel. Advanced output
+options let you pick delimiters, quote style, and date formatting. You can
+flatten nested objects, suppress newlines and choose line endings. The converted
+data can be copied or downloaded as `.csv` or `.xlsx` at `/json-converter`.
+Files over **20MB** are rejected with an error. While parsing big JSON you will
+see a spinner, and only the first 50 rows are previewed when data exceeds 10k
+entries.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -37,6 +37,7 @@ Every section starts with an import snippet showing the component location so yo
 - [Metadata Echo](#metadata-echo)
 - [WebSocket Simulator](#websocket-simulator)
 - [CSV to Markdown Converter](#csv-to-markdown-converter)
+- [JSON to CSV / Excel Converter](#json-to-csv--excel-converter)
 
 ## Crypto Lab
 
@@ -340,3 +341,13 @@ Upload or paste a CSV and convert it to a GitHub-flavored Markdown table. Each
 column's alignment can be toggled between left, center and right. The generated
 Markdown can be copied or downloaded as a `.md` file. Access this tool at
 `/csvtomd`.
+
+## JSON to CSV / Excel Converter
+
+```tsx
+import JsonConverterPage from "../src/tools/json-converter/page";
+```
+
+Paste or upload JSON data and convert it into CSV or Excel. You can flatten
+nested objects, include a header row and choose LF or CRLF line endings. Copy
+the output or download it as `.csv` or `.xlsx` at `/json-converter`.

--- a/model/jsonConverter.ts
+++ b/model/jsonConverter.ts
@@ -33,11 +33,11 @@ export const convertJsonToCsv = (
   return convertToCSV(data, options);
 };
 
-export const convertJsonToExcel = (
+export const convertJsonToExcel = async (
   text: string,
   fileName: string,
   options: ExcelOptions,
-): void => {
+): Promise<void> => {
   const data = parseJson(text);
-  exportToExcel(data, fileName, options);
+  await exportToExcel(data, fileName, options);
 };

--- a/model/jsonConverter.ts
+++ b/model/jsonConverter.ts
@@ -1,0 +1,43 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { convertToCSV } from '../src/utils/convertToCSV';
+import { exportToExcel } from '../src/utils/exportToExcel';
+import type { CsvOptions } from '../src/utils/convertToCSV';
+import type { ExcelOptions } from '../src/utils/exportToExcel';
+
+export const parseJson = (
+  text: string,
+): Record<string, unknown>[] => {
+  try {
+    const data = JSON.parse(text.trim());
+    return Array.isArray(data) ? data : [data];
+  } catch {
+    throw new Error('Invalid JSON input');
+  }
+};
+
+export const fetchJsonFromUrl = async (url: string): Promise<string> => {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Request failed with ${res.status}`);
+  const text = await res.text();
+  JSON.parse(text); // validate
+  return text;
+};
+
+export const convertJsonToCsv = (
+  text: string,
+  options: CsvOptions,
+): string => {
+  const data = parseJson(text);
+  return convertToCSV(data, options);
+};
+
+export const convertJsonToExcel = (
+  text: string,
+  fileName: string,
+  options: ExcelOptions,
+): void => {
+  const data = parseJson(text);
+  exportToExcel(data, fileName, options);
+};

--- a/model/jsonConverterTypes.ts
+++ b/model/jsonConverterTypes.ts
@@ -1,0 +1,16 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+export interface OutputOptions {
+  delimiter: string;
+  includeHeader: boolean;
+  suppressNewlines: boolean;
+  flatten: boolean;
+  pivot: boolean;
+  dateFormat: string;
+  forceQuotes: boolean;
+  objectPath: string;
+  upgradeToArray: boolean;
+  useAltMode: boolean;
+  eol: 'LF' | 'CRLF';
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react-use": "^17.4.0",
     "tailwindcss": "^3.3.3",
     "vite": "^4.5.2",
-    "web-push": "^3.6.7"
+    "web-push": "^3.6.7",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lodash": "^4.17.21",
     "lucide-react": "^0.517.0",
     "lz-string": "^1.5.0",
+    "moment": "^2.30.1",
     "next": "^14.0.4",
     "node-fetch": "^3.3.0",
     "openpgp": "5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       lz-string:
         specifier: ^1.5.0
         version: 1.5.0
+      moment:
+        specifier: ^2.30.1
+        version: 2.30.1
       next:
         specifier: ^14.0.4
         version: 14.2.29(@babel/core@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2656,6 +2659,9 @@ packages:
 
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  moment@2.30.1:
+    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
   motion-dom@12.18.1:
     resolution: {integrity: sha512-dR/4EYT23Snd+eUSLrde63Ws3oXQtJNw/krgautvTfwrN/2cHfCZMdu6CeTxVfRRWREW3Fy1f5vobRDiBb/q+w==}
@@ -6835,6 +6841,8 @@ snapshots:
   minipass@7.1.2: {}
 
   mitt@3.0.1: {}
+
+  moment@2.30.1: {}
 
   motion-dom@12.18.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       web-push:
         specifier: ^3.6.7
         version: 3.6.7
+      xlsx:
+        specifier: ^0.18.5
+        version: 0.18.5
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^2.1.4
@@ -1026,6 +1029,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
@@ -1308,6 +1315,10 @@ packages:
     resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
     engines: {node: '>=10.0.0'}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chalk@3.0.0:
     resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
     engines: {node: '>=8'}
@@ -1358,6 +1369,10 @@ packages:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
 
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
+
   collect-v8-coverage@1.0.2:
     resolution: {integrity: sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==}
 
@@ -1398,6 +1413,11 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   create-jest@29.7.0:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
@@ -1875,6 +1895,10 @@ packages:
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -3297,6 +3321,10 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   stack-generator@2.0.10:
     resolution: {integrity: sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==}
 
@@ -3696,9 +3724,17 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -3730,6 +3766,11 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -4730,6 +4771,8 @@ snapshots:
 
   acorn@8.14.1: {}
 
+  adler-32@1.3.1: {}
+
   agent-base@7.1.3: {}
 
   ajv@6.12.6:
@@ -5054,6 +5097,11 @@ snapshots:
       svg-pathdata: 6.0.3
     optional: true
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chalk@3.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -5108,6 +5156,8 @@ snapshots:
 
   co@4.6.0: {}
 
+  codepage@1.15.0: {}
+
   collect-v8-coverage@1.0.2: {}
 
   color-convert@2.0.1:
@@ -5141,6 +5191,8 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.8.3
+
+  crc-32@1.2.2: {}
 
   create-jest@29.7.0(@types/node@18.19.111):
     dependencies:
@@ -5808,6 +5860,8 @@ snapshots:
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
+
+  frac@1.1.2: {}
 
   fraction.js@4.3.7: {}
 
@@ -7504,6 +7558,10 @@ snapshots:
 
   sprintf-js@1.1.3: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   stack-generator@2.0.10:
     dependencies:
       stackframe: 1.3.4
@@ -7972,7 +8030,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  wmf@1.0.2: {}
+
   word-wrap@1.2.5: {}
+
+  word@0.3.0: {}
 
   wrap-ansi@6.2.0:
     dependencies:
@@ -8000,6 +8062,16 @@ snapshots:
       signal-exit: 3.0.7
 
   ws@8.18.2: {}
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   xml-name-validator@5.0.0: {}
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -678,6 +678,20 @@ const toolRegistry: Tool[] = [
     uiOptions: { showExamples: false },
   },
   {
+    id: "json-converter",
+    route: "/json-converter",
+    title: "JSON to CSV / Excel Converter",
+    description: "Convert JSON data to CSV or Excel spreadsheets.",
+    icon: ConversionIcon,
+    component: lazy(() => import("./json-converter/page")),
+    category: "Conversion",
+    metadata: {
+      keywords: ["json", "csv", "excel", "convert"],
+      relatedTools: ["csv-to-markdown"],
+    },
+    uiOptions: { showExamples: false },
+  },
+  {
     id: "stayawake",
     route: "/stayawake",
     title: "Stay Awake Toggle",

--- a/src/tools/json-converter/index.ts
+++ b/src/tools/json-converter/index.ts
@@ -1,0 +1,3 @@
+import JsonConverterPage from './page';
+export { JsonConverterPage };
+export default JsonConverterPage;

--- a/src/tools/json-converter/page.tsx
+++ b/src/tools/json-converter/page.tsx
@@ -1,0 +1,24 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import useJsonConverter from '../../../viewmodel/useJsonConverter';
+import JsonConverterView from '../../../view/JsonConverterView';
+import { getToolByRoute } from '../index';
+import { ToolLayout } from '../../design-system/components/layout';
+
+const JsonConverterPage: React.FC = () => {
+  const vm = useJsonConverter();
+  const tool = getToolByRoute('/json-converter');
+  return (
+    <ToolLayout
+      tool={tool!}
+      title="JSON to CSV / Excel Converter"
+      description="Convert JSON data to CSV or Excel spreadsheets."
+    >
+      <JsonConverterView {...vm} />
+    </ToolLayout>
+  );
+};
+
+export default JsonConverterPage;

--- a/src/utils/convertToCSV.ts
+++ b/src/utils/convertToCSV.ts
@@ -1,0 +1,22 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import * as Papa from 'papaparse';
+import flattenJSON from './flattenJSON';
+
+export interface CsvOptions {
+  flatten?: boolean;
+  header?: boolean;
+  eol?: '\n' | '\r\n';
+}
+
+export const convertToCSV = (
+  data: unknown,
+  options: CsvOptions = {},
+): string => {
+  const { flatten = false, header = true, eol = '\n' } = options;
+  const arr = Array.isArray(data) ? data : [data];
+  const rows = arr.map((d) => (flatten ? flattenJSON(d as Record<string, unknown>) : d));
+  return Papa.unparse(rows, { header, newline: eol });
+};
+

--- a/src/utils/convertToCSV.ts
+++ b/src/utils/convertToCSV.ts
@@ -4,19 +4,51 @@
 import * as Papa from 'papaparse';
 import flattenJSON from './flattenJSON';
 
+const getPath = (obj: any, path: string) =>
+  path.split('.').reduce<any>((acc, key) => acc?.[key], obj);
+
 export interface CsvOptions {
+  delimiter?: string;
+  includeHeader?: boolean;
+  suppressNewlines?: boolean;
   flatten?: boolean;
-  header?: boolean;
+  forceQuotes?: boolean;
   eol?: '\n' | '\r\n';
+  dateFormat?: string;
+  objectPath?: string;
 }
 
 export const convertToCSV = (
   data: unknown,
   options: CsvOptions = {},
 ): string => {
-  const { flatten = false, header = true, eol = '\n' } = options;
+  const {
+    delimiter = ',',
+    includeHeader = true,
+    suppressNewlines = false,
+    flatten = false,
+    forceQuotes = false,
+    eol = '\n',
+    dateFormat,
+    objectPath,
+  } = options;
+
   const arr = Array.isArray(data) ? data : [data];
-  const rows = arr.map((d) => (flatten ? flattenJSON(d as Record<string, unknown>) : d));
-  return Papa.unparse(rows, { header, newline: eol });
+  const selected = objectPath ? arr.map((r) => getPath(r, objectPath)) : arr;
+  const rows = selected.map((d) =>
+    flatten ? flattenJSON(d as Record<string, unknown>, '', {}, dateFormat) : d,
+  );
+  let csv = Papa.unparse(rows, {
+    delimiter,
+    header: includeHeader,
+    newline: eol,
+    quotes: forceQuotes,
+  });
+
+  if (suppressNewlines) {
+    csv = csv.replace(/\r?\n/g, '');
+  }
+
+  return csv;
 };
 

--- a/src/utils/exportToExcel.ts
+++ b/src/utils/exportToExcel.ts
@@ -1,0 +1,32 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import * as XLSX from 'xlsx';
+import flattenJSON from './flattenJSON';
+
+export interface ExcelOptions {
+  flatten?: boolean;
+}
+
+export const exportToExcel = (
+  data: unknown,
+  fileName: string,
+  options: ExcelOptions = {},
+): void => {
+  const { flatten = false } = options;
+  const arr = Array.isArray(data) ? data : [data];
+  const rows = arr.map((d) => (flatten ? flattenJSON(d as Record<string, unknown>) : d));
+  const ws = XLSX.utils.json_to_sheet(rows);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
+  const blob = new Blob([XLSX.write(wb, { bookType: 'xlsx', type: 'array' })], {
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = fileName.endsWith('.xlsx') ? fileName : `${fileName}.xlsx`;
+  a.click();
+  URL.revokeObjectURL(url);
+};
+

--- a/src/utils/exportToExcel.ts
+++ b/src/utils/exportToExcel.ts
@@ -1,7 +1,6 @@
 /**
  * © 2025 MyDebugger Contributors – MIT License
  */
-import * as XLSX from 'xlsx';
 import flattenJSON from './flattenJSON';
 
 export interface ExcelOptions {
@@ -9,11 +8,12 @@ export interface ExcelOptions {
   dateFormat?: string;
 }
 
-export const exportToExcel = (
+export const exportToExcel = async (
   data: unknown,
   fileName: string,
   options: ExcelOptions = {},
-): void => {
+): Promise<void> => {
+  const { default: XLSX } = await import('xlsx');
   const { flatten = false, dateFormat } = options;
   const arr = Array.isArray(data) ? data : [data];
   const rows = arr.map((d) =>

--- a/src/utils/exportToExcel.ts
+++ b/src/utils/exportToExcel.ts
@@ -6,6 +6,7 @@ import flattenJSON from './flattenJSON';
 
 export interface ExcelOptions {
   flatten?: boolean;
+  dateFormat?: string;
 }
 
 export const exportToExcel = (
@@ -13,9 +14,11 @@ export const exportToExcel = (
   fileName: string,
   options: ExcelOptions = {},
 ): void => {
-  const { flatten = false } = options;
+  const { flatten = false, dateFormat } = options;
   const arr = Array.isArray(data) ? data : [data];
-  const rows = arr.map((d) => (flatten ? flattenJSON(d as Record<string, unknown>) : d));
+  const rows = arr.map((d) =>
+    flatten ? flattenJSON(d as Record<string, unknown>, '', {}, dateFormat) : d,
+  );
   const ws = XLSX.utils.json_to_sheet(rows);
   const wb = XLSX.utils.book_new();
   XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');

--- a/src/utils/flattenJSON.ts
+++ b/src/utils/flattenJSON.ts
@@ -1,10 +1,13 @@
 /**
  * © 2025 MyDebugger Contributors – MIT License
  */
+import * as moment from 'moment';
+
 export const flattenJSON = (
   obj: Record<string, unknown>,
   prefix = '',
   res: Record<string, unknown> = {},
+  dateFormat?: string,
 ): Record<string, unknown> => {
   Object.entries(obj).forEach(([key, value]) => {
     const newKey = prefix ? `${prefix}.${key}` : key;
@@ -13,9 +16,17 @@ export const flattenJSON = (
       typeof value === 'object' &&
       !Array.isArray(value)
     ) {
-      flattenJSON(value as Record<string, unknown>, newKey, res);
+      flattenJSON(value as Record<string, unknown>, newKey, res, dateFormat);
     } else {
-      res[newKey] = Array.isArray(value) ? JSON.stringify(value) : value;
+      let val: unknown = value;
+      if (
+        dateFormat &&
+        typeof value === 'string' &&
+        moment(value, moment.ISO_8601, true).isValid()
+      ) {
+        val = moment(value).format(dateFormat);
+      }
+      res[newKey] = Array.isArray(val) ? JSON.stringify(val) : val;
     }
   });
   return res;

--- a/src/utils/flattenJSON.ts
+++ b/src/utils/flattenJSON.ts
@@ -1,0 +1,24 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+export const flattenJSON = (
+  obj: Record<string, unknown>,
+  prefix = '',
+  res: Record<string, unknown> = {},
+): Record<string, unknown> => {
+  Object.entries(obj).forEach(([key, value]) => {
+    const newKey = prefix ? `${prefix}.${key}` : key;
+    if (
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value)
+    ) {
+      flattenJSON(value as Record<string, unknown>, newKey, res);
+    } else {
+      res[newKey] = Array.isArray(value) ? JSON.stringify(value) : value;
+    }
+  });
+  return res;
+};
+
+export default flattenJSON;

--- a/view/JsonConverterView.tsx
+++ b/view/JsonConverterView.tsx
@@ -5,6 +5,8 @@ import React from 'react';
 import { TOOL_PANEL_CLASS } from '../src/design-system/foundations/layout';
 import { Button } from '../src/design-system/components/inputs';
 import { LoadingSpinner } from '../src/design-system/components/feedback/LoadingSpinner';
+import OutputOptionsPanel from './OutputOptionsPanel';
+import type { OutputOptions } from '../model/jsonConverterTypes';
 
 interface Props {
   input: string;
@@ -13,14 +15,10 @@ interface Props {
   setUrl: (v: string) => void;
   output: string;
   previewNotice: string;
-  flatten: boolean;
-  setFlatten: (v: boolean) => void;
-  header: boolean;
-  setHeader: (v: boolean) => void;
-  eol: 'LF' | 'CRLF';
-  setEol: (v: 'LF' | 'CRLF') => void;
   filename: string;
   setFilename: (v: string) => void;
+  outputOptions: OutputOptions;
+  setOptions: (opts: OutputOptions) => void;
   error: string;
   fileInfo: string;
   loading: boolean;
@@ -42,14 +40,10 @@ export function JsonConverterView({
   setUrl,
   output,
   previewNotice,
-  flatten,
-  setFlatten,
-  header,
-  setHeader,
-  eol,
-  setEol,
   filename,
   setFilename,
+  outputOptions,
+  setOptions,
   error,
   fileInfo,
   loading,
@@ -104,8 +98,8 @@ export function JsonConverterView({
                 id="flatten"
                 type="checkbox"
                 className="form-checkbox h-4 w-4"
-                checked={flatten}
-                onChange={(e) => setFlatten(e.target.checked)}
+                checked={outputOptions.flatten}
+                onChange={(e) => setOptions({ ...outputOptions, flatten: e.target.checked })}
               />
               <span className="ml-1">Flatten</span>
             </label>
@@ -114,25 +108,26 @@ export function JsonConverterView({
                 id="header"
                 type="checkbox"
                 className="form-checkbox h-4 w-4"
-                checked={header}
-                onChange={(e) => setHeader(e.target.checked)}
+                checked={outputOptions.includeHeader}
+                onChange={(e) => setOptions({ ...outputOptions, includeHeader: e.target.checked })}
               />
               <span className="ml-1">Header</span>
             </label>
             <select
               className="border px-1 py-0.5 rounded dark:bg-gray-700 dark:text-gray-200"
-              value={eol}
-              onChange={(e) => setEol(e.target.value as 'LF' | 'CRLF')}
+              value={outputOptions.eol}
+              onChange={(e) => setOptions({ ...outputOptions, eol: e.target.value as 'LF' | 'CRLF' })}
             >
               <option value="LF">LF</option>
               <option value="CRLF">CRLF</option>
             </select>
+        </div>
+        <OutputOptionsPanel options={outputOptions} onChange={setOptions} />
+        {loading && (
+          <div className="flex items-center gap-2 text-gray-500">
+            <LoadingSpinner size="sm" /> Processing large file...
           </div>
-          {loading && (
-            <div className="flex items-center gap-2 text-gray-500">
-              <LoadingSpinner size="sm" /> Processing large file...
-            </div>
-          )}
+        )}
           {error && (
             <div className="text-red-600 text-sm flex items-center gap-2">
               {error}

--- a/view/JsonConverterView.tsx
+++ b/view/JsonConverterView.tsx
@@ -1,0 +1,149 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import { TOOL_PANEL_CLASS } from '../src/design-system/foundations/layout';
+import { Button } from '../src/design-system/components/inputs';
+
+interface Props {
+  input: string;
+  setInput: (v: string) => void;
+  url: string;
+  setUrl: (v: string) => void;
+  output: string;
+  flatten: boolean;
+  setFlatten: (v: boolean) => void;
+  header: boolean;
+  setHeader: (v: boolean) => void;
+  eol: 'LF' | 'CRLF';
+  setEol: (v: 'LF' | 'CRLF') => void;
+  filename: string;
+  setFilename: (v: string) => void;
+  error: string;
+  format: () => void;
+  clear: () => void;
+  loadExample: () => void;
+  uploadFile: (f: File) => void;
+  fetchUrl: () => void;
+  convert: () => void;
+  copyOutput: () => void;
+  downloadCsv: () => void;
+  downloadExcel: () => void;
+}
+
+export function JsonConverterView({
+  input,
+  setInput,
+  url,
+  setUrl,
+  output,
+  flatten,
+  setFlatten,
+  header,
+  setHeader,
+  eol,
+  setEol,
+  filename,
+  setFilename,
+  error,
+  format,
+  clear,
+  loadExample,
+  uploadFile,
+  fetchUrl,
+  convert,
+  copyOutput,
+  downloadCsv,
+  downloadExcel,
+}: Props) {
+  return (
+    <div className="space-y-4">
+      <div className="grid md:grid-cols-2 gap-4">
+        <div className={`${TOOL_PANEL_CLASS.replace('p-6', 'p-4')} space-y-4`}>
+          <textarea
+            className="w-full border px-2 py-1 rounded h-40 dark:bg-gray-700 dark:text-gray-200"
+            placeholder="Paste JSON here"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+          />
+          <input
+            type="file"
+            accept=".json,.txt,application/json,text/plain"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) uploadFile(f);
+            }}
+          />
+          <div className="flex gap-2">
+            <input
+              type="url"
+              className="flex-1 border px-2 py-1 rounded dark:bg-gray-700 dark:text-gray-200"
+              placeholder="https://example.com/data.json"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+            />
+            <Button size="sm" onClick={fetchUrl}>Fetch</Button>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button size="sm" onClick={format}>Format</Button>
+            <Button size="sm" variant="secondary" onClick={clear}>Clear</Button>
+            <Button size="sm" variant="outline" onClick={loadExample}>Example</Button>
+            <Button size="sm" onClick={convert}>Convert</Button>
+          </div>
+          <div className="flex flex-wrap items-center gap-4 text-sm">
+            <label htmlFor="flatten" className="inline-flex items-center">
+              <input
+                id="flatten"
+                type="checkbox"
+                className="form-checkbox h-4 w-4"
+                checked={flatten}
+                onChange={(e) => setFlatten(e.target.checked)}
+              />
+              <span className="ml-1">Flatten</span>
+            </label>
+            <label htmlFor="header" className="inline-flex items-center">
+              <input
+                id="header"
+                type="checkbox"
+                className="form-checkbox h-4 w-4"
+                checked={header}
+                onChange={(e) => setHeader(e.target.checked)}
+              />
+              <span className="ml-1">Header</span>
+            </label>
+            <select
+              className="border px-1 py-0.5 rounded dark:bg-gray-700 dark:text-gray-200"
+              value={eol}
+              onChange={(e) => setEol(e.target.value as 'LF' | 'CRLF')}
+            >
+              <option value="LF">LF</option>
+              <option value="CRLF">CRLF</option>
+            </select>
+          </div>
+          {error && <div className="text-red-600 text-sm">{error}</div>}
+        </div>
+        <div className={`${TOOL_PANEL_CLASS.replace('p-6', 'p-4')} space-y-2`}>
+          <textarea
+            className="w-full border px-2 py-1 rounded h-40 font-mono dark:bg-gray-700 dark:text-gray-200"
+            readOnly
+            value={output}
+          />
+          <div className="flex flex-wrap gap-2 items-center">
+            <Button size="sm" onClick={copyOutput}>Copy</Button>
+            <input
+              type="text"
+              className="border px-2 py-1 rounded flex-1 dark:bg-gray-700 dark:text-gray-200"
+              value={filename}
+              onChange={(e) => setFilename(e.target.value)}
+              placeholder="filename"
+            />
+            <Button size="sm" variant="secondary" onClick={downloadCsv}>Download CSV</Button>
+            <Button size="sm" variant="secondary" onClick={downloadExcel}>Download Excel</Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default JsonConverterView;

--- a/view/JsonConverterView.tsx
+++ b/view/JsonConverterView.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { TOOL_PANEL_CLASS } from '../src/design-system/foundations/layout';
 import { Button } from '../src/design-system/components/inputs';
+import { LoadingSpinner } from '../src/design-system/components/feedback/LoadingSpinner';
 
 interface Props {
   input: string;
@@ -11,6 +12,7 @@ interface Props {
   url: string;
   setUrl: (v: string) => void;
   output: string;
+  previewNotice: string;
   flatten: boolean;
   setFlatten: (v: boolean) => void;
   header: boolean;
@@ -20,6 +22,8 @@ interface Props {
   filename: string;
   setFilename: (v: string) => void;
   error: string;
+  fileInfo: string;
+  loading: boolean;
   format: () => void;
   clear: () => void;
   loadExample: () => void;
@@ -37,6 +41,7 @@ export function JsonConverterView({
   url,
   setUrl,
   output,
+  previewNotice,
   flatten,
   setFlatten,
   header,
@@ -46,6 +51,8 @@ export function JsonConverterView({
   filename,
   setFilename,
   error,
+  fileInfo,
+  loading,
   format,
   clear,
   loadExample,
@@ -74,6 +81,7 @@ export function JsonConverterView({
               if (f) uploadFile(f);
             }}
           />
+          {fileInfo && <div className="text-xs text-gray-500">{fileInfo}</div>}
           <div className="flex gap-2">
             <input
               type="url"
@@ -82,13 +90,13 @@ export function JsonConverterView({
               value={url}
               onChange={(e) => setUrl(e.target.value)}
             />
-            <Button size="sm" onClick={fetchUrl}>Fetch</Button>
+            <Button size="sm" onClick={fetchUrl} isLoading={loading} disabled={loading}>Fetch</Button>
           </div>
           <div className="flex flex-wrap gap-2">
-            <Button size="sm" onClick={format}>Format</Button>
-            <Button size="sm" variant="secondary" onClick={clear}>Clear</Button>
-            <Button size="sm" variant="outline" onClick={loadExample}>Example</Button>
-            <Button size="sm" onClick={convert}>Convert</Button>
+            <Button size="sm" onClick={format} disabled={loading}>Format</Button>
+            <Button size="sm" variant="secondary" onClick={clear} disabled={loading}>Clear</Button>
+            <Button size="sm" variant="outline" onClick={loadExample} disabled={loading}>Example</Button>
+            <Button size="sm" onClick={convert} isLoading={loading} disabled={loading}>Convert</Button>
           </div>
           <div className="flex flex-wrap items-center gap-4 text-sm">
             <label htmlFor="flatten" className="inline-flex items-center">
@@ -120,7 +128,17 @@ export function JsonConverterView({
               <option value="CRLF">CRLF</option>
             </select>
           </div>
-          {error && <div className="text-red-600 text-sm">{error}</div>}
+          {loading && (
+            <div className="flex items-center gap-2 text-gray-500">
+              <LoadingSpinner size="sm" /> Processing large file...
+            </div>
+          )}
+          {error && (
+            <div className="text-red-600 text-sm flex items-center gap-2">
+              {error}
+              <Button size="xs" variant="outline" onClick={clear} className="ml-auto">Clear & Try Again</Button>
+            </div>
+          )}
         </div>
         <div className={`${TOOL_PANEL_CLASS.replace('p-6', 'p-4')} space-y-2`}>
           <textarea
@@ -128,6 +146,9 @@ export function JsonConverterView({
             readOnly
             value={output}
           />
+          {previewNotice && (
+            <div className="text-xs text-gray-500">{previewNotice}</div>
+          )}
           <div className="flex flex-wrap gap-2 items-center">
             <Button size="sm" onClick={copyOutput}>Copy</Button>
             <input

--- a/view/OutputOptionsPanel.tsx
+++ b/view/OutputOptionsPanel.tsx
@@ -1,0 +1,132 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import type { OutputOptions } from '../model/jsonConverterTypes';
+
+interface Props {
+  options: OutputOptions;
+  onChange: (opts: OutputOptions) => void;
+}
+
+function OutputOptionsPanel({ options, onChange }: Props) {
+  const update = (partial: Partial<OutputOptions>) =>
+    onChange({ ...options, ...partial });
+
+  const delimiterOptions = [
+    { value: ',', label: 'Comma' },
+    { value: ';', label: 'Semicolon' },
+    { value: '|', label: 'Pipe' },
+    { value: '\t', label: 'Tab' },
+  ];
+
+  return (
+    <fieldset className="space-y-2 text-sm border p-2 rounded-md">
+      <legend className="font-semibold">Output Options</legend>
+      <label className="mr-2 block" htmlFor="delimiter">
+        Delimiter
+        <select
+          id="delimiter"
+          className="ml-2 border px-1 py-0.5 rounded dark:bg-gray-700 dark:text-gray-200"
+          value={options.delimiter}
+          onChange={(e) => update({ delimiter: e.target.value })}
+        >
+          {delimiterOptions.map((d) => (
+            <option key={d.value} value={d.value}>
+              {d.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="inline-flex items-center gap-1" htmlFor="includeHeader">
+        <input
+          id="includeHeader"
+          type="checkbox"
+          checked={options.includeHeader}
+          onChange={(e) => update({ includeHeader: e.target.checked })}
+        />
+        Include Header
+      </label>
+      <label className="inline-flex items-center gap-1" htmlFor="suppressNewlines">
+        <input
+          id="suppressNewlines"
+          type="checkbox"
+          checked={options.suppressNewlines}
+          onChange={(e) => update({ suppressNewlines: e.target.checked })}
+        />
+        Suppress Newlines
+      </label>
+      <label className="inline-flex items-center gap-1" htmlFor="flattenOpt">
+        <input
+          id="flattenOpt"
+          type="checkbox"
+          checked={options.flatten}
+          onChange={(e) => update({ flatten: e.target.checked })}
+        />
+        Flatten
+      </label>
+      <label className="inline-flex items-center gap-1" htmlFor="forceQuotes">
+        <input
+          id="forceQuotes"
+          type="checkbox"
+          checked={options.forceQuotes}
+          onChange={(e) => update({ forceQuotes: e.target.checked })}
+        />
+        Force Quotes
+      </label>
+      <label className="inline-flex items-center gap-1" htmlFor="upgradeToArray">
+        <input
+          id="upgradeToArray"
+          type="checkbox"
+          checked={options.upgradeToArray}
+          onChange={(e) => update({ upgradeToArray: e.target.checked })}
+        />
+        Upgrade To Array
+      </label>
+      <label className="inline-flex items-center gap-1" htmlFor="useAltMode">
+        <input
+          id="useAltMode"
+          type="checkbox"
+          checked={options.useAltMode}
+          onChange={(e) => update({ useAltMode: e.target.checked })}
+        />
+        Alternative Mode
+      </label>
+      <label className="block" htmlFor="objectPath">
+        <span className="mr-2">Object Path</span>
+        <input
+          id="objectPath"
+          type="text"
+          value={options.objectPath}
+          onChange={(e) => update({ objectPath: e.target.value })}
+          className="border px-1 py-0.5 rounded dark:bg-gray-700 dark:text-gray-200"
+        />
+      </label>
+      <label className="block" htmlFor="dateFormat">
+        <span className="mr-2">Date Format</span>
+        <input
+          id="dateFormat"
+          type="text"
+          value={options.dateFormat}
+          onChange={(e) => update({ dateFormat: e.target.value })}
+          className="border px-1 py-0.5 rounded dark:bg-gray-700 dark:text-gray-200"
+          placeholder="YYYY-MM-DD"
+        />
+      </label>
+      <label className="block" htmlFor="lineEndings">
+        <span className="mr-2">Line Endings</span>
+        <select
+          id="lineEndings"
+          value={options.eol}
+          onChange={(e) => update({ eol: e.target.value as 'LF' | 'CRLF' })}
+          className="border px-1 py-0.5 rounded dark:bg-gray-700 dark:text-gray-200"
+        >
+          <option value="LF">LF</option>
+          <option value="CRLF">CRLF</option>
+        </select>
+      </label>
+    </fieldset>
+  );
+};
+
+export default OutputOptionsPanel;

--- a/viewmodel/useJsonConverter.ts
+++ b/viewmodel/useJsonConverter.ts
@@ -1,0 +1,132 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { useState } from 'react';
+import {
+  convertJsonToCsv,
+  convertJsonToExcel,
+  fetchJsonFromUrl,
+  parseJson,
+} from '../model/jsonConverter';
+
+const EXAMPLE = [
+  { name: 'Alice', age: 30, city: 'NY' },
+  { name: 'Bob', age: 25, city: 'LA' },
+];
+
+export const useJsonConverter = () => {
+  const [input, setInput] = useState('');
+  const [url, setUrl] = useState('');
+  const [output, setOutput] = useState('');
+  const [flatten, setFlatten] = useState(false);
+  const [header, setHeader] = useState(true);
+  const [eol, setEol] = useState<'LF' | 'CRLF'>('LF');
+  const [filename, setFilename] = useState('data');
+  const [error, setError] = useState('');
+
+  const options = { flatten, header, eol: eol === 'LF' ? '\n' : '\r\n' } as const;
+
+  const format = () => {
+    try {
+      const data = parseJson(input);
+      setInput(JSON.stringify(data.length === 1 ? data[0] : data, null, 2));
+      setError('');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const clear = () => {
+    setInput('');
+    setOutput('');
+    setError('');
+  };
+
+  const loadExample = () => {
+    setInput(JSON.stringify(EXAMPLE, null, 2));
+    setError('');
+  };
+
+  const uploadFile = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = () => setInput(String(reader.result || ''));
+    reader.readAsText(file);
+  };
+
+  const fetchUrl = async () => {
+    try {
+      const text = await fetchJsonFromUrl(url);
+      setInput(text);
+      setError('');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const convert = () => {
+    try {
+      const csv = convertJsonToCsv(input, options);
+      setOutput(csv);
+      setError('');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const copyOutput = async () => {
+    if (!output) return;
+    await navigator.clipboard.writeText(output);
+  };
+
+  const downloadCsv = () => {
+    try {
+      const csv = convertJsonToCsv(input, options);
+      const blob = new Blob([csv], { type: 'text/csv' });
+      const urlObj = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = urlObj;
+      a.download = `${filename || 'data'}.csv`;
+      a.click();
+      URL.revokeObjectURL(urlObj);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const downloadExcel = () => {
+    try {
+      convertJsonToExcel(input, `${filename || 'data'}.xlsx`, { flatten });
+      setError('');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  return {
+    input,
+    setInput,
+    url,
+    setUrl,
+    output,
+    flatten,
+    setFlatten,
+    header,
+    setHeader,
+    eol,
+    setEol,
+    filename,
+    setFilename,
+    error,
+    format,
+    clear,
+    loadExample,
+    uploadFile,
+    fetchUrl,
+    convert,
+    copyOutput,
+    downloadCsv,
+    downloadExcel,
+  };
+};
+
+export default useJsonConverter;

--- a/viewmodel/useJsonConverter.ts
+++ b/viewmodel/useJsonConverter.ts
@@ -57,13 +57,16 @@ export const useJsonConverter = () => {
     return true;
   };
 
-  const parseAsync = (text: string, cb: (data: Record<string, unknown>[]) => void) => {
+  const parseAsync = (
+    text: string,
+    cb: (data: Record<string, unknown>[]) => void | Promise<void>,
+  ) => {
     if (!validateSize(text.length)) return;
     setLoading(true);
-    setTimeout(() => {
+    setTimeout(async () => {
       try {
         const data = parseJson(text);
-        cb(data);
+        await cb(data);
         setError('');
       } catch (e: unknown) {
         setError(e instanceof Error ? e.message : String(e));
@@ -145,8 +148,8 @@ export const useJsonConverter = () => {
   };
 
   const downloadExcel = () => {
-    parseAsync(input, (data) => {
-      exportToExcel(data, `${filename || 'data'}.xlsx`, {
+    parseAsync(input, async (data) => {
+      await exportToExcel(data, `${filename || 'data'}.xlsx`, {
         flatten: outputOptions.flatten,
         dateFormat: outputOptions.dateFormat || undefined,
       });


### PR DESCRIPTION
## Summary
- add JSON converter utilities for flattening JSON, CSV and Excel export
- implement viewmodel and view components for JSON Converter
- register new tool route and docs
- include tests for conversion logic
- install xlsx dependency

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686e0af19c108329b80946c3e458d3d5