### PR TITLE
feat(random-password-generator): entropy-seeded single-viewport UX

### DIFF
--- a/__tests__/tools.random-password-generator.entropy.test.ts
+++ b/__tests__/tools.random-password-generator.entropy.test.ts
@@ -1,0 +1,100 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ */
+import {
+  EntropyPool,
+  ENTROPY_POOL_SIZE,
+  ENTROPY_PROGRESS_TARGET,
+  pointerEntropyValues,
+} from '../src/tools/random-password-generator/lib/entropy';
+import {
+  generateKey,
+  generatePassword,
+  generateUUIDv4,
+} from '../src/tools/random-password-generator/lib/generators';
+
+describe('EntropyPool', () => {
+  test('pool is seeded and reports the expected size', () => {
+    const pool = new EntropyPool();
+    expect(pool.snapshot()).toHaveLength(ENTROPY_POOL_SIZE);
+  });
+
+  test('absorb mutates the pool without growing it', () => {
+    const pool = new EntropyPool();
+    const before = pool.snapshot();
+    for (let i = 0; i < 20; i += 1) {
+      pool.absorb(pointerEntropyValues(i * 17, i * 31, Date.now() + i, 0.5));
+    }
+    const after = pool.snapshot();
+    expect(after).toHaveLength(ENTROPY_POOL_SIZE);
+    expect(Array.from(before)).not.toEqual(Array.from(after));
+    expect(pool.events).toBe(20);
+  });
+
+  test('progress saturates at 100% and resets to zero', () => {
+    const pool = new EntropyPool();
+    for (let i = 0; i <= ENTROPY_PROGRESS_TARGET + 10; i += 1) {
+      pool.absorb([i & 0xff]);
+    }
+    expect(pool.progress).toBe(1);
+    pool.reset();
+    expect(pool.progress).toBe(0);
+    expect(pool.events).toBe(0);
+  });
+
+  test('snapshot returns a detached copy', () => {
+    const pool = new EntropyPool();
+    const a = pool.snapshot();
+    a[0] = (a[0] + 1) & 0xff;
+    const b = pool.snapshot();
+    expect(a[0]).not.toBe(b[0]);
+  });
+});
+
+describe('seeded generators', () => {
+  const basePwOpts = {
+    length: 16,
+    includeLowercase: true,
+    includeUppercase: true,
+    includeNumbers: true,
+    includeSymbols: false,
+    excludeAmbiguous: false,
+  } as const;
+
+  test('generatePassword with entropy still produces the requested length', () => {
+    const pool = new EntropyPool();
+    for (let i = 0; i < 40; i += 1) pool.absorb([i, i * 2, i * 3]);
+    const pwd = generatePassword(basePwOpts, pool.snapshot());
+    expect(pwd).toHaveLength(16);
+  });
+
+  test('generatePassword without entropy behaves as before', () => {
+    const pwd = generatePassword(basePwOpts);
+    expect(pwd).toHaveLength(16);
+  });
+
+  test('generateUUIDv4 with entropy still yields a valid v4 UUID', () => {
+    const pool = new EntropyPool();
+    for (let i = 0; i < 16; i += 1) pool.absorb([i * 7]);
+    const id = generateUUIDv4(pool.snapshot());
+    expect(id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  test('generateKey with entropy stays in the requested encoding', () => {
+    const pool = new EntropyPool();
+    for (let i = 0; i < 8; i += 1) pool.absorb([i, 255 - i]);
+    const hex = generateKey({ bits: 128, format: 'hex' }, pool.snapshot());
+    expect(hex).toMatch(/^[0-9a-f]+$/);
+    expect(hex).toHaveLength(32);
+    const b64 = generateKey({ bits: 256, format: 'base64' }, pool.snapshot());
+    expect(typeof b64).toBe('string');
+    expect(b64.length).toBeGreaterThan(0);
+  });
+
+  test('empty entropy buffer is treated as no entropy', () => {
+    const pwd = generatePassword(basePwOpts, new Uint8Array(0));
+    expect(pwd).toHaveLength(16);
+  });
+});

--- a/src/tools/random-password-generator/components/EntropyCanvas.tsx
+++ b/src/tools/random-password-generator/components/EntropyCanvas.tsx
@@ -1,0 +1,191 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ *
+ * Interactive canvas that absorbs pointer/touch entropy while rendering a
+ * particle trail. Provides tactile feedback that randomness is being
+ * actively seeded by the user's hover/touch activity.
+ */
+import React, { useEffect, useRef } from 'react';
+import { EntropyPool, pointerEntropyValues } from '../lib/entropy';
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  hue: number;
+  size: number;
+}
+
+interface Props {
+  pool: EntropyPool;
+  onEvent: () => void;
+  progress: number;
+  events: number;
+  className?: string;
+}
+
+const MAX_PARTICLES = 120;
+const PARTICLE_DECAY = 0.018;
+
+export const EntropyCanvas: React.FC<Props> = ({
+  pool,
+  onEvent,
+  progress,
+  events,
+  className,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const particlesRef = useRef<Particle[]>([]);
+  const rafRef = useRef<number | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const lastMixRef = useRef<number>(0);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return undefined;
+
+    const resize = () => {
+      const ratio = window.devicePixelRatio || 1;
+      const { clientWidth, clientHeight } = canvas;
+      canvas.width = Math.max(1, Math.round(clientWidth * ratio));
+      canvas.height = Math.max(1, Math.round(clientHeight * ratio));
+    };
+
+    resize();
+    const observer = new ResizeObserver(resize);
+    observer.observe(canvas);
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      observer.disconnect();
+      return undefined;
+    }
+
+    const step = () => {
+      const ratio = window.devicePixelRatio || 1;
+      ctx.save();
+      ctx.scale(ratio, ratio);
+      const w = canvas.clientWidth;
+      const h = canvas.clientHeight;
+      // Fade trail
+      ctx.fillStyle = 'rgba(11, 18, 32, 0.22)';
+      ctx.fillRect(0, 0, w, h);
+
+      const particles = particlesRef.current;
+      for (let i = particles.length - 1; i >= 0; i -= 1) {
+        const p = particles[i];
+        p.x += p.vx;
+        p.y += p.vy;
+        p.vx *= 0.94;
+        p.vy *= 0.94;
+        p.life -= PARTICLE_DECAY;
+        if (p.life <= 0) {
+          particles.splice(i, 1);
+          continue;
+        }
+        const alpha = Math.max(0, Math.min(1, p.life));
+        ctx.beginPath();
+        ctx.fillStyle = `hsla(${p.hue}, 90%, 65%, ${alpha})`;
+        ctx.shadowColor = `hsla(${p.hue}, 95%, 70%, ${alpha * 0.9})`;
+        ctx.shadowBlur = 14;
+        ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      ctx.restore();
+      rafRef.current = requestAnimationFrame(step);
+    };
+
+    rafRef.current = requestAnimationFrame(step);
+
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      observer.disconnect();
+    };
+  }, []);
+
+  const handlePointer = (event: React.PointerEvent<HTMLDivElement>) => {
+    const target = containerRef.current;
+    if (!target) return;
+    const rect = target.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    const now = performance.now();
+
+    // throttle absorb to one mix per ~16ms to avoid saturating the pool
+    if (now - lastMixRef.current < 12) return;
+    lastMixRef.current = now;
+
+    pool.absorb(
+      pointerEntropyValues(
+        Math.round(x),
+        Math.round(y),
+        Math.round(now),
+        event.pressure,
+      ),
+    );
+    onEvent();
+
+    const particles = particlesRef.current;
+    const hue = (now / 12) % 360;
+    for (let i = 0; i < 3; i += 1) {
+      const angle = Math.random() * Math.PI * 2;
+      const speed = Math.random() * 1.8 + 0.4;
+      particles.push({
+        x,
+        y,
+        vx: Math.cos(angle) * speed,
+        vy: Math.sin(angle) * speed,
+        life: 1,
+        hue: (hue + i * 18) % 360,
+        size: Math.random() * 1.8 + 1.1,
+      });
+    }
+    if (particles.length > MAX_PARTICLES) {
+      particles.splice(0, particles.length - MAX_PARTICLES);
+    }
+  };
+
+  const percent = Math.round(progress * 100);
+
+  return (
+    <div
+      ref={containerRef}
+      onPointerMove={handlePointer}
+      onPointerDown={handlePointer}
+      role="img"
+      aria-label={`Entropy seeder. ${events} pointer events captured, ${percent} percent seeded.`}
+      className={`group relative overflow-hidden rounded-2xl border border-gray-200/60 dark:border-gray-700/60 bg-[#0b1220] touch-none select-none ${className ?? ''}`}
+      style={{ minHeight: 160 }}
+    >
+      <canvas
+        ref={canvasRef}
+        className="absolute inset-0 h-full w-full"
+        aria-hidden="true"
+      />
+      <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center text-center px-4">
+        <div className="text-[11px] uppercase tracking-[0.22em] text-cyan-200/80 font-semibold">
+          Entropy seeder
+        </div>
+        <div className="mt-1 text-sm sm:text-base text-white/90">
+          Move your cursor to seed · tap &amp; drag on mobile
+        </div>
+        <div className="mt-3 w-full max-w-xs">
+          <div className="h-1.5 w-full rounded-full bg-white/10 overflow-hidden">
+            <div
+              className="h-full bg-gradient-to-r from-cyan-400 via-violet-400 to-fuchsia-400 transition-[width] duration-150"
+              style={{ width: `${percent}%` }}
+            />
+          </div>
+          <div className="mt-1.5 flex items-center justify-between text-[10px] uppercase tracking-wider text-white/60">
+            <span>{events} events</span>
+            <span>{percent}%</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EntropyCanvas;

--- a/src/tools/random-password-generator/components/GeneratorPanel.tsx
+++ b/src/tools/random-password-generator/components/GeneratorPanel.tsx
@@ -1,19 +1,29 @@
 /**
- * Random Password Generator UI with multiple modes (UUID, Key, Password).
+ * © 2025 MyDebugger Contributors – MIT License
+ *
+ * Single-viewport password / UUID / key generator with an interactive
+ * entropy canvas. Pointer and touch events seed a pool that is XORed
+ * against crypto.getRandomValues() output when the user forges a key.
  */
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@design-system/components/inputs/Button';
-import { Card } from '@design-system/components/layout/Card';
-import { ProgressBar } from '@design-system/components/feedback/ProgressBar';
-import { SelectInput } from '@design-system/components/inputs/SelectInput';
 import './CopyAnimation.css';
-import { generatePassword, estimateStrength, PasswordOptions, generateUUIDv4, generateKey, KeyOptions } from '../lib/generators';
+import {
+  generatePassword,
+  estimateStrength,
+  PasswordOptions,
+  generateUUIDv4,
+  generateKey,
+  KeyOptions,
+} from '../lib/generators';
+import { EntropyPool } from '../lib/entropy';
+import { EntropyCanvas } from './EntropyCanvas';
 import { logEvent } from '../../../lib/analytics';
 
 type Mode = 'password' | 'uuid' | 'key';
 
 const defaultPasswordOptions: PasswordOptions = {
-  length: 16,
+  length: 20,
   includeLowercase: true,
   includeUppercase: true,
   includeNumbers: true,
@@ -21,56 +31,70 @@ const defaultPasswordOptions: PasswordOptions = {
   excludeAmbiguous: true,
 };
 
+const strengthStyles: Record<string, { bg: string; text: string }> = {
+  'Very weak': { bg: 'bg-red-100 dark:bg-red-900/40', text: 'text-red-700 dark:text-red-200' },
+  Weak: { bg: 'bg-orange-100 dark:bg-orange-900/40', text: 'text-orange-700 dark:text-orange-200' },
+  Good: { bg: 'bg-yellow-100 dark:bg-yellow-900/40', text: 'text-yellow-800 dark:text-yellow-200' },
+  Strong: { bg: 'bg-green-100 dark:bg-green-900/40', text: 'text-green-700 dark:text-green-200' },
+  'Very strong': { bg: 'bg-emerald-100 dark:bg-emerald-900/40', text: 'text-emerald-700 dark:text-emerald-200' },
+};
+
 export const GeneratorPanel: React.FC = () => {
   const [mode, setMode] = useState<Mode>('password');
   const [passOpts, setPassOpts] = useState<PasswordOptions>(() => {
-    // restore last settings
     try {
       const raw = localStorage.getItem('rpg_options');
       return raw ? { ...defaultPasswordOptions, ...JSON.parse(raw) } : defaultPasswordOptions;
-    } catch { return defaultPasswordOptions; }
+    } catch {
+      return defaultPasswordOptions;
+    }
   });
   const [keyOpts, setKeyOpts] = useState<KeyOptions>({ bits: 256, format: 'hex' });
-  const [output, setOutput] = useState<string>('');
-  const [copied, setCopied] = useState<boolean>(false);
-  const [regenSpin, setRegenSpin] = useState<boolean>(false);
-  const copyAnimateRef = useRef<HTMLDivElement | null>(null);
+  const [output, setOutput] = useState('');
+  const [copied, setCopied] = useState(false);
+  const [seedUsed, setSeedUsed] = useState(0);
+  const [entropyVersion, setEntropyVersion] = useState(0);
 
-  // Generate on mount and whenever options change
+  const poolRef = useRef<EntropyPool>(new EntropyPool());
+  const copyBurstRef = useRef<HTMLDivElement | null>(null);
+
+  const regenerate = useCallback(() => {
+    const pool = poolRef.current;
+    const snapshot = pool.snapshot();
+    const seededEvents = pool.events;
+    let next = '';
+    if (mode === 'uuid') next = generateUUIDv4(snapshot);
+    else if (mode === 'key') next = generateKey(keyOpts, snapshot);
+    else next = generatePassword(passOpts, snapshot);
+    setOutput(next);
+    setSeedUsed(seededEvents);
+    try { logEvent('rpg_regenerate', { mode, seeded_events: seededEvents }); } catch { /* noop */ }
+  }, [mode, passOpts, keyOpts]);
+
   useEffect(() => {
     regenerate();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mode, passOpts, keyOpts.bits, keyOpts.format]);
+  }, [regenerate]);
 
   useEffect(() => {
-    try { localStorage.setItem('rpg_options', JSON.stringify(passOpts)); } catch {}
+    try { localStorage.setItem('rpg_options', JSON.stringify(passOpts)); } catch { /* noop */ }
   }, [passOpts]);
 
-  const strength = useMemo(() => {
-    if (mode !== 'password') return null;
-    return estimateStrength(passOpts, output || '');
-  }, [mode, passOpts, output]);
+  const strength = useMemo(
+    () => (mode === 'password' ? estimateStrength(passOpts, output || '') : null),
+    [mode, passOpts, output],
+  );
 
-  function regenerate() {
-    if (mode === 'uuid') {
-      setOutput(generateUUIDv4());
-    } else if (mode === 'key') {
-      setOutput(generateKey(keyOpts));
-    } else {
-      setOutput(generatePassword(passOpts));
-    }
-    try { logEvent('rpg_regenerate', { mode }); } catch {}
-  }
+  const strengthBadge = useMemo(() => {
+    if (!strength) return null;
+    return strengthStyles[strength.label] ?? {
+      bg: 'bg-gray-100 dark:bg-gray-800',
+      text: 'text-gray-700 dark:text-gray-200',
+    };
+  }, [strength]);
 
-  function handleRegenerate() {
-    setRegenSpin(true);
-    regenerate();
-    setTimeout(() => setRegenSpin(false), 700);
-  }
-
-  async function copyToClipboard() {
+  const copyToClipboard = async () => {
     try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
+      if (navigator.clipboard?.writeText) {
         await navigator.clipboard.writeText(output);
       } else {
         const ta = document.createElement('textarea');
@@ -84,12 +108,11 @@ export const GeneratorPanel: React.FC = () => {
         document.body.removeChild(ta);
       }
       setCopied(true);
-      // simple burst dots to mimic micro-animation feedback
-      const container = copyAnimateRef.current;
+      const container = copyBurstRef.current;
       if (container) {
         const burst = document.createElement('div');
         burst.className = 'copy-burst';
-        for (let i = 0; i < 8; i++) {
+        for (let i = 0; i < 8; i += 1) {
           const dot = document.createElement('span');
           const angle = (i / 8) * 2 * Math.PI;
           const radius = 14;
@@ -101,216 +124,273 @@ export const GeneratorPanel: React.FC = () => {
         setTimeout(() => burst.remove(), 650);
       }
       setTimeout(() => setCopied(false), 1600);
-      try { logEvent('rpg_copy', { mode, length: output.length }); } catch {}
-    } catch {}
-  }
+      try { logEvent('rpg_copy', { mode, length: output.length }); } catch { /* noop */ }
+    } catch { /* noop */ }
+  };
 
-  const strengthBadge = useMemo(() => {
-    if (!strength) return null;
-    const map: Record<string, { bg: string; text: string }> = {
-      'Very weak': { bg: 'bg-red-100 dark:bg-red-900/30', text: 'text-red-700 dark:text-red-200' },
-      Weak: { bg: 'bg-orange-100 dark:bg-orange-900/30', text: 'text-orange-700 dark:text-orange-200' },
-      Good: { bg: 'bg-yellow-100 dark:bg-yellow-900/30', text: 'text-yellow-800 dark:text-yellow-200' },
-      Strong: { bg: 'bg-green-100 dark:bg-green-900/30', text: 'text-green-700 dark:text-green-200' },
-      'Very strong': { bg: 'bg-emerald-100 dark:bg-emerald-900/30', text: 'text-emerald-700 dark:text-emerald-200' },
-    };
-    return map[strength.label] || { bg: 'bg-gray-100 dark:bg-gray-800', text: 'text-gray-700 dark:text-gray-200' };
-  }, [strength]);
+  const handleEntropyEvent = useCallback(() => {
+    // throttle state updates — only re-render every 6 events for perf
+    const pool = poolRef.current;
+    if (pool.events % 6 === 0) {
+      setEntropyVersion((v) => v + 1);
+    }
+  }, []);
+
+  // Referenced to avoid unused-variable lint when reading progress
+  void entropyVersion;
+
+  const resetPool = () => {
+    poolRef.current.reset();
+    setEntropyVersion((v) => v + 1);
+  };
+
+  const charSetCount = [
+    passOpts.includeUppercase,
+    passOpts.includeLowercase,
+    passOpts.includeNumbers,
+    passOpts.includeSymbols,
+  ].filter(Boolean).length;
+
+  const noCharSetSelected = mode === 'password' && charSetCount === 0;
 
   return (
-    <div className="space-y-6">
-      <Card
-        title="Generator"
-        subtitle="Generated locally via Web Crypto; never transmitted."
-        className="overflow-visible"
-        actions={
-          <div className="flex flex-wrap gap-2 justify-end">
-            <div className="inline-flex rounded-xl bg-gray-100 dark:bg-gray-800 p-1">
-              {[{ id: 'password', label: 'Password' }, { id: 'uuid', label: 'UUID' }, { id: 'key', label: 'Key' }].map((t) => (
-                <button
-                  key={t.id}
-                  className={`px-3 py-1.5 rounded-lg text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900 ${mode === t.id ? 'bg-white dark:bg-gray-700 shadow-sm text-primary-700 dark:text-primary-200' : 'text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'}`}
-                  onClick={() => setMode(t.id as Mode)}
-                  aria-pressed={mode === t.id}
-                >
-                  {t.label}
-                </button>
-              ))}
-            </div>
-          </div>
-        }
-      >
-        <div className="flex flex-col gap-6">
-          <div className="space-y-3" onDoubleClick={handleRegenerate}>
-            <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white/60 dark:bg-gray-900/40 p-3">
-              <textarea
-                className="w-full min-h-[52px] resize-none bg-transparent outline-none font-mono text-sm sm:text-base leading-6 text-gray-900 dark:text-gray-100"
-                value={output}
-                readOnly
-                aria-label="Generated output"
-                spellCheck={false}
-                autoCorrect="off"
-                autoCapitalize="off"
-                onFocus={(e) => e.currentTarget.select()}
-              />
-            </div>
-
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+    <div className="mx-auto w-full max-w-6xl">
+      <div className="grid gap-4 lg:gap-5 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
+        {/* LEFT: key display + entropy canvas */}
+        <div className="flex flex-col gap-4">
+          {/* Final render key card */}
+          <div className="rounded-2xl border border-gray-200 dark:border-gray-800 bg-white/80 dark:bg-gray-900/70 backdrop-blur-sm p-4 sm:p-5 shadow-sm">
+            <div className="flex items-center justify-between gap-2">
               <div className="flex items-center gap-2">
+                <span aria-hidden="true" className="text-lg">🔑</span>
+                <h2 className="text-xs font-semibold uppercase tracking-[0.22em] text-gray-500 dark:text-gray-400">
+                  Final render key
+                </h2>
+              </div>
+              <div className="flex items-center gap-2 text-[11px] text-gray-500 dark:text-gray-400">
+                <span className="inline-flex items-center gap-1 rounded-full bg-cyan-50 dark:bg-cyan-900/30 text-cyan-700 dark:text-cyan-200 px-2 py-0.5">
+                  <svg className="h-3 w-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><circle cx="12" cy="12" r="6" /></svg>
+                  Seeded · {seedUsed} events
+                </span>
+              </div>
+            </div>
+            <div
+              className="mt-3 rounded-xl bg-gray-950 text-gray-100 font-mono text-base sm:text-lg leading-7 p-4 break-all min-h-[88px] select-all shadow-inner"
+              onDoubleClick={regenerate}
+              aria-live="polite"
+            >
+              {output || <span className="text-gray-500">Move your cursor over the entropy canvas to seed your first key.</span>}
+            </div>
+            <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+              <div className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
+                <span className="rounded-full bg-gray-100 dark:bg-gray-800 px-2 py-0.5">Length {output.length}</span>
                 {mode === 'password' && strength && strengthBadge && (
-                  <span className={`text-xs px-2.5 py-1 rounded-full ${strengthBadge.bg} ${strengthBadge.text}`}>
+                  <span className={`rounded-full px-2 py-0.5 ${strengthBadge.bg} ${strengthBadge.text}`}>
                     {strength.label}
                   </span>
                 )}
-                <span className="text-xs text-gray-500 dark:text-gray-400">Length: {output.length}</span>
+                {mode === 'password' && strength && (
+                  <span className="hidden sm:inline text-[11px] text-gray-400">
+                    ~{Math.round(strength.entropy)} bits
+                  </span>
+                )}
               </div>
-
               <div className="flex items-center gap-2">
-                <div className="relative" ref={copyAnimateRef}>
-                  <Button size="sm" onClick={copyToClipboard} aria-live="polite" disabled={!output}>
-                    {copied ? 'Copied' : 'Copy'}
+                <div className="relative" ref={copyBurstRef}>
+                  <Button size="sm" onClick={copyToClipboard} disabled={!output}>
+                    {copied ? 'Copied ✓' : 'Copy'}
                   </Button>
                 </div>
-                <Button
-                  size="sm"
-                  variant="outline-primary"
-                  onClick={handleRegenerate}
-                >
-                  <span className={`inline-flex items-center ${regenSpin ? 'transition-transform rotate-180' : 'transition-transform'}`}>
-                    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v6h6M20 20v-6h-6M20 8a8 8 0 10-7.906 8"/></svg>
-                  </span>
-                  <span className="ml-2">Regenerate</span>
+                <Button size="sm" variant="outline-primary" onClick={regenerate} disabled={noCharSetSelected}>
+                  <svg className="mr-1.5 h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v6h6M20 20v-6h-6M20 8a8 8 0 10-7.906 8" /></svg>
+                  Forge key
                 </Button>
               </div>
             </div>
-
-            {mode === 'password' && strength && (
-              <div className="pt-2">
-                <ProgressBar value={strength.score} />
-              </div>
-            )}
           </div>
 
-          {mode === 'password' && (
-            <div className="grid lg:grid-cols-2 gap-6">
-              <div className="space-y-3">
-                <div className="flex items-baseline justify-between">
-                  <label className="block text-sm font-medium">Password length</label>
-                  <span className="text-sm text-gray-600 dark:text-gray-300">{passOpts.length}</span>
+          {/* Entropy canvas */}
+          <EntropyCanvas
+            pool={poolRef.current}
+            onEvent={handleEntropyEvent}
+            progress={poolRef.current.progress}
+            events={poolRef.current.events}
+            className="h-[180px] sm:h-[220px] lg:h-[260px]"
+          />
+          <div className="flex items-center justify-between text-[11px] text-gray-500 dark:text-gray-400">
+            <span>Pointer data XORs against Web Crypto — CSPRNG still guarantees security.</span>
+            <button
+              type="button"
+              onClick={resetPool}
+              className="text-gray-500 hover:text-gray-800 dark:hover:text-gray-200 underline underline-offset-2"
+            >
+              Reset pool
+            </button>
+          </div>
+        </div>
+
+        {/* RIGHT: settings */}
+        <div className="flex flex-col gap-3">
+          <div className="rounded-2xl border border-gray-200 dark:border-gray-800 bg-white/80 dark:bg-gray-900/70 backdrop-blur-sm p-4 sm:p-5">
+            <div className="flex items-center justify-between">
+              <h2 className="text-xs font-semibold uppercase tracking-[0.22em] text-gray-500 dark:text-gray-400">
+                Output type
+              </h2>
+            </div>
+            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+            <label htmlFor="rpg-mode" className="sr-only">Output type</label>
+            <select
+              id="rpg-mode"
+              value={mode}
+              onChange={(e) => setMode(e.target.value as Mode)}
+              className="mt-2 w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+            >
+              <option value="password">Password</option>
+              <option value="uuid">UUID v4</option>
+              <option value="key">Crypto key</option>
+            </select>
+
+            {mode === 'password' && (
+              <div className="mt-4 space-y-3">
+                <div>
+                  <div className="flex items-baseline justify-between">
+                    <span className="text-xs font-medium text-gray-600 dark:text-gray-300">Length</span>
+                    <span className="text-sm tabular-nums text-gray-900 dark:text-gray-100">{passOpts.length}</span>
+                  </div>
+                  {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+                  <label htmlFor="rpg-length" className="sr-only">Password length</label>
+                  <input
+                    id="rpg-length"
+                    type="range"
+                    min={8}
+                    max={64}
+                    value={passOpts.length}
+                    onChange={(e) => setPassOpts({ ...passOpts, length: parseInt(e.target.value, 10) })}
+                    className="w-full accent-primary-500"
+                  />
+                  <div className="mt-1 flex flex-wrap gap-1.5">
+                    {[12, 16, 20, 24, 32, 48].map((v) => (
+                      <button
+                        key={v}
+                        type="button"
+                        onClick={() => setPassOpts({ ...passOpts, length: v })}
+                        className={`px-2 py-0.5 text-xs rounded-md border transition-colors ${
+                          passOpts.length === v
+                            ? 'bg-primary-50 border-primary-300 text-primary-700 dark:bg-primary-900/30 dark:border-primary-700 dark:text-primary-200'
+                            : 'border-gray-300 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800'
+                        }`}
+                      >
+                        {v}
+                      </button>
+                    ))}
+                  </div>
                 </div>
-                <input
-                  type="range"
-                  min={8}
-                  max={64}
-                  value={passOpts.length}
-                  onChange={(e) => setPassOpts({ ...passOpts, length: parseInt(e.target.value) })}
-                  className="w-full accent-blue-500"
-                />
-                <div className="flex flex-wrap gap-2">
-                  {[12, 16, 20, 24, 32].map((v) => (
+
+                <div>
+                  <div className="text-xs font-medium text-gray-600 dark:text-gray-300">Character sets</div>
+                  <div className="mt-1.5 grid grid-cols-2 gap-1.5">
+                    {[
+                      { key: 'includeUppercase' as const, label: 'A–Z' },
+                      { key: 'includeLowercase' as const, label: 'a–z' },
+                      { key: 'includeNumbers' as const, label: '0–9' },
+                      { key: 'includeSymbols' as const, label: '!@#$' },
+                    ].map((opt) => {
+                      const active = passOpts[opt.key];
+                      return (
+                        <button
+                          key={opt.key}
+                          type="button"
+                          aria-pressed={active}
+                          onClick={() => setPassOpts({ ...passOpts, [opt.key]: !active })}
+                          className={`rounded-lg border px-2.5 py-1.5 text-sm transition-colors text-left ${
+                            active
+                              ? 'bg-primary-50 border-primary-300 text-primary-700 dark:bg-primary-900/30 dark:border-primary-700 dark:text-primary-100'
+                              : 'border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
+                          }`}
+                        >
+                          {opt.label}
+                        </button>
+                      );
+                    })}
                     <button
-                      key={v}
-                      onClick={() => setPassOpts({ ...passOpts, length: v })}
-                      className={`px-2.5 py-1 text-xs rounded-lg border focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900 ${passOpts.length === v ? 'bg-primary-50 border-primary-300 text-primary-700 dark:bg-primary-900/30 dark:border-primary-700 dark:text-primary-200' : 'border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800'}`}
+                      type="button"
+                      aria-pressed={passOpts.excludeAmbiguous}
+                      onClick={() => setPassOpts({ ...passOpts, excludeAmbiguous: !passOpts.excludeAmbiguous })}
+                      className={`col-span-2 rounded-lg border px-2.5 py-1.5 text-xs transition-colors text-left ${
+                        passOpts.excludeAmbiguous
+                          ? 'bg-primary-50 border-primary-300 text-primary-700 dark:bg-primary-900/30 dark:border-primary-700 dark:text-primary-100'
+                          : 'border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
+                      }`}
                     >
-                      {v}
+                      Avoid look-alikes <span className="text-[11px] opacity-70">(O/0, l/1)</span>
                     </button>
-                  ))}
-                </div>
-              </div>
-
-              <div className="space-y-3">
-                <div className="text-sm font-medium">Character sets</div>
-                <div className="grid sm:grid-cols-2 gap-2">
-                  {[
-                    { key: 'includeUppercase', label: 'Uppercase', hint: 'ABC' },
-                    { key: 'includeLowercase', label: 'Lowercase', hint: 'abc' },
-                    { key: 'includeNumbers', label: 'Numbers', hint: '123' },
-                    { key: 'includeSymbols', label: 'Symbols', hint: '#$&' },
-                  ].map((opt) => (
-                    <label
-                      key={opt.key}
-                      className="flex items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white/40 dark:bg-gray-900/20 px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
-                    >
-                      <input
-                        type="checkbox"
-                        className="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
-                        checked={(passOpts as any)[opt.key]}
-                        onChange={(e) => setPassOpts({ ...(passOpts as any), [opt.key]: e.target.checked })}
-                      />
-                      <span className="flex-1">{opt.label}</span>
-                      <span className="text-xs text-gray-500 dark:text-gray-400">{opt.hint}</span>
-                    </label>
-                  ))}
-
-                  <label className="sm:col-span-2 flex items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white/40 dark:bg-gray-900/20 px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
-                    <input
-                      type="checkbox"
-                      className="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
-                      checked={passOpts.excludeAmbiguous}
-                      onChange={(e) => setPassOpts({ ...passOpts, excludeAmbiguous: e.target.checked })}
-                    />
-                    <span className="flex-1">Avoid ambiguous characters</span>
-                    <span className="text-xs text-gray-500 dark:text-gray-400">O/0, l/1</span>
-                  </label>
-
-                  {!(passOpts.includeLowercase || passOpts.includeUppercase || passOpts.includeNumbers || passOpts.includeSymbols) && (
-                    <div className="sm:col-span-2 text-xs text-red-600">Select at least one character set.</div>
+                  </div>
+                  {noCharSetSelected && (
+                    <p className="mt-1.5 text-xs text-red-600">Select at least one character set.</p>
                   )}
                 </div>
               </div>
-            </div>
-          )}
+            )}
 
-          {mode === 'key' && (
-            <div className="grid lg:grid-cols-2 gap-6">
-              <SelectInput
-                label="Key size"
-                className="mb-0"
-                value={String(keyOpts.bits)}
-                onChange={(value) => setKeyOpts({ ...keyOpts, bits: parseInt(value) as KeyOptions['bits'] })}
-                options={[
-                  { value: '128', label: '128-bit' },
-                  { value: '192', label: '192-bit' },
-                  { value: '256', label: '256-bit' },
-                ]}
-              />
-              <SelectInput
-                label="Format"
-                className="mb-0"
-                value={keyOpts.format}
-                onChange={(value) => setKeyOpts({ ...keyOpts, format: value as KeyOptions['format'] })}
-                options={[
-                  { value: 'hex', label: 'Hex' },
-                  { value: 'base64', label: 'Base64' },
-                ]}
-              />
-              <div className="lg:col-span-2 text-sm text-gray-500 dark:text-gray-400">
-                Use for API keys, secrets, or test tokens. Store securely.
+            {mode === 'key' && (
+              <div className="mt-4 space-y-3">
+                <div>
+                  <div className="text-xs font-medium text-gray-600 dark:text-gray-300 mb-1">Key size</div>
+                  <div className="flex gap-1.5">
+                    {([128, 192, 256] as const).map((bits) => (
+                      <button
+                        key={bits}
+                        type="button"
+                        onClick={() => setKeyOpts({ ...keyOpts, bits })}
+                        className={`flex-1 rounded-lg border px-2.5 py-1.5 text-sm transition-colors ${
+                          keyOpts.bits === bits
+                            ? 'bg-primary-50 border-primary-300 text-primary-700 dark:bg-primary-900/30 dark:border-primary-700 dark:text-primary-100'
+                            : 'border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
+                        }`}
+                      >
+                        {bits}-bit
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-xs font-medium text-gray-600 dark:text-gray-300 mb-1">Encoding</div>
+                  <div className="flex gap-1.5">
+                    {(['hex', 'base64'] as const).map((fmt) => (
+                      <button
+                        key={fmt}
+                        type="button"
+                        onClick={() => setKeyOpts({ ...keyOpts, format: fmt })}
+                        className={`flex-1 rounded-lg border px-2.5 py-1.5 text-sm transition-colors ${
+                          keyOpts.format === fmt
+                            ? 'bg-primary-50 border-primary-300 text-primary-700 dark:bg-primary-900/30 dark:border-primary-700 dark:text-primary-100'
+                            : 'border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
+                        }`}
+                      >
+                        {fmt === 'hex' ? 'Hex' : 'Base64'}
+                      </button>
+                    ))}
+                  </div>
+                </div>
               </div>
-            </div>
-          )}
+            )}
 
-          {mode === 'uuid' && (
-            <div className="text-sm text-gray-500 dark:text-gray-400">
-              UUID v4 generated with Web Crypto.
-            </div>
-          )}
+            {mode === 'uuid' && (
+              <p className="mt-4 text-xs text-gray-500 dark:text-gray-400">
+                UUID v4 · version and variant bits are fixed; the remaining 122 bits come
+                from Web Crypto, optionally XORed with your pointer entropy.
+              </p>
+            )}
+          </div>
+
+          <div className="rounded-2xl border border-gray-200 dark:border-gray-800 bg-white/60 dark:bg-gray-900/60 p-3 sm:p-4 text-[11px] text-gray-500 dark:text-gray-400 leading-relaxed">
+            Local-only. Generated via <span className="font-mono">crypto.getRandomValues</span>; never transmitted or stored.
+          </div>
         </div>
-      </Card>
-
-      <Card title="Best practices" className="text-sm">
-        <ul className="list-disc pl-5 space-y-1 text-gray-600 dark:text-gray-300">
-          <li>Use 16+ characters and include multiple character sets.</li>
-          <li>Never reuse passwords. Store them in a trusted manager.</li>
-          <li>All generation happens locally in your browser.</li>
-        </ul>
-        <div className="sr-only" aria-live="polite">{copied ? 'Copied to clipboard' : ''}</div>
-      </Card>
+      </div>
+      <div className="sr-only" aria-live="polite">{copied ? 'Copied to clipboard' : ''}</div>
     </div>
   );
 };
 
 export default GeneratorPanel;
-
-

--- a/src/tools/random-password-generator/lib/entropy.ts
+++ b/src/tools/random-password-generator/lib/entropy.ts
@@ -1,0 +1,92 @@
+/**
+ * © 2025 MyDebugger Contributors – MIT License
+ *
+ * Entropy pool that absorbs pointer events (mouse move, touch move) and
+ * exposes bytes used to XOR-augment crypto.getRandomValues output. The
+ * pool is seeded with CSPRNG data, so zero user input still yields a
+ * cryptographically secure stream; user input only diffuses additional
+ * entropy and provides a visible proof of mixing.
+ */
+
+export const ENTROPY_POOL_SIZE = 64;
+export const ENTROPY_PROGRESS_TARGET = 256;
+
+export class EntropyPool {
+  private readonly pool: Uint8Array;
+
+  private position: number;
+
+  private eventCount: number;
+
+  constructor() {
+    this.pool = new Uint8Array(ENTROPY_POOL_SIZE);
+    if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+      crypto.getRandomValues(this.pool);
+    }
+    this.position = 0;
+    this.eventCount = 0;
+  }
+
+  /**
+   * Absorb a sequence of small integers (pointer coordinates, timestamps,
+   * pressure) into the pool. Each byte is XORed into a rotating slot and
+   * rotated left by one bit to diffuse.
+   */
+  absorb(values: readonly number[]): void {
+    if (values.length === 0) return;
+    for (const raw of values) {
+      const byte = raw & 0xff;
+      const idx = this.position % this.pool.length;
+      const current = this.pool[idx];
+      const mixed = (current ^ byte) & 0xff;
+      this.pool[idx] = ((mixed << 1) | (mixed >> 7)) & 0xff;
+      this.position += 1;
+    }
+    this.eventCount += 1;
+  }
+
+  /**
+   * Return a detached copy of the pool for use in a generator.
+   */
+  snapshot(): Uint8Array {
+    return this.pool.slice();
+  }
+
+  get events(): number {
+    return this.eventCount;
+  }
+
+  get progress(): number {
+    return Math.min(1, this.eventCount / ENTROPY_PROGRESS_TARGET);
+  }
+
+  reset(): void {
+    if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+      crypto.getRandomValues(this.pool);
+    } else {
+      for (let i = 0; i < this.pool.length; i += 1) this.pool[i] = 0;
+    }
+    this.position = 0;
+    this.eventCount = 0;
+  }
+}
+
+/**
+ * Build the list of small integers we want to mix from a pointer event.
+ */
+export const pointerEntropyValues = (
+  x: number,
+  y: number,
+  t: number,
+  pressure = 0,
+): number[] => [
+  x & 0xff,
+  (x >> 8) & 0xff,
+  y & 0xff,
+  (y >> 8) & 0xff,
+  t & 0xff,
+  (t >> 8) & 0xff,
+  (t >> 16) & 0xff,
+  (t >> 24) & 0xff,
+  Math.round(pressure * 255) & 0xff,
+];

--- a/src/tools/random-password-generator/lib/generators.ts
+++ b/src/tools/random-password-generator/lib/generators.ts
@@ -32,10 +32,46 @@ const NUMBERS = "0123456789";
 const SYMBOLS = "!@#$%^&*()_+[]{}|;:,.<>?/~-";
 const AMBIGUOUS = "O0oIl1|S5B8G6Z2"; // characters users often confuse
 
+export type EntropySource = {
+  bytes: Uint8Array;
+  cursor: { value: number };
+};
+
+export const createEntropySource = (entropy?: Uint8Array): EntropySource | undefined => {
+  if (!entropy || entropy.length === 0) return undefined;
+  return { bytes: entropy, cursor: { value: 0 } };
+};
+
 /**
- * Create a cryptographically strong random integer in [0, maxExclusive)
+ * Fill a typed array with cryptographically strong random bytes, optionally
+ * XORing each byte with the next value from a user-supplied entropy source.
+ * The entropy source never weakens the stream — it only diffuses additional
+ * randomness drawn from pointer events.
  */
-function secureRandInt(maxExclusive: number): number {
+function fillRandom(buffer: Uint32Array | Uint8Array, source?: EntropySource): void {
+  if (globalThis.crypto && globalThis.crypto.getRandomValues) {
+    globalThis.crypto.getRandomValues(buffer);
+  } else {
+    // eslint-disable-next-line no-restricted-syntax
+    for (let i = 0; i < buffer.length; i += 1) {
+      buffer[i] = Math.floor(Math.random() * 0x100000000);
+    }
+  }
+  if (source && source.bytes.length > 0) {
+    const view = new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+    for (let i = 0; i < view.length; i += 1) {
+      const { value } = source.cursor;
+      view[i] ^= source.bytes[value % source.bytes.length];
+      source.cursor.value = value + 1;
+    }
+  }
+}
+
+/**
+ * Create a cryptographically strong random integer in [0, maxExclusive),
+ * optionally diffused with bytes from a user-entropy source.
+ */
+function secureRandInt(maxExclusive: number, source?: EntropySource): number {
   if (maxExclusive <= 0) return 0;
   // Use rejection sampling to avoid modulo bias
   const maxUint = 0xffffffff;
@@ -43,9 +79,7 @@ function secureRandInt(maxExclusive: number): number {
   const buffer = new Uint32Array(1);
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    (globalThis.crypto && globalThis.crypto.getRandomValues
-      ? globalThis.crypto.getRandomValues(buffer)
-      : buffer.fill(Math.floor(Math.random() * (maxUint + 1)))) as any;
+    fillRandom(buffer, source);
     const value = buffer[0];
     if (value < maxUnbiased) {
       return value % maxExclusive;
@@ -53,7 +87,10 @@ function secureRandInt(maxExclusive: number): number {
   }
 }
 
-export function generatePassword(options: PasswordOptions): string {
+export function generatePassword(
+  options: PasswordOptions,
+  entropy?: Uint8Array,
+): string {
   const {
     length,
     includeUppercase,
@@ -64,10 +101,12 @@ export function generatePassword(options: PasswordOptions): string {
     customChars
   } = options;
 
+  const source = createEntropySource(entropy);
+
   if (customChars && customChars.length > 0) {
     const chars: string[] = [];
     for (let i = 0; i < length; i++) {
-      chars.push(customChars[secureRandInt(customChars.length)]);
+      chars.push(customChars[secureRandInt(customChars.length, source)]);
     }
     return chars.join("");
   }
@@ -94,33 +133,33 @@ export function generatePassword(options: PasswordOptions): string {
   // If requested length is smaller than the number of required sets,
   // choose a subset of sets at random to keep exact length
   const setsToUse = requiredSets.slice();
-  
+
   // Apply ambiguity filter to sets
-  const filteredSets = setsToUse.map(set => 
+  const filteredSets = setsToUse.map(set =>
     excludeAmbiguous ? [...set].filter(c => !AMBIGUOUS.includes(c)).join("") : set
   ).filter(s => s.length > 0);
 
   if (length < filteredSets.length) {
     // shuffle and keep first N
     for (let i = filteredSets.length - 1; i > 0; i--) {
-      const j = secureRandInt(i + 1);
+      const j = secureRandInt(i + 1, source);
       [filteredSets[i], filteredSets[j]] = [filteredSets[j], filteredSets[i]];
     }
     filteredSets.length = length;
   }
 
   for (const set of filteredSets) {
-    chars.push(set[secureRandInt(set.length)]);
+    chars.push(set[secureRandInt(set.length, source)]);
   }
 
   const remaining = Math.max(0, length - chars.length);
   for (let i = 0; i < remaining; i++) {
-    chars.push(pool[secureRandInt(pool.length)]);
+    chars.push(pool[secureRandInt(pool.length, source)]);
   }
 
   // Shuffle
   for (let i = chars.length - 1; i > 0; i--) {
-    const j = secureRandInt(i + 1);
+    const j = secureRandInt(i + 1, source);
     [chars[i], chars[j]] = [chars[j], chars[i]];
   }
 
@@ -209,13 +248,21 @@ export function estimateStrength(options: PasswordOptions | PassphraseOptions | 
 }
 
 
-export function generateUUIDv4(): string {
-  if (globalThis.crypto && typeof globalThis.crypto.randomUUID === "function") return globalThis.crypto.randomUUID();
-  // Fallback
+export function generateUUIDv4(entropy?: Uint8Array): string {
+  // When the user has seeded the pool, derive the UUID from a
+  // crypto+entropy mix so the variant/version bits still come from a
+  // known-good stream. When no seed is provided, prefer the native
+  // randomUUID (same CSPRNG, simpler path).
+  if (
+    (!entropy || entropy.length === 0) &&
+    globalThis.crypto &&
+    typeof globalThis.crypto.randomUUID === "function"
+  ) {
+    return globalThis.crypto.randomUUID();
+  }
+  const source = createEntropySource(entropy);
   const bytes = new Uint8Array(16);
-  (globalThis.crypto && globalThis.crypto.getRandomValues
-    ? globalThis.crypto.getRandomValues(bytes)
-    : bytes.forEach((_, i, a) => (a[i] = Math.floor(Math.random() * 256)))) as any;
+  fillRandom(bytes, source);
   bytes[6] = (bytes[6] & 0x0f) | 0x40;
   bytes[8] = (bytes[8] & 0x3f) | 0x80;
   const toHex = (n: number) => n.toString(16).padStart(2, "0");
@@ -231,10 +278,14 @@ export type KeyOptions = {
   format: "hex" | "base64";
 };
 
-export function generateKey({ bits, format }: KeyOptions): string {
+export function generateKey(
+  { bits, format }: KeyOptions,
+  entropy?: Uint8Array,
+): string {
   const bytes = bits / 8;
   const buf = new Uint8Array(bytes);
-  crypto.getRandomValues(buf);
+  const source = createEntropySource(entropy);
+  fillRandom(buf, source);
   if (format === "hex") {
     return [...buf].map((b) => b.toString(16).padStart(2, "0")).join("");
   }

--- a/src/tools/random-password-generator/page.tsx
+++ b/src/tools/random-password-generator/page.tsx
@@ -46,7 +46,8 @@ const RandomPasswordGeneratorPage: React.FC = () => {
       <ToolLayout
         tool={tool!}
         title="Random Password Generator"
-        description="Generate strong passwords, UUIDs, and cryptographic keys locally in your browser. Secure, fast, and copy with one click."
+        description="Seed randomness with your cursor. Passwords, UUIDs and keys are generated locally via Web Crypto — never transmitted."
+        showRelatedTools={false}
       >
         <GeneratorPanel />
       </ToolLayout>


### PR DESCRIPTION
## Summary
Reimagines `/random-password-generator` around an interactive entropy-seeding experience. One viewport, no tabs, no scroll — mobile and desktop.

- **Final render key** sits at the top with a live strength/entropy badge and a prominent **Forge key** action.
- **Entropy canvas** absorbs pointer-move and touch-move events into a 64-byte pool (seeded with Web Crypto), rendering a fading particle trail + live progress meter so the user literally sees randomness being mixed.
- **Settings** collapse into a side column with a compact `<select>` mode switcher (Password / UUID v4 / Crypto key) instead of the previous tab-like segmented control, plus toggle pills for character sets.
- `ToolLayout` now hides the related-tools section for this page to preserve the one-viewport budget.

## How the randomness works
`generatePassword`, `generateUUIDv4`, `generateKey` gain an optional `entropy?: Uint8Array` parameter. When provided, each random byte drawn from `crypto.getRandomValues` is XORed against the pool. XORing with attacker-unknown user motion cannot weaken a CSPRNG stream, so security is preserved even with zero user input — the seeding is a diffusion step, not a replacement.

## UI / layout notes
- CSS grid: `minmax(0,1.4fr)_minmax(0,1fr)` on `lg`, stacks on smaller screens.
- `PointerEvent`-based capture handles mouse, stylus and touch uniformly; the canvas uses `touch-none` + `select-none` to keep gestures smooth on mobile.
- Particle system is capped at 120 live particles with `requestAnimationFrame` cleanup.
- Event absorption is throttled to ≤ 1 mix per ~12 ms and pool state updates are batched every 6 events to keep renders light on mobile.

## Test plan
- [x] `jest --testPathPattern=random-password` — 14/14 pass (existing 5 + 9 new in `tools.random-password-generator.entropy.test.ts`)
- [x] `pnpm exec eslint src/tools/random-password-generator __tests__/tools.random-password-generator.entropy.test.ts --max-warnings 0`
- [x] `pnpm typecheck` introduces no new errors (pre-existing unrelated failures remain)
- [ ] Manual: verify mobile (320px) shows output + canvas + settings without vertical scroll
- [ ] Manual: verify dark-mode contrast on canvas and badges
- [ ] Manual: verify Copy + Forge key actions work with keyboard only

## Branch note
This lands on a fresh branch (`claude/random-password-entropy-ux`) branched from latest `main` because the previous session's branch (`claude/add-menu-tls-checker-BZfof`) was already merged in PR #169 — continuing there would have mixed the merged diff back into the new PR.