### PR TITLE
Add sort option for tool listings

### DIFF
--- a/__tests__/utils.toolFilters.test.ts
+++ b/__tests__/utils.toolFilters.test.ts
@@ -1,0 +1,19 @@
+import { sortByTitle } from '../src/utils/toolFilters';
+
+describe('sortByTitle', () => {
+  const items = [
+    { title: 'Banana' },
+    { title: 'Apple' },
+    { title: 'Cherry' },
+  ];
+
+  test('sorts ascending by title', () => {
+    const sorted = sortByTitle(items, 'asc');
+    expect(sorted.map(i => i.title)).toEqual(['Apple', 'Banana', 'Cherry']);
+  });
+
+  test('sorts descending by title', () => {
+    const sorted = sortByTitle(items, 'desc');
+    expect(sorted.map(i => i.title)).toEqual(['Cherry', 'Banana', 'Apple']);
+  });
+});

--- a/src/utils/toolFilters.ts
+++ b/src/utils/toolFilters.ts
@@ -6,3 +6,14 @@ export interface Identifiable { id: string }
 export function excludeById<T extends Identifiable>(items: T[], exclude: T[]): T[] {
   return items.filter(item => !exclude.some(e => e.id === item.id));
 }
+
+export function sortByTitle<T extends { title: string }>(
+  items: T[],
+  order: 'asc' | 'desc' = 'asc'
+): T[] {
+  return [...items].sort((a, b) =>
+    order === 'asc'
+      ? a.title.localeCompare(b.title)
+      : b.title.localeCompare(a.title)
+  );
+}


### PR DESCRIPTION
## Summary
- allow tools on the home page to be ordered A–Z or Z–A
- add generic `sortByTitle` utility with unit tests

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Visible, non-interactive elements with click handlers must have at least one keyboard listener and other pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ae1278b648329a2e75644772ef712