### PR TITLE
feat(tls-checker): add TLS protocol version probe tool

### DIFF
--- a/__tests__/tools.tls-checker.test.ts
+++ b/__tests__/tools.tls-checker.test.ts
@@ -1,0 +1,127 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import {
+  TLS_PROTOCOL_LABELS,
+  describeErrorCode,
+  getProtocolSeverity,
+  isDeprecatedProtocol,
+  isValidDomain,
+  normalizeDomain,
+  runTlsCheck,
+} from '../src/tools/tls-checker/lib/tlsChecker';
+
+describe('TLS Checker lib', () => {
+  test('TLS_PROTOCOL_LABELS contains six protocol versions in order', () => {
+    expect(TLS_PROTOCOL_LABELS).toEqual([
+      'SSL 2.0',
+      'SSL 3.0',
+      'TLS 1.0',
+      'TLS 1.1',
+      'TLS 1.2',
+      'TLS 1.3',
+    ]);
+  });
+
+  test('isDeprecatedProtocol flags SSL and early TLS', () => {
+    expect(isDeprecatedProtocol('SSL 2.0')).toBe(true);
+    expect(isDeprecatedProtocol('SSL 3.0')).toBe(true);
+    expect(isDeprecatedProtocol('TLS 1.0')).toBe(true);
+    expect(isDeprecatedProtocol('TLS 1.1')).toBe(true);
+    expect(isDeprecatedProtocol('TLS 1.2')).toBe(false);
+    expect(isDeprecatedProtocol('TLS 1.3')).toBe(false);
+  });
+
+  test('normalizeDomain strips scheme, path and whitespace', () => {
+    expect(normalizeDomain('  https://Example.COM/path?x=1 ')).toBe(
+      'example.com',
+    );
+    expect(normalizeDomain('sub.Example.org')).toBe('sub.example.org');
+  });
+
+  test('isValidDomain accepts typical hostnames and rejects malformed input', () => {
+    expect(isValidDomain('example.com')).toBe(true);
+    expect(isValidDomain('sub.example.co.uk')).toBe(true);
+    expect(isValidDomain('https://example.com/foo')).toBe(true);
+    expect(isValidDomain('')).toBe(false);
+    expect(isValidDomain('example')).toBe(false);
+    expect(isValidDomain('.example.com')).toBe(false);
+    expect(isValidDomain('example..com')).toBe(false);
+    expect(isValidDomain('-bad.example.com')).toBe(false);
+    expect(isValidDomain('a b.com')).toBe(false);
+  });
+
+  test('getProtocolSeverity classifies results', () => {
+    expect(
+      getProtocolSeverity({ version: 'TLS 1.3', supported: true, deprecated: false }),
+    ).toBe('secure');
+    expect(
+      getProtocolSeverity({ version: 'TLS 1.0', supported: true, deprecated: true }),
+    ).toBe('insecure');
+    expect(
+      getProtocolSeverity({ version: 'SSL 3.0', supported: false, deprecated: true }),
+    ).toBe('disabled');
+  });
+
+  test('describeErrorCode returns user-friendly strings', () => {
+    expect(describeErrorCode('INVALID_DOMAIN')).toMatch(/valid domain/i);
+    expect(describeErrorCode('CONNECTION_FAILED')).toMatch(/connect/i);
+    expect(describeErrorCode('TIMEOUT')).toMatch(/timed out/i);
+    expect(describeErrorCode('SERVER_ERROR')).toMatch(/wrong/i);
+    expect(describeErrorCode('UNKNOWN_CODE')).toMatch(/wrong/i);
+  });
+});
+
+describe('runTlsCheck', () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test('posts domain to API and returns parsed response', async () => {
+    const payload = {
+      domain: 'example.com',
+      results: [
+        { version: 'TLS 1.2', supported: true, deprecated: false },
+        { version: 'TLS 1.3', supported: true, deprecated: false },
+      ],
+      scannedAt: '2026-04-22T10:00:00Z',
+    };
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await runTlsCheck('example.com');
+    expect(result).toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/tls-check',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ domain: 'example.com' }),
+      }),
+    );
+  });
+
+  test('throws with server-provided error code on non-ok response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'CONNECTION_FAILED' }),
+    }) as unknown as typeof fetch;
+    await expect(runTlsCheck('bad.example')).rejects.toThrow(
+      'CONNECTION_FAILED',
+    );
+  });
+
+  test('falls back to SERVER_ERROR when response body is unparseable', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      json: async () => {
+        throw new Error('bad json');
+      },
+    }) as unknown as typeof fetch;
+    await expect(runTlsCheck('bad.example')).rejects.toThrow('SERVER_ERROR');
+  });
+});

--- a/api/tls-check.js
+++ b/api/tls-check.js
@@ -1,0 +1,172 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ *
+ * Serverless probe that negotiates individual TLS versions against the
+ * requested host. SSL 2.0 and SSL 3.0 cannot be negotiated by modern
+ * Node.js/OpenSSL builds, so they are reported as unsupported.
+ */
+import tls from 'node:tls';
+
+const PORT = 443;
+const PROBE_TIMEOUT_MS = 5000;
+const OVERALL_BUDGET_MS = 9500;
+
+const PROBE_VERSIONS = [
+  { label: 'TLS 1.0', node: 'TLSv1' },
+  { label: 'TLS 1.1', node: 'TLSv1.1' },
+  { label: 'TLS 1.2', node: 'TLSv1.2' },
+  { label: 'TLS 1.3', node: 'TLSv1.3' },
+];
+
+const DEPRECATED = new Set(['SSL 2.0', 'SSL 3.0', 'TLS 1.0', 'TLS 1.1']);
+const DOMAIN_REGEX =
+  /^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?:\.[A-Za-z0-9-]{1,63})+$/;
+
+function normalizeDomain(raw) {
+  if (typeof raw !== 'string') return '';
+  const trimmed = raw.trim();
+  if (!trimmed) return '';
+  try {
+    const candidate = trimmed.includes('://') ? trimmed : `https://${trimmed}`;
+    return new URL(candidate).hostname.toLowerCase();
+  } catch {
+    return trimmed.toLowerCase();
+  }
+}
+
+function isValidDomain(value) {
+  if (!value || value.length > 253) return false;
+  if (value.startsWith('.') || value.endsWith('.')) return false;
+  if (value.includes('..')) return false;
+  return DOMAIN_REGEX.test(value);
+}
+
+function probeVersion(host, nodeVersion) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      try { socket.destroy(); } catch { /* noop */ }
+      resolve(result);
+    };
+
+    let socket;
+    try {
+      socket = tls.connect({
+        host,
+        port: PORT,
+        servername: host,
+        minVersion: nodeVersion,
+        maxVersion: nodeVersion,
+        rejectUnauthorized: false,
+        ALPNProtocols: ['http/1.1'],
+      });
+    } catch {
+      resolve({ supported: false, reason: 'unsupported' });
+      return;
+    }
+
+    socket.setTimeout(PROBE_TIMEOUT_MS);
+    socket.once('secureConnect', () => finish({ supported: true }));
+    socket.once('error', (err) => {
+      const code = err && err.code ? String(err.code) : '';
+      const connectionIssue =
+        code === 'ENOTFOUND' ||
+        code === 'EAI_AGAIN' ||
+        code === 'ECONNREFUSED' ||
+        code === 'ETIMEDOUT' ||
+        code === 'ECONNRESET';
+      finish({
+        supported: false,
+        reason: connectionIssue ? 'connection' : 'handshake',
+      });
+    });
+    socket.once('timeout', () => finish({ supported: false, reason: 'timeout' }));
+  });
+}
+
+async function probeHost(host) {
+  const probes = await Promise.all(
+    PROBE_VERSIONS.map((v) => probeVersion(host, v.node)),
+  );
+
+  const connectionFailures = probes.filter(
+    (p) => !p.supported && p.reason === 'connection',
+  ).length;
+  const timeouts = probes.filter(
+    (p) => !p.supported && p.reason === 'timeout',
+  ).length;
+
+  // If every probe failed at the connection layer, treat as unreachable.
+  if (connectionFailures === PROBE_VERSIONS.length) {
+    return { ok: false, error: 'CONNECTION_FAILED' };
+  }
+  if (
+    timeouts === PROBE_VERSIONS.length ||
+    (timeouts > 0 && timeouts + connectionFailures === PROBE_VERSIONS.length)
+  ) {
+    return { ok: false, error: 'TIMEOUT' };
+  }
+
+  const results = [
+    { version: 'SSL 2.0', supported: false, deprecated: true },
+    { version: 'SSL 3.0', supported: false, deprecated: true },
+    ...PROBE_VERSIONS.map((v, i) => ({
+      version: v.label,
+      supported: probes[i].supported,
+      deprecated: DEPRECATED.has(v.label),
+    })),
+  ];
+  return { ok: true, results };
+}
+
+function readJsonBody(req) {
+  if (req.body && typeof req.body === 'object') return req.body;
+  if (typeof req.body === 'string') {
+    try { return JSON.parse(req.body); } catch { return {}; }
+  }
+  return {};
+}
+
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'SERVER_ERROR' });
+    return;
+  }
+
+  const body = readJsonBody(req);
+  const domain = normalizeDomain(body?.domain ?? '');
+  if (!isValidDomain(domain)) {
+    res.status(400).json({ error: 'INVALID_DOMAIN' });
+    return;
+  }
+
+  const budget = new Promise((resolve) =>
+    setTimeout(() => resolve({ ok: false, error: 'TIMEOUT' }), OVERALL_BUDGET_MS),
+  );
+
+  try {
+    const outcome = await Promise.race([probeHost(domain), budget]);
+    if (!outcome.ok) {
+      const status = outcome.error === 'TIMEOUT' ? 504 : 502;
+      res.status(status).json({ error: outcome.error });
+      return;
+    }
+    res.status(200).json({
+      domain,
+      results: outcome.results,
+      scannedAt: new Date().toISOString(),
+    });
+  } catch {
+    res.status(500).json({ error: 'SERVER_ERROR' });
+  }
+}

--- a/src/design-system/icons/tool-icons.tsx
+++ b/src/design-system/icons/tool-icons.tsx
@@ -280,6 +280,40 @@ export const CompassIcon: React.FC<IconProps> = ({ className }) => (
   </svg>
 );
 
+export const TlsCheckerIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+  >
+    {/* Shield outline */}
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M12 3l8 3v5c0 5-3.5 8.5-8 10-4.5-1.5-8-5-8-10V6l8-3z"
+    />
+    {/* Padlock body */}
+    <rect
+      x="9"
+      y="11"
+      width="6"
+      height="5"
+      rx="1"
+      strokeWidth={2}
+    />
+    {/* Padlock shackle */}
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M10.5 11V9.5a1.5 1.5 0 013 0V11"
+    />
+  </svg>
+);
+
 export const UnicodeAnalyzerIcon: React.FC<IconProps> = ({ className }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -74,6 +74,7 @@ import {
   PdfToImageIcon,
   CompassIcon,
   UnicodeAnalyzerIcon,
+  TlsCheckerIcon,
 } from "../design-system/icons/tool-icons";
 
 // Category definitions with icons for consistent UI
@@ -395,6 +396,37 @@ const toolRegistry: Tool[] = [
     uiOptions: {
       showExamples: false,
     },
+  },
+  {
+    id: "tls-checker",
+    route: "/tls-checker",
+    title: "TLS Checker",
+    description:
+      "Probe which SSL/TLS protocol versions a domain still accepts on port 443.",
+    longDescription:
+      "Connect to a host and attempt each SSL/TLS protocol version in isolation to find out which ones remain negotiable. Deprecated versions (SSL 2.0/3.0, TLS 1.0/1.1) are flagged in red so you can disable them; TLS 1.2 and 1.3 are highlighted as secure baselines.",
+    icon: TlsCheckerIcon,
+    component: lazy(() => import("./tls-checker/page")),
+    category: "Security",
+    isNew: true,
+    metadata: {
+      keywords: [
+        "tls",
+        "ssl",
+        "tls checker",
+        "tls version",
+        "tls 1.2",
+        "tls 1.3",
+        "deprecated tls",
+        "handshake",
+        "port 443",
+        "cipher",
+        "security",
+      ],
+      learnMoreUrl: "https://datatracker.ietf.org/doc/html/rfc8996",
+      relatedTools: ["header-scanner", "clickjacking-validator"],
+    },
+    uiOptions: { showExamples: false },
   },
   {
     id: "header-scanner",

--- a/src/tools/tls-checker/components/TlsCheckerPanel.tsx
+++ b/src/tools/tls-checker/components/TlsCheckerPanel.tsx
@@ -1,0 +1,252 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import { Badge } from '../../../design-system/components/display/Badge';
+import { Button } from '../../../design-system/components/inputs/Button';
+import { Card } from '../../../design-system/components/layout/Card';
+import { LoadingSpinner } from '../../../design-system/components/feedback/LoadingSpinner';
+import {
+  TLS_PROTOCOL_LABELS,
+  TlsProbeResult,
+  getProtocolSeverity,
+} from '../lib/tlsChecker';
+import { UseTlsCheckerState } from '../hooks/useTlsChecker';
+
+type Props = UseTlsCheckerState;
+
+const severityStyles: Record<
+  'secure' | 'insecure' | 'disabled',
+  { border: string; bg: string; label: string }
+> = {
+  secure: {
+    border: 'border-green-300 dark:border-green-700',
+    bg: 'bg-green-50 dark:bg-green-900/20',
+    label: 'text-green-700 dark:text-green-300',
+  },
+  insecure: {
+    border: 'border-red-300 dark:border-red-700',
+    bg: 'bg-red-50 dark:bg-red-900/20',
+    label: 'text-red-700 dark:text-red-300',
+  },
+  disabled: {
+    border: 'border-gray-300 dark:border-gray-700',
+    bg: 'bg-gray-50 dark:bg-gray-800/40',
+    label: 'text-gray-600 dark:text-gray-400',
+  },
+};
+
+const skeletonItems = TLS_PROTOCOL_LABELS.map((label) => label);
+
+const renderStatusBadge = (result: TlsProbeResult) => {
+  const severity = getProtocolSeverity(result);
+  if (severity === 'secure') {
+    return (
+      <Badge variant="success" pill>
+        Supported
+      </Badge>
+    );
+  }
+  if (severity === 'insecure') {
+    return (
+      <Badge variant="danger" pill>
+        Supported
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="secondary" pill>
+      Not Supported
+    </Badge>
+  );
+};
+
+export const TlsCheckerView: React.FC<Props> = ({
+  domain,
+  setDomain,
+  results,
+  scannedDomain,
+  scannedAt,
+  loading,
+  error,
+  check,
+  reset,
+}) => {
+  const handleKey = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') check();
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card isElevated>
+        <div className="space-y-4">
+          <div>
+            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+            <label
+              htmlFor="tls-domain"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+            >
+              Domain
+            </label>
+            <div className="flex flex-col sm:flex-row gap-2">
+              <input
+                id="tls-domain"
+                type="text"
+                inputMode="url"
+                autoComplete="off"
+                autoCapitalize="off"
+                spellCheck={false}
+                className="flex-grow rounded-md sm:rounded-r-none border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:text-white shadow-sm focus:border-primary-500 focus:ring focus:ring-primary-200 dark:focus:ring-primary-900 focus:ring-opacity-50"
+                placeholder="example.com"
+                value={domain}
+                onChange={(event) => setDomain(event.target.value)}
+                onKeyDown={handleKey}
+                disabled={loading}
+                aria-invalid={Boolean(error) && !loading}
+              />
+              <div className="flex gap-2">
+                <Button
+                  onClick={check}
+                  isLoading={loading}
+                  disabled={loading || !domain.trim()}
+                  className="sm:rounded-l-none"
+                >
+                  Test now
+                </Button>
+                {(results.length > 0 || error) && !loading && (
+                  <Button
+                    variant="ghost"
+                    onClick={() => {
+                      setDomain('');
+                      reset();
+                    }}
+                  >
+                    Clear
+                  </Button>
+                )}
+              </div>
+            </div>
+            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+              Probes TLS 1.0 – 1.3 on port 443. SSL 2.0/3.0 cannot be
+              negotiated by modern runtimes and are reported as disabled.
+            </p>
+          </div>
+
+          {error && (
+            <div
+              role="alert"
+              className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md text-red-700 dark:text-red-400 text-sm"
+            >
+              {error}
+            </div>
+          )}
+
+          {loading && (
+            <div
+              aria-label="Testing TLS protocols"
+              className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
+            >
+              {skeletonItems.map((label) => (
+                <div
+                  key={label}
+                  className="animate-pulse border border-gray-200 dark:border-gray-700 rounded-md p-4 h-28 bg-gray-50 dark:bg-gray-800/40"
+                >
+                  <div className="h-4 w-20 bg-gray-200 dark:bg-gray-700 rounded mb-3" />
+                  <div className="h-3 w-28 bg-gray-200 dark:bg-gray-700 rounded" />
+                </div>
+              ))}
+              <div className="col-span-full flex justify-center py-2">
+                <LoadingSpinner />
+              </div>
+            </div>
+          )}
+
+          {!loading && results.length > 0 && (
+            <div className="space-y-4">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                <div className="text-sm text-gray-600 dark:text-gray-300">
+                  Results for{' '}
+                  <span className="font-semibold text-gray-900 dark:text-white">
+                    {scannedDomain}
+                  </span>
+                  {scannedAt && (
+                    <span className="ml-2 text-xs text-gray-400">
+                      {new Date(scannedAt).toLocaleString()}
+                    </span>
+                  )}
+                </div>
+              </div>
+              <div
+                role="list"
+                className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
+              >
+                {results.map((result) => {
+                  const severity = getProtocolSeverity(result);
+                  const style = severityStyles[severity];
+                  return (
+                    <div
+                      key={result.version}
+                      role="listitem"
+                      className={`border rounded-md p-4 flex flex-col gap-2 ${style.border} ${style.bg}`}
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className={`font-semibold ${style.label}`}>
+                          {result.version}
+                        </span>
+                        {renderStatusBadge(result)}
+                      </div>
+                      <div className="flex items-center gap-2 text-xs">
+                        {result.deprecated && (
+                          <Badge variant="warning" pill size="xs">
+                            Deprecated
+                          </Badge>
+                        )}
+                        {!result.deprecated && (
+                          <Badge variant="info" pill size="xs">
+                            Modern
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="text-xs text-gray-600 dark:text-gray-400">
+                        {severity === 'secure' &&
+                          'Modern protocol enabled on the server.'}
+                        {severity === 'insecure' &&
+                          'Deprecated protocol is enabled — disable it on the server.'}
+                        {severity === 'disabled' &&
+                          (result.deprecated
+                            ? 'Not supported — this protocol is deprecated.'
+                            : 'Not negotiated — consider enabling this modern protocol.')}
+                      </p>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      </Card>
+
+      <Card>
+        <div className="space-y-2 text-sm text-gray-600 dark:text-gray-300">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+            What is TLS?
+          </h2>
+          <p>
+            TLS (Transport Layer Security) encrypts traffic between browsers
+            and servers. Each protocol version is negotiated during the
+            handshake. Older versions — SSL 2.0, SSL 3.0, TLS 1.0 and
+            TLS 1.1 — have known weaknesses and are deprecated by the IETF.
+          </p>
+          <p>
+            Servers should enable TLS 1.2 and TLS 1.3 and disable everything
+            older. This tool connects to the host on port 443 and attempts
+            each version in isolation to report which ones your server still
+            accepts.
+          </p>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default TlsCheckerView;

--- a/src/tools/tls-checker/hooks/useTlsChecker.ts
+++ b/src/tools/tls-checker/hooks/useTlsChecker.ts
@@ -1,0 +1,78 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import { useState } from 'react';
+import {
+  TlsProbeResult,
+  describeErrorCode,
+  isValidDomain,
+  normalizeDomain,
+  runTlsCheck,
+} from '../lib/tlsChecker';
+
+export interface UseTlsCheckerState {
+  domain: string;
+  setDomain: (value: string) => void;
+  results: TlsProbeResult[];
+  scannedDomain: string;
+  scannedAt: string;
+  loading: boolean;
+  error: string;
+  check: () => Promise<void>;
+  reset: () => void;
+}
+
+export const useTlsChecker = (): UseTlsCheckerState => {
+  const [domain, setDomain] = useState('');
+  const [results, setResults] = useState<TlsProbeResult[]>([]);
+  const [scannedDomain, setScannedDomain] = useState('');
+  const [scannedAt, setScannedAt] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const reset = () => {
+    setResults([]);
+    setScannedDomain('');
+    setScannedAt('');
+    setError('');
+  };
+
+  const check = async () => {
+    if (!isValidDomain(domain)) {
+      setError(describeErrorCode('INVALID_DOMAIN'));
+      setResults([]);
+      return;
+    }
+    setLoading(true);
+    setError('');
+    try {
+      const target = normalizeDomain(domain);
+      const response = await runTlsCheck(target);
+      setResults(response.results);
+      setScannedDomain(response.domain);
+      setScannedAt(response.scannedAt);
+    } catch (err) {
+      const code = err instanceof Error ? err.message : 'SERVER_ERROR';
+      setError(describeErrorCode(code));
+      setResults([]);
+      setScannedDomain('');
+      setScannedAt('');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    domain,
+    setDomain,
+    results,
+    scannedDomain,
+    scannedAt,
+    loading,
+    error,
+    check,
+    reset,
+  };
+};
+
+export default useTlsChecker;

--- a/src/tools/tls-checker/index.ts
+++ b/src/tools/tls-checker/index.ts
@@ -1,0 +1,4 @@
+import TlsCheckerPage from './page';
+
+export { TlsCheckerPage };
+export default TlsCheckerPage;

--- a/src/tools/tls-checker/lib/tlsChecker.ts
+++ b/src/tools/tls-checker/lib/tlsChecker.ts
@@ -1,0 +1,116 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+
+export type TlsProtocolLabel =
+  | 'SSL 2.0'
+  | 'SSL 3.0'
+  | 'TLS 1.0'
+  | 'TLS 1.1'
+  | 'TLS 1.2'
+  | 'TLS 1.3';
+
+export interface TlsProbeResult {
+  version: TlsProtocolLabel;
+  supported: boolean;
+  deprecated: boolean;
+}
+
+export interface TlsCheckResponse {
+  domain: string;
+  results: TlsProbeResult[];
+  scannedAt: string;
+}
+
+export type TlsCheckErrorCode =
+  | 'INVALID_DOMAIN'
+  | 'CONNECTION_FAILED'
+  | 'TIMEOUT'
+  | 'SERVER_ERROR';
+
+export interface TlsCheckErrorResponse {
+  error: TlsCheckErrorCode;
+}
+
+export const TLS_PROTOCOL_LABELS: readonly TlsProtocolLabel[] = [
+  'SSL 2.0',
+  'SSL 3.0',
+  'TLS 1.0',
+  'TLS 1.1',
+  'TLS 1.2',
+  'TLS 1.3',
+];
+
+const DEPRECATED_PROTOCOLS = new Set<TlsProtocolLabel>([
+  'SSL 2.0',
+  'SSL 3.0',
+  'TLS 1.0',
+  'TLS 1.1',
+]);
+
+export const isDeprecatedProtocol = (label: TlsProtocolLabel): boolean =>
+  DEPRECATED_PROTOCOLS.has(label);
+
+export type ProtocolSeverity = 'secure' | 'insecure' | 'disabled';
+
+export const getProtocolSeverity = (
+  result: TlsProbeResult,
+): ProtocolSeverity => {
+  if (!result.supported) return 'disabled';
+  return result.deprecated ? 'insecure' : 'secure';
+};
+
+const DOMAIN_REGEX =
+  /^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?:\.[A-Za-z0-9-]{1,63})+$/;
+
+export const normalizeDomain = (raw: string): string => {
+  const trimmed = raw.trim();
+  if (!trimmed) return '';
+  try {
+    const candidate = trimmed.includes('://') ? trimmed : `https://${trimmed}`;
+    const url = new URL(candidate);
+    return url.hostname.toLowerCase();
+  } catch {
+    return trimmed.toLowerCase();
+  }
+};
+
+export const isValidDomain = (raw: string): boolean => {
+  const domain = normalizeDomain(raw);
+  if (!domain || domain.length > 253) return false;
+  if (domain.endsWith('.') || domain.startsWith('.')) return false;
+  if (domain.includes('..')) return false;
+  return DOMAIN_REGEX.test(domain);
+};
+
+const ERROR_MESSAGES: Record<TlsCheckErrorCode, string> = {
+  INVALID_DOMAIN: 'Please enter a valid domain (e.g. example.com)',
+  CONNECTION_FAILED:
+    'Could not connect to the server. Please check the domain and try again.',
+  TIMEOUT: 'Request timed out. The server may be slow or unreachable.',
+  SERVER_ERROR: 'Something went wrong on our end. Please try again.',
+};
+
+export const describeErrorCode = (code: string): string =>
+  ERROR_MESSAGES[code as TlsCheckErrorCode] ?? ERROR_MESSAGES.SERVER_ERROR;
+
+export const runTlsCheck = async (
+  domain: string,
+): Promise<TlsCheckResponse> => {
+  const res = await fetch('/api/tls-check', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ domain }),
+  });
+  if (!res.ok) {
+    let code: TlsCheckErrorCode = 'SERVER_ERROR';
+    try {
+      const body = (await res.json()) as TlsCheckErrorResponse;
+      if (body?.error) code = body.error;
+    } catch {
+      // ignore parse errors and fall through to SERVER_ERROR
+    }
+    throw new Error(code);
+  }
+  return (await res.json()) as TlsCheckResponse;
+};

--- a/src/tools/tls-checker/page.tsx
+++ b/src/tools/tls-checker/page.tsx
@@ -1,0 +1,20 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import React from 'react';
+import useTlsChecker from './hooks/useTlsChecker';
+import TlsCheckerView from './components/TlsCheckerPanel';
+import { getToolByRoute } from '../index';
+import { ToolLayout } from '@design-system';
+
+const TlsCheckerPage: React.FC = () => {
+  const vm = useTlsChecker();
+  const tool = getToolByRoute('/tls-checker');
+  return (
+    <ToolLayout tool={tool!}>
+      <TlsCheckerView {...vm} />
+    </ToolLayout>
+  );
+};
+
+export default TlsCheckerPage;


### PR DESCRIPTION
## Summary
- Adds a new **TLS Checker** tool under the Security category that probes which SSL/TLS protocol versions a domain accepts on port 443.
- New Vercel serverless endpoint `POST /api/tls-check` negotiates TLS 1.0–1.3 individually via Node's `tls` module and returns per-version support/deprecation flags. SSL 2.0/3.0 are reported as unsupported because modern OpenSSL cannot negotiate them.
- UI renders color-coded protocol cards (green = modern supported, red = deprecated supported, gray = not supported), with input validation, skeleton loading state, and user-friendly error messages.

## Implementation notes
- `src/tools/tls-checker/` follows the project's hook + view + lib convention used by `header-scanner` and `cors-tester`.
- Domain input is normalized via the `URL` constructor so `https://example.com/path` becomes `example.com` before validation and probing.
- The serverless handler wraps the Promise.all of per-version probes in an overall 9.5s budget to stay within the 10s contract from the PRD.
- New `TlsCheckerIcon` added to `design-system/icons/tool-icons.tsx`.

## Test plan
- [x] `pnpm exec eslint` clean on all new/modified files (max-warnings 0)
- [x] `pnpm typecheck` introduces no new errors (pre-existing failures in unrelated tools remain)
- [x] `jest --testPathPattern=tls-checker` — 9/9 pass (lib helpers, validation, runTlsCheck success/error/parse-failure paths)
- [ ] Manual: verify production deploy on Vercel returns correct `/api/tls-check` JSON for a real domain
- [ ] Manual: confirm mobile layout at 320px and dark mode color contrast for the cards