### PR TITLE
fix: correct JSON compare placeholders

### DIFF
--- a/src/tools/json-compare/components/JsonComparePanel.tsx
+++ b/src/tools/json-compare/components/JsonComparePanel.tsx
@@ -1,3 +1,7 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
 import React, { ChangeEvent } from 'react';
 import type { UseJsonCompareVM } from '../hooks/useJsonCompare';
 import { Button, Card, CodeEditor } from '@design-system';
@@ -122,11 +126,23 @@ const JsonComparePanel: React.FC<UseJsonCompareVM> = ({
               </button>
             }
           />
-          <TextArea value={leftText} onChange={setLeftText} placeholder="{"} Enter or upload JSON..." error={leftError} onSubmit={onCompare} />
+          <TextArea
+            value={leftText}
+            onChange={setLeftText}
+            placeholder="{} Enter or upload JSON..."
+            error={leftError}
+            onSubmit={onCompare}
+          />
         </Card>
         <Card className="p-3">
           <EditorHeader title="Comparison JSON" onUpload={onUploadRight} />
-          <TextArea value={rightText} onChange={setRightText} placeholder="{"} Enter or upload JSON..." error={rightError} onSubmit={onCompare} />
+          <TextArea
+            value={rightText}
+            onChange={setRightText}
+            placeholder="{} Enter or upload JSON..."
+            error={rightError}
+            onSubmit={onCompare}
+          />
         </Card>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- fix JSON Compare panel placeholders to use string literal and add license header

## Testing
- `pnpm build:vercel`
- `npx eslint src/tools/json-compare/components/JsonComparePanel.tsx`
- `pnpm lint` *(fails: existing repo lint errors)*
- `pnpm typecheck` *(fails: Cannot find types and other errors)*
- `pnpm test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_689b6cb866508329bdaa4582ad19523b