### PR TITLE
feat(qrscan): mobile-first AR scanner with live engine HUD

### DIFF
--- a/__tests__/tools.qrscan.controller.test.ts
+++ b/__tests__/tools.qrscan.controller.test.ts
@@ -256,7 +256,7 @@ describe('startScanner', () => {
       decodeMs: 4,
     });
 
-    expect(onResult).toHaveBeenCalledWith('https://example.com', 'BarcodeDetector');
+    expect(onResult).toHaveBeenCalledWith('https://example.com', 'BarcodeDetector', 4);
     handle.stop();
   });
 
@@ -277,6 +277,46 @@ describe('startScanner', () => {
     raf.flush(1);
 
     expect(worker.posts.map((p) => p.runLevel)).toEqual(['fast', 'medium', 'full']);
+    handle.stop();
+  });
+
+  test('fires onDecodeAttempt for both hits and misses with runLevel + canvas size', async () => {
+    const worker = createFakeWorker();
+    const onDecodeAttempt = jest.fn();
+    const video = createFakeVideo(800, 600);
+
+    const handle = await startScanner({
+      video,
+      onResult: jest.fn(),
+      onDecodeAttempt,
+      initialWidth: 640,
+      workerFactory: () => worker as unknown as Worker,
+    });
+
+    raf.flush(1);
+    worker.reply({ jobId: worker.posts[0].jobId, result: null, decodeMs: 7 });
+
+    raf.flush(1);
+    worker.reply({
+      jobId: worker.posts[1].jobId,
+      result: { text: 'HI', engine: 'jsQR-fast' },
+      decodeMs: 12,
+    });
+
+    expect(onDecodeAttempt).toHaveBeenCalledTimes(2);
+    expect(onDecodeAttempt.mock.calls[0][0]).toMatchObject({
+      matched: false,
+      engine: null,
+      decodeMs: 7,
+      runLevel: 'fast',
+      canvasWidth: 640,
+    });
+    expect(onDecodeAttempt.mock.calls[1][0]).toMatchObject({
+      matched: true,
+      engine: 'jsQR-fast',
+      decodeMs: 12,
+      runLevel: 'medium',
+    });
     handle.stop();
   });
 

--- a/__tests__/tools.qrscan.performance.test.ts
+++ b/__tests__/tools.qrscan.performance.test.ts
@@ -1,0 +1,67 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import {
+  createEmptyPerformance,
+  mergeAttempt,
+} from '../src/tools/qrscan/hooks/useQrscan';
+import type { DecodeAttemptMeta } from '../src/tools/qrscan/lib/qrscan';
+
+const attempt = (overrides: Partial<DecodeAttemptMeta> = {}): DecodeAttemptMeta => ({
+  engine: 'BarcodeDetector',
+  matched: true,
+  decodeMs: 5,
+  runLevel: 'fast',
+  canvasWidth: 640,
+  canvasHeight: 480,
+  ...overrides,
+});
+
+describe('mergeAttempt', () => {
+  test('populates last-attempt fields', () => {
+    const next = mergeAttempt(createEmptyPerformance(), attempt({ decodeMs: 12 }));
+    expect(next.lastEngine).toBe('BarcodeDetector');
+    expect(next.lastDecodeMs).toBe(12);
+    expect(next.lastRunLevel).toBe('fast');
+    expect(next.lastCanvasSize).toEqual({ width: 640, height: 480 });
+    expect(next.attempts).toBe(1);
+    expect(next.hits).toBe(1);
+  });
+
+  test('computes rolling averages per engine', () => {
+    let perf = createEmptyPerformance();
+    perf = mergeAttempt(perf, attempt({ engine: 'jsQR-fast', decodeMs: 10 }));
+    perf = mergeAttempt(perf, attempt({ engine: 'jsQR-fast', decodeMs: 20 }));
+    perf = mergeAttempt(perf, attempt({ engine: 'jsQR-fast', decodeMs: 30 }));
+    expect(perf.engines['jsQR-fast'].hits).toBe(3);
+    expect(perf.engines['jsQR-fast'].averageDecodeMs).toBeCloseTo(20, 5);
+    expect(perf.engines['jsQR-fast'].lastDecodeMs).toBe(30);
+  });
+
+  test('picks winningEngine by hit count, tie-broken by avg latency', () => {
+    let perf = createEmptyPerformance();
+    perf = mergeAttempt(perf, attempt({ engine: 'BarcodeDetector', decodeMs: 5 }));
+    perf = mergeAttempt(perf, attempt({ engine: 'BarcodeDetector', decodeMs: 5 }));
+    perf = mergeAttempt(perf, attempt({ engine: 'jsQR-fast', decodeMs: 15 }));
+    perf = mergeAttempt(perf, attempt({ engine: 'jsQR-fast', decodeMs: 15 }));
+    expect(perf.winningEngine).toBe('BarcodeDetector'); // same hits, lower avg wins
+  });
+
+  test('ignores misses for engine hit counts but still increments global attempts', () => {
+    let perf = createEmptyPerformance();
+    perf = mergeAttempt(perf, attempt({ engine: null, matched: false, decodeMs: 8 }));
+    perf = mergeAttempt(perf, attempt({ engine: null, matched: false, decodeMs: 9 }));
+    expect(perf.attempts).toBe(2);
+    expect(perf.hits).toBe(0);
+    expect(perf.winningEngine).toBeNull();
+    expect(perf.averageDecodeMs).toBeCloseTo(8.5, 5);
+  });
+
+  test('uses decodeMs of missed attempts in global average but not in engine averages', () => {
+    let perf = createEmptyPerformance();
+    perf = mergeAttempt(perf, attempt({ engine: 'jsQR-fast', matched: true, decodeMs: 10 }));
+    perf = mergeAttempt(perf, attempt({ engine: null, matched: false, decodeMs: 40 }));
+    expect(perf.engines['jsQR-fast'].averageDecodeMs).toBe(10);
+    expect(perf.averageDecodeMs).toBeCloseTo(25, 5);
+  });
+});

--- a/src/tools/qrscan/components/ARScannerView.css
+++ b/src/tools/qrscan/components/ARScannerView.css
@@ -1,0 +1,51 @@
+@keyframes scanline {
+  0% {
+    transform: translateY(0);
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  50% {
+    transform: translateY(calc(72vw - 0.5rem));
+    opacity: 1;
+  }
+  52% {
+    transform: translateY(calc(72vw - 0.5rem));
+    opacity: 0.1;
+  }
+  90% {
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 0;
+  }
+}
+
+@media (min-width: 640px) {
+  @keyframes scanline {
+    0% {
+      transform: translateY(0);
+      opacity: 0;
+    }
+    10% {
+      opacity: 1;
+    }
+    50% {
+      transform: translateY(340px);
+      opacity: 1;
+    }
+    52% {
+      transform: translateY(340px);
+      opacity: 0.1;
+    }
+    90% {
+      opacity: 0;
+    }
+    100% {
+      transform: translateY(0);
+      opacity: 0;
+    }
+  }
+}

--- a/src/tools/qrscan/components/ARScannerView.tsx
+++ b/src/tools/qrscan/components/ARScannerView.tsx
@@ -1,0 +1,524 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ *
+ * ARScannerView — fullscreen, mobile-first QR scanner UI.
+ *
+ * Design:
+ *   - Camera fills the viewport (object-cover).
+ *   - A translucent scrim with a center "window" forms the scan target reticle.
+ *   - Animated scan-line sweeps inside the reticle while scanning.
+ *   - Top bar: close, flip camera, torch.
+ *   - Bottom sheet: performance HUD (engine winner, decode ms, FPS, history).
+ *   - When a QR is decoded, a floating result card pops up with contextual
+ *     actions: open URL, copy, open map, add to wallet/contact, etc.
+ */
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import clsx from 'clsx';
+import type {
+  EngineStat,
+  ScanPerformance,
+  ScanRecord,
+  UseQrscanReturn,
+} from '../hooks/useQrscan';
+import './ARScannerView.css';
+
+type Props = UseQrscanReturn;
+
+const formatMs = (value: number | null | undefined): string => {
+  if (value === null || value === undefined || !Number.isFinite(value)) return '—';
+  if (value < 1) return '<1 ms';
+  if (value < 10) return `${value.toFixed(1)} ms`;
+  return `${Math.round(value)} ms`;
+};
+
+const formatCount = (value: number): string => {
+  if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
+  return String(value);
+};
+
+const detectAction = (text: string): { kind: 'url' | 'tel' | 'mailto' | 'sms' | 'wifi' | 'geo' | 'text'; primary: string; href?: string } => {
+  const v = text.trim();
+  const lower = v.toLowerCase();
+  if (lower.startsWith('http://') || lower.startsWith('https://')) return { kind: 'url', primary: 'Open link', href: v };
+  if (lower.startsWith('tel:')) return { kind: 'tel', primary: 'Call', href: v };
+  if (lower.startsWith('mailto:')) return { kind: 'mailto', primary: 'Send email', href: v };
+  if (lower.startsWith('smsto:')) return { kind: 'sms', primary: 'Send SMS', href: `sms:${v.slice(6).replace(/:.*/, '')}` };
+  if (lower.startsWith('sms:')) return { kind: 'sms', primary: 'Send SMS', href: v };
+  if (lower.startsWith('geo:')) return { kind: 'geo', primary: 'Open map', href: v };
+  if (lower.startsWith('wifi:')) return { kind: 'wifi', primary: 'Copy Wi-Fi details' };
+  return { kind: 'text', primary: 'Copy text' };
+};
+
+const ENGINE_COLORS: Record<string, string> = {
+  BarcodeDetector: 'bg-emerald-500/90 text-emerald-50',
+  'jsQR-fast': 'bg-sky-500/90 text-sky-50',
+  'jsQR-deep': 'bg-amber-500/90 text-amber-50',
+};
+
+const ENGINE_DESCRIPTION: Record<string, string> = {
+  BarcodeDetector: 'Native · GPU-accelerated',
+  'jsQR-fast': 'jsQR · no-inversion pass',
+  'jsQR-deep': 'jsQR · inverted QR pass',
+};
+
+const TopButton: React.FC<{
+  label: string;
+  onClick: () => void;
+  active?: boolean;
+  disabled?: boolean;
+  children: React.ReactNode;
+}> = ({ label, onClick, active, disabled, children }) => (
+  <button
+    type="button"
+    aria-label={label}
+    disabled={disabled}
+    onClick={onClick}
+    className={clsx(
+      'h-12 w-12 rounded-full border border-white/20 backdrop-blur-md',
+      'flex items-center justify-center text-xl text-white transition',
+      'active:scale-95 disabled:opacity-40',
+      active ? 'bg-yellow-300/90 text-slate-900' : 'bg-black/40 hover:bg-black/60',
+    )}
+  >
+    {children}
+  </button>
+);
+
+const Reticle: React.FC<{ scanning: boolean }> = ({ scanning }) => (
+  <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+    <div className="relative aspect-square w-[72vw] max-w-[360px]">
+      <div className="absolute inset-0 rounded-3xl shadow-[0_0_0_9999px_rgba(0,0,0,0.55)]" />
+      <div className="absolute inset-0 rounded-3xl border border-white/20" />
+      <span className="absolute -top-1 -left-1 h-8 w-8 rounded-tl-2xl border-t-4 border-l-4 border-emerald-300" />
+      <span className="absolute -top-1 -right-1 h-8 w-8 rounded-tr-2xl border-t-4 border-r-4 border-emerald-300" />
+      <span className="absolute -bottom-1 -left-1 h-8 w-8 rounded-bl-2xl border-b-4 border-l-4 border-emerald-300" />
+      <span className="absolute -bottom-1 -right-1 h-8 w-8 rounded-br-2xl border-b-4 border-r-4 border-emerald-300" />
+      {scanning && (
+        <span
+          aria-hidden
+          className="absolute inset-x-2 top-0 h-0.5 animate-[scanline_1.8s_ease-in-out_infinite] rounded-full bg-gradient-to-r from-transparent via-emerald-300 to-transparent shadow-[0_0_16px_rgba(110,231,183,0.8)]"
+        />
+      )}
+    </div>
+  </div>
+);
+
+const EngineChip: React.FC<{ stat: EngineStat; winner: boolean }> = ({ stat, winner }) => (
+  <div
+    className={clsx(
+      'flex flex-col rounded-xl border px-3 py-2',
+      winner ? 'border-yellow-300 bg-yellow-300/10' : 'border-white/10 bg-white/5',
+    )}
+  >
+    <div className="flex items-center justify-between text-[11px] uppercase tracking-wide text-white/70">
+      <span>{stat.engine}</span>
+      {winner && <span className="text-yellow-300">★ winner</span>}
+    </div>
+    <div className="mt-1 text-sm font-semibold text-white">
+      {formatCount(stat.hits)} hit{stat.hits === 1 ? '' : 's'}
+    </div>
+    <div className="text-[11px] text-white/60">
+      avg {formatMs(stat.averageDecodeMs)} · last {formatMs(stat.lastDecodeMs)}
+    </div>
+  </div>
+);
+
+const PerformanceHUD: React.FC<{ performance: ScanPerformance; scanning: boolean }> = ({
+  performance: perf,
+  scanning,
+}) => (
+  <div className="rounded-2xl border border-white/10 bg-black/50 p-4 text-white backdrop-blur-lg">
+    <div className="flex items-center justify-between">
+      <div className="text-xs uppercase tracking-widest text-white/60">
+        {scanning ? 'Live performance' : 'Last session'}
+      </div>
+      <div className="flex items-center gap-2 text-sm">
+        <span
+          className={clsx(
+            'inline-block h-2 w-2 rounded-full',
+            scanning ? 'animate-pulse bg-emerald-400' : 'bg-slate-500',
+          )}
+        />
+        {scanning ? 'scanning' : 'idle'}
+      </div>
+    </div>
+    <div className="mt-3 grid grid-cols-3 gap-3 text-center">
+      <div>
+        <div className="text-2xl font-bold">{formatMs(perf.lastDecodeMs)}</div>
+        <div className="text-[11px] uppercase tracking-wide text-white/60">Last decode</div>
+      </div>
+      <div>
+        <div className="text-2xl font-bold">{perf.scansPerSecond ?? '—'}</div>
+        <div className="text-[11px] uppercase tracking-wide text-white/60">Scans / sec</div>
+      </div>
+      <div>
+        <div className="text-2xl font-bold">{formatCount(perf.hits)}</div>
+        <div className="text-[11px] uppercase tracking-wide text-white/60">Total hits</div>
+      </div>
+    </div>
+    <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-3">
+      {(Object.values(perf.engines) as EngineStat[]).map((stat) => (
+        <EngineChip key={stat.engine} stat={stat} winner={perf.winningEngine === stat.engine} />
+      ))}
+    </div>
+    {perf.winningEngine && (
+      <div className="mt-3 rounded-lg bg-white/5 px-3 py-2 text-xs text-white/80">
+        <span className="font-semibold">{perf.winningEngine}</span> is winning —{' '}
+        {ENGINE_DESCRIPTION[perf.winningEngine]}
+      </div>
+    )}
+  </div>
+);
+
+const ResultCard: React.FC<{
+  text: string;
+  format: string;
+  engine: string | null;
+  decodeMs: number | null;
+  onCopy: () => void;
+  onClear: () => void;
+}> = ({ text, format, engine, decodeMs, onCopy, onClear }) => {
+  const action = useMemo(() => detectAction(text), [text]);
+  const isLink = Boolean(action.href);
+
+  return (
+    <div className="rounded-2xl border border-emerald-300/40 bg-slate-900/90 p-4 text-white shadow-2xl backdrop-blur-lg">
+      <div className="flex items-center gap-2 text-[11px] uppercase tracking-widest text-emerald-300">
+        <span
+          className={clsx(
+            'inline-block rounded-full px-2 py-0.5',
+            engine ? ENGINE_COLORS[engine] ?? 'bg-white/10' : 'bg-white/10',
+          )}
+        >
+          {engine ?? format}
+        </span>
+        {decodeMs !== null && <span className="text-white/60">{formatMs(decodeMs)}</span>}
+      </div>
+      <div className="mt-2 max-h-32 overflow-auto break-all text-sm">{text}</div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {isLink && (
+          <a
+            href={action.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex-1 rounded-xl bg-emerald-400 px-4 py-3 text-center text-sm font-semibold text-slate-900 transition active:scale-95"
+          >
+            {action.primary} →
+          </a>
+        )}
+        <button
+          type="button"
+          onClick={onCopy}
+          className="flex-1 rounded-xl border border-white/20 bg-white/5 px-4 py-3 text-sm font-semibold text-white transition active:scale-95"
+        >
+          Copy
+        </button>
+        <button
+          type="button"
+          onClick={onClear}
+          aria-label="Dismiss result"
+          className="rounded-xl border border-white/20 bg-white/5 px-4 py-3 text-sm font-semibold text-white transition active:scale-95"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const HistoryList: React.FC<{
+  history: ScanRecord[];
+  onOpen: (text: string) => void;
+  onRemove: (id: string) => void;
+  onClear: () => void;
+}> = ({ history, onOpen, onRemove, onClear }) => {
+  if (history.length === 0) {
+    return (
+      <div className="rounded-xl border border-white/10 bg-white/5 p-4 text-center text-sm text-white/60">
+        No scans yet. Point the camera at a QR code.
+      </div>
+    );
+  }
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-xs uppercase tracking-wide text-white/60">
+          Recent ({history.length})
+        </span>
+        <button
+          type="button"
+          onClick={onClear}
+          className="text-xs text-white/60 underline-offset-2 hover:text-white hover:underline"
+        >
+          Clear
+        </button>
+      </div>
+      <ul className="divide-y divide-white/10 rounded-xl border border-white/10 bg-white/5">
+        {history.slice(0, 5).map((record) => (
+          <li key={record.id} className="flex items-center gap-2 px-3 py-2 text-sm">
+            <button
+              type="button"
+              onClick={() => onOpen(record.text)}
+              className="flex-1 truncate text-left text-white/90 hover:text-white"
+            >
+              {record.text}
+            </button>
+            <span className="text-[11px] uppercase text-white/40">{record.type}</span>
+            <button
+              type="button"
+              aria-label="Remove entry"
+              onClick={() => onRemove(record.id)}
+              className="text-white/40 hover:text-white"
+            >
+              ×
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+const ARScannerView: React.FC<Props> = ({
+  videoRef,
+  start,
+  stop,
+  flip,
+  scanning,
+  isBusy,
+  canFlip,
+  cameraStatus,
+  cameraPermission,
+  error,
+  clearError,
+  result,
+  format,
+  clearResult,
+  torch,
+  performance: perf,
+  scanHistory,
+  removeHistoryEntry,
+  clearHistory,
+  scanFromFile,
+  processManualText,
+}) => {
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [manualText, setManualText] = useState('');
+
+  const lastEngine = perf.lastEngine;
+  const lastDecodeMs = perf.lastDecodeMs;
+
+  useEffect(() => {
+    if (!result) return;
+    setCopied(false);
+  }, [result]);
+
+  const copyResult = useCallback(async () => {
+    if (!result) return;
+    try {
+      await navigator.clipboard.writeText(result);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch {
+      // ignore — most likely insecure context
+    }
+  }, [result]);
+
+  const onFileChange = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (file) {
+        await scanFromFile(file);
+        event.target.value = '';
+      }
+    },
+    [scanFromFile],
+  );
+
+  const statusLabel = useMemo(() => {
+    if (cameraStatus === 'initializing') return 'Starting camera…';
+    if (cameraStatus === 'blocked' || cameraPermission === 'denied') return 'Camera permission needed';
+    if (cameraStatus === 'no-device') return 'No camera found on this device';
+    if (cameraStatus === 'error') return 'Camera error — tap to retry';
+    if (!scanning) return 'Tap Start to scan';
+    return 'Point the camera at a QR code';
+  }, [cameraPermission, cameraStatus, scanning]);
+
+  return (
+    <div className="relative isolate overflow-hidden rounded-3xl bg-black text-white">
+      {/* Camera surface */}
+      <div className="relative h-[78vh] min-h-[520px] w-full overflow-hidden">
+        <video
+          ref={videoRef}
+          muted
+          playsInline
+          autoPlay
+          className="absolute inset-0 h-full w-full object-cover"
+        />
+        {!scanning && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 bg-slate-950/80 p-6 text-center">
+            <div className="text-4xl">📷</div>
+            <div className="max-w-xs text-sm text-white/70">{statusLabel}</div>
+            <button
+              type="button"
+              disabled={isBusy || cameraStatus === 'no-device'}
+              onClick={() => void start()}
+              className="rounded-full bg-emerald-400 px-6 py-3 text-sm font-semibold text-slate-900 transition active:scale-95 disabled:opacity-40"
+            >
+              {isBusy ? 'Starting…' : 'Start camera'}
+            </button>
+          </div>
+        )}
+
+        {scanning && <Reticle scanning={scanning} />}
+
+        {/* Top controls */}
+        <div className="absolute inset-x-0 top-0 flex items-center justify-between gap-2 p-4 pt-[max(env(safe-area-inset-top),0.75rem)]">
+          <TopButton label={scanning ? 'Stop camera' : 'Camera idle'} onClick={scanning ? stop : () => void start()}>
+            {scanning ? '✕' : '▶'}
+          </TopButton>
+          <div className="flex items-center gap-2 rounded-full border border-white/15 bg-black/40 px-3 py-1.5 text-xs backdrop-blur-md">
+            <span
+              className={clsx(
+                'h-2 w-2 rounded-full',
+                scanning ? 'animate-pulse bg-emerald-400' : 'bg-white/50',
+              )}
+            />
+            {statusLabel}
+          </div>
+          <div className="flex gap-2">
+            {torch.available && (
+              <TopButton label="Toggle torch" onClick={() => void torch.toggle()} active={torch.enabled}>
+                ⚡
+              </TopButton>
+            )}
+            <TopButton label="Flip camera" onClick={() => void flip()} disabled={!canFlip}>
+              ⇆
+            </TopButton>
+          </div>
+        </div>
+
+        {/* Live HUD (compact) */}
+        {scanning && (
+          <div className="absolute bottom-[max(env(safe-area-inset-bottom),1rem)] left-1/2 -translate-x-1/2 rounded-full border border-white/15 bg-black/60 px-4 py-1.5 text-xs font-mono backdrop-blur-md">
+            {lastEngine ? (
+              <span className="text-emerald-300">{lastEngine}</span>
+            ) : (
+              <span className="text-white/60">scanning…</span>
+            )}
+            <span className="mx-2 text-white/30">·</span>
+            <span>{formatMs(lastDecodeMs)}</span>
+            <span className="mx-2 text-white/30">·</span>
+            <span>{perf.scansPerSecond ?? 0}/s</span>
+          </div>
+        )}
+
+        {/* Result card */}
+        {result && (
+          <div className="absolute inset-x-4 bottom-[max(env(safe-area-inset-bottom),1.25rem)] sm:inset-x-6">
+            <ResultCard
+              text={result}
+              format={format}
+              engine={lastEngine}
+              decodeMs={lastDecodeMs}
+              onCopy={copyResult}
+              onClear={clearResult}
+            />
+            {copied && (
+              <div className="mt-2 text-center text-xs text-emerald-300">Copied to clipboard</div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Bottom sheet trigger */}
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => setSheetOpen((prev) => !prev)}
+          aria-expanded={sheetOpen}
+          className="flex w-full items-center justify-between gap-2 border-t border-white/10 bg-slate-900/80 px-4 py-3 text-sm text-white"
+        >
+          <span>
+            <strong>Performance & history</strong>
+            <span className="ml-2 text-white/60">
+              {perf.hits} hits · winner:{' '}
+              {perf.winningEngine ?? '—'}
+            </span>
+          </span>
+          <span className="text-white/60">{sheetOpen ? '▾' : '▸'}</span>
+        </button>
+
+        {sheetOpen && (
+          <div className="space-y-4 bg-slate-900/95 p-4">
+            <PerformanceHUD performance={perf} scanning={scanning} />
+
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-white">
+              <div className="mb-2 text-xs uppercase tracking-widest text-white/60">Scan an image</div>
+              <input
+                type="file"
+                accept="image/*"
+                onChange={onFileChange}
+                className="block w-full text-sm file:mr-3 file:rounded-lg file:border-0 file:bg-emerald-400 file:px-3 file:py-2 file:text-sm file:font-semibold file:text-slate-900"
+              />
+            </div>
+
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-white">
+              <div className="mb-2 text-xs uppercase tracking-widest text-white/60">Paste text</div>
+              <div className="flex gap-2">
+                <input
+                  value={manualText}
+                  onChange={(event) => setManualText(event.target.value)}
+                  placeholder="Paste QR content..."
+                  className="flex-1 rounded-lg border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-white placeholder:text-white/40"
+                />
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (manualText.trim()) {
+                      processManualText(manualText);
+                      setManualText('');
+                    }
+                  }}
+                  className="rounded-lg bg-emerald-400 px-4 py-2 text-sm font-semibold text-slate-900 disabled:opacity-40"
+                  disabled={!manualText.trim()}
+                >
+                  Record
+                </button>
+              </div>
+            </div>
+
+            <HistoryList
+              history={scanHistory}
+              onOpen={(text) => {
+                const action = detectAction(text);
+                if (action.href) window.open(action.href, '_blank', 'noopener');
+              }}
+              onRemove={removeHistoryEntry}
+              onClear={clearHistory}
+            />
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <div className="absolute inset-x-4 top-20 rounded-xl border border-red-400/40 bg-red-950/80 p-3 text-sm text-red-100 backdrop-blur-md">
+          <div className="flex items-start gap-2">
+            <span>{error}</span>
+            <button
+              type="button"
+              onClick={clearError}
+              aria-label="Dismiss error"
+              className="ml-auto text-red-200"
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ARScannerView;

--- a/src/tools/qrscan/hooks/useQrscan.ts
+++ b/src/tools/qrscan/hooks/useQrscan.ts
@@ -1,5 +1,5 @@
 /**
- * ? 2025 MyDebugger Contributors – MIT License
+ * ? 2025 MyDebugger Contributors ï¿½ MIT License
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { IScannerControls } from '@zxing/browser';
@@ -13,6 +13,8 @@ import {
   startQrScan,
   stopQrScan,
   toggleTorch as toggleTorchOnTrack,
+  type DecodeAttemptMeta,
+  type DecodeEngineName,
   type VideoDevice,
 } from '../lib/qrscan';
 
@@ -45,6 +47,96 @@ export interface SessionStats {
   averageIntervalMs: number | null;
   lastScanAgoMs: number | null;
 }
+
+export interface EngineStat {
+  engine: DecodeEngineName;
+  hits: number;
+  attempts: number;
+  lastDecodeMs: number | null;
+  averageDecodeMs: number | null;
+}
+
+export interface ScanPerformance {
+  lastEngine: DecodeEngineName | null;
+  lastDecodeMs: number | null;
+  lastRunLevel: DecodeAttemptMeta['runLevel'] | null;
+  lastCanvasSize: { width: number; height: number } | null;
+  attempts: number;
+  hits: number;
+  averageDecodeMs: number | null;
+  scansPerSecond: number | null;
+  engines: Record<DecodeEngineName, EngineStat>;
+  winningEngine: DecodeEngineName | null;
+}
+
+export const EMPTY_ENGINE_STAT = (engine: DecodeEngineName): EngineStat => ({
+  engine,
+  hits: 0,
+  attempts: 0,
+  lastDecodeMs: null,
+  averageDecodeMs: null,
+});
+
+export const createEmptyPerformance = (): ScanPerformance => ({
+  lastEngine: null,
+  lastDecodeMs: null,
+  lastRunLevel: null,
+  lastCanvasSize: null,
+  attempts: 0,
+  hits: 0,
+  averageDecodeMs: null,
+  scansPerSecond: null,
+  engines: {
+    BarcodeDetector: EMPTY_ENGINE_STAT('BarcodeDetector'),
+    'jsQR-fast': EMPTY_ENGINE_STAT('jsQR-fast'),
+    'jsQR-deep': EMPTY_ENGINE_STAT('jsQR-deep'),
+  },
+  winningEngine: null,
+});
+
+export const mergeAttempt = (
+  previous: ScanPerformance,
+  meta: DecodeAttemptMeta,
+): ScanPerformance => {
+  const attempts = previous.attempts + 1;
+  const hits = previous.hits + (meta.matched ? 1 : 0);
+  const prevAvg = previous.averageDecodeMs ?? 0;
+  const averageDecodeMs = (prevAvg * previous.attempts + meta.decodeMs) / attempts;
+
+  const engines = { ...previous.engines };
+  const key = meta.engine;
+  if (key) {
+    const bucket = engines[key] ?? EMPTY_ENGINE_STAT(key);
+    const engineAttempts = bucket.attempts + 1;
+    const engineHits = bucket.hits + (meta.matched ? 1 : 0);
+    const prevEngineAvg = bucket.averageDecodeMs ?? 0;
+    engines[key] = {
+      engine: key,
+      attempts: engineAttempts,
+      hits: engineHits,
+      lastDecodeMs: meta.decodeMs,
+      averageDecodeMs: (prevEngineAvg * bucket.attempts + meta.decodeMs) / engineAttempts,
+    };
+  }
+
+  const winningEngine = (Object.values(engines) as EngineStat[])
+    .filter((stat) => stat.hits > 0)
+    .sort((a, b) => b.hits - a.hits || (a.averageDecodeMs ?? Infinity) - (b.averageDecodeMs ?? Infinity))[0]?.engine ?? null;
+
+  return {
+    ...previous,
+    lastEngine: meta.engine ?? previous.lastEngine,
+    lastDecodeMs: meta.decodeMs,
+    lastRunLevel: meta.runLevel,
+    lastCanvasSize: { width: meta.canvasWidth, height: meta.canvasHeight },
+    attempts,
+    hits,
+    averageDecodeMs,
+    engines,
+    winningEngine,
+    scansPerSecond: previous.scansPerSecond,
+  };
+};
 
 export interface UseQrscanReturn {
   videoRef: React.RefObject<HTMLVideoElement>;
@@ -96,6 +188,7 @@ export interface UseQrscanReturn {
     available: boolean;
     set: (value: number) => Promise<void>;
   };
+  performance: ScanPerformance;
   scanFromFile: (file: File) => Promise<void>;
   processManualText: (text: string) => void;
 }
@@ -228,6 +321,8 @@ const useQrscan = (): UseQrscanReturn => {
   const [torchAvailable, setTorchAvailable] = useState(false);
   const [zoomValue, setZoomValue] = useState(1);
   const [zoomCapability, setZoomCapability] = useState<{ min: number; max: number; step: number } | null>(null);
+  const [performance, setPerformance] = useState<ScanPerformance>(() => createEmptyPerformance());
+  const attemptTimesRef = useRef<number[]>([]);
 
   const historyRef = useRef<ScanRecord[]>([]);
   useEffect(() => {
@@ -448,6 +543,24 @@ const useQrscan = (): UseQrscanReturn => {
     }
   }, [continuousMode, processDecodedValue, stop]);
 
+  const handleDecodeAttempt = useCallback((meta: DecodeAttemptMeta) => {
+    setPerformance((previous) => mergeAttempt(previous, meta));
+    const now = Date.now();
+    const times = attemptTimesRef.current;
+    times.push(now);
+    const cutoff = now - 2000;
+    while (times.length > 0 && times[0] < cutoff) times.shift();
+    setPerformance((previous) => ({
+      ...previous,
+      scansPerSecond: times.length > 0 ? Math.round((times.length / 2) * 10) / 10 : 0,
+    }));
+  }, []);
+
+  const resetPerformance = useCallback(() => {
+    attemptTimesRef.current = [];
+    setPerformance(createEmptyPerformance());
+  }, []);
+
   const startInternal = useCallback(async (cameraOverride?: string) => {
     if (!isBrowser) return;
     const video = videoRef.current;
@@ -471,8 +584,13 @@ const useQrscan = (): UseQrscanReturn => {
     stopQrScan(controlsRef.current);
     controlsRef.current = undefined;
 
+    resetPerformance();
     try {
-      controlsRef.current = await startQrScan(video, handleCameraResult, cameraId || undefined, true);
+      controlsRef.current = await startQrScan(
+        video,
+        (text, format) => handleCameraResult(text, format),
+        { deviceId: cameraId || undefined, onDecodeAttempt: handleDecodeAttempt },
+      );
       setScanning(true);
       setCameraStatus('ready');
       updateCapabilities();
@@ -484,7 +602,15 @@ const useQrscan = (): UseQrscanReturn => {
     } finally {
       setIsBusy(false);
     }
-  }, [cameraPermission, devices, handleCameraResult, selectedCamera, updateCapabilities]);
+  }, [
+    cameraPermission,
+    devices,
+    handleCameraResult,
+    handleDecodeAttempt,
+    resetPerformance,
+    selectedCamera,
+    updateCapabilities,
+  ]);
 
   const start = useCallback(async () => {
     await startInternal();
@@ -676,6 +802,7 @@ const useQrscan = (): UseQrscanReturn => {
     setFilterDuplicates,
     torch,
     zoom,
+    performance,
     scanFromFile,
     processManualText,
   };

--- a/src/tools/qrscan/lib/qrscan.ts
+++ b/src/tools/qrscan/lib/qrscan.ts
@@ -11,8 +11,15 @@
 import { BrowserMultiFormatReader, BrowserQRCodeReader, type IScannerControls } from '@zxing/browser';
 import type { Result } from '@zxing/library';
 
+import {
+  startScanner,
+  type DecodeAttemptMeta,
+  type ScannerHandle,
+} from './scannerController';
+
+export type { DecodeAttemptMeta } from './scannerController';
+export type { DecodeEngineName } from './qrCascade';
 import type { DecodeEngineName } from './qrCascade';
-import { startScanner, type ScannerHandle } from './scannerController';
 
 export type VideoDevice = MediaDeviceInfo;
 
@@ -42,19 +49,35 @@ export const listVideoInputDevices = async (): Promise<VideoDevice[]> =>
 
 const formatForEngine = (engine: DecodeEngineName): string => `${DEFAULT_FORMAT}:${engine}`;
 
+export interface StartQrScanOptions {
+  deviceId?: string;
+  /** Retained for API compatibility — camera path is QR-only; non-QR formats
+   * are still handled by {@link decodeFile}. */
+  enableMultiFormat?: boolean;
+  /** Fires after every worker reply (hit or miss) — use for a live HUD. */
+  onDecodeAttempt?: (meta: DecodeAttemptMeta) => void;
+  onError?: (error: Error) => void;
+}
+
 export const startQrScan = async (
   video: HTMLVideoElement,
-  onResult: (text: string, format?: string) => void,
-  deviceId?: string,
-  // Retained for API compatibility — the worker cascade is QR-only. Multi-format
-  // decoding remains available through `decodeFile` for uploaded images.
+  onResult: (text: string, format: string, decodeMs: number) => void,
+  deviceIdOrOptions?: string | StartQrScanOptions,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   enableMultiFormat: boolean = true,
 ): Promise<IScannerControls> => {
+  const options: StartQrScanOptions =
+    typeof deviceIdOrOptions === 'string' || deviceIdOrOptions === undefined
+      ? { deviceId: deviceIdOrOptions }
+      : deviceIdOrOptions;
+
   const handle: ScannerHandle = await startScanner({
     video,
-    deviceId,
-    onResult: (text, engine) => onResult(text, formatForEngine(engine)),
+    deviceId: options.deviceId,
+    onDecodeAttempt: options.onDecodeAttempt,
+    onError: options.onError,
+    onResult: (text, engine, decodeMs) =>
+      onResult(text, formatForEngine(engine), decodeMs),
   });
 
   return {

--- a/src/tools/qrscan/lib/scannerController.ts
+++ b/src/tools/qrscan/lib/scannerController.ts
@@ -24,10 +24,22 @@ import {
 import type { DecodeRequest, DecodeResponse } from './qr.worker';
 import { createDefaultQrWorker } from './defaultQrWorker';
 
+export interface DecodeAttemptMeta {
+  /** Engine that produced the hit, or null if every engine missed. */
+  engine: DecodeEngineName | null;
+  matched: boolean;
+  decodeMs: number;
+  runLevel: RunLevel;
+  canvasWidth: number;
+  canvasHeight: number;
+}
+
 export interface ScannerStartOptions {
   video: HTMLVideoElement;
   deviceId?: string;
-  onResult: (text: string, engine: DecodeEngineName) => void;
+  onResult: (text: string, engine: DecodeEngineName, decodeMs: number) => void;
+  /** Fires after every worker reply (hit or miss) — use for live performance HUD. */
+  onDecodeAttempt?: (meta: DecodeAttemptMeta) => void;
   onError?: (error: Error) => void;
   initialWidth?: number;
   minWidth?: number;
@@ -70,6 +82,7 @@ export const startScanner = async (
     video,
     deviceId,
     onResult,
+    onDecodeAttempt,
     onError,
     initialWidth = DEFAULT_INITIAL_WIDTH,
     minWidth = DEFAULT_MIN_WIDTH,
@@ -113,6 +126,9 @@ export const startScanner = async (
   let frameIndex = 0;
   let lastDecodeMs = 0;
   let pendingJobId = 0;
+  let pendingRunLevel: RunLevel = 'fast';
+  let pendingCanvasWidth = 0;
+  let pendingCanvasHeight = 0;
   let nextJobId = 1;
   let currentWidth = initialWidth;
   let decodeTimer: ReturnType<typeof setTimeout> | null = null;
@@ -203,10 +219,26 @@ export const startScanner = async (
     }
 
     if (data.jobId !== pendingJobId) return;
+
+    if (onDecodeAttempt) {
+      try {
+        onDecodeAttempt({
+          engine: data.result?.engine ?? null,
+          matched: Boolean(data.result),
+          decodeMs: data.decodeMs,
+          runLevel: pendingRunLevel,
+          canvasWidth: pendingCanvasWidth,
+          canvasHeight: pendingCanvasHeight,
+        });
+      } catch (attemptError) {
+        reportError(attemptError, 'QR decode attempt handler threw');
+      }
+    }
+
     if (!data.result) return;
 
     try {
-      onResult(data.result.text, data.result.engine);
+      onResult(data.result.text, data.result.engine, data.decodeMs);
     } catch (callbackError) {
       reportError(callbackError, 'QR result handler threw');
     }
@@ -266,6 +298,9 @@ export const startScanner = async (
     frameIndex += 1;
     pendingJobId = nextJobId;
     nextJobId += 1;
+    pendingRunLevel = pickRunLevel(thisFrameIndex, runLevelPattern);
+    pendingCanvasWidth = canvas.width;
+    pendingCanvasHeight = canvas.height;
 
     let imageData: ImageData;
     try {
@@ -283,7 +318,7 @@ export const startScanner = async (
       width: imageData.width,
       height: imageData.height,
       buffer,
-      runLevel: pickRunLevel(thisFrameIndex, runLevelPattern),
+      runLevel: pendingRunLevel,
     };
 
     try {

--- a/src/tools/qrscan/page-fixed.tsx
+++ b/src/tools/qrscan/page-fixed.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { ToolLayout } from '@design-system';
 import { getToolByRoute } from '../index';
 import useQrscan from './hooks/useQrscan';
-import QRScannerPanelFixed from './components/QRScannerPanelFixed';
+import ARScannerView from './components/ARScannerView';
 
 const QrscanPageFixed: React.FC = () => {
   const vm = useQrscan();
@@ -15,10 +15,10 @@ const QrscanPageFixed: React.FC = () => {
     <ToolLayout
       tool={tool!}
       title="QR Scanner"
-      description="Scan QR codes with live camera preview, import images, and manage a persistent scan history."
+      description="Fullscreen AR-style QR scanner with live engine performance telemetry. Tap to open decoded links instantly."
       showRelatedTools
     >
-      <QRScannerPanelFixed {...vm} />
+      <ARScannerView {...vm} />
     </ToolLayout>
   );
 };


### PR DESCRIPTION
## Summary

Mobile-first overhaul of `/qrscan`: fullscreen AR-style scanner with tappable result actions and a live performance HUD that shows which decode engine is winning.

### UX
- **Fullscreen camera** (`object-cover`, respects safe-area insets). Translucent scrim with corner brackets forms the AR reticle; a sweeping scanline shows "we're looking."
- **Tap-through results** — the primary CTA adapts to the content:
  - `https://…` → **Open link →**
  - `tel:` → **Call**, `mailto:` → **Send email**, `sms:`/`smsto:` → **Send SMS**, `geo:` → **Open map**
  - Otherwise → **Copy**
- **Large-tap controls**: start/stop (✕ / ▶), flip camera, torch (⚡) lit in yellow when active.
- **Live status pill**: engine · decode ms · scans per second — updated every frame.
- **Collapsible bottom sheet** for per-engine performance, file upload, paste text, and the 5 most recent scans.

### Performance telemetry
- Per-engine breakdown: `BarcodeDetector`, `jsQR-fast`, `jsQR-deep` — each with hits, attempts, avg decode ms, last decode ms.
- **Winning engine** = most hits (tie-broken by fastest avg latency). Shown with a ★ badge.
- Rolling scans/second over a 2s window.

### Plumbing
- `scannerController.onDecodeAttempt(meta)` fires on every worker reply — hit or miss — with `{ engine, matched, decodeMs, runLevel, canvasWidth, canvasHeight }`.
- `lib/qrscan.startQrScan` takes a `StartQrScanOptions` form so the attempt callback can be wired without breaking back-compat with positional args.
- `useQrscan` owns the `ScanPerformance` view-model (pure `mergeAttempt` reducer, easy to unit-test).

## Test plan

- [x] `pnpm jest tools.qrscan` → 37 passed (was 31).
- [x] `pnpm typecheck` → no new errors (baseline 33 → 32 unchanged since previous PR).
- [x] `pnpm build` → Vite bundles the new component + CSS cleanly; worker chunk still emitted separately.
- [ ] Manual smoke test on mobile Safari (iOS): reticle, tap-to-open URL, torch.
- [ ] Manual smoke test on Chrome Android: performance HUD accuracy vs. Perf tab.
- [ ] Verify `BarcodeDetector` gets the win in desktop Chrome; jsQR wins on Firefox.

https://claude.ai/code/session_017vea8TouSY2XUNQCRT5sPk