### PR TITLE
feat(footer): add share button using Web Share API

### DIFF
--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from '../context/TranslationContext';
 import { TrustBanner } from '@design-system';
@@ -16,6 +16,15 @@ const getIconHelper = (name: string) => {
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
         <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
       </svg>
+    ),
+    share: (
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="18" cy="5" r="3" />
+        <circle cx="6" cy="12" r="3" />
+        <circle cx="18" cy="19" r="3" />
+        <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+        <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+      </svg>
     )
   };
   return icons[name] || <span>📄</span>;
@@ -24,14 +33,49 @@ const getIconHelper = (name: string) => {
 const Footer: React.FC = () => {
   const { t } = useTranslation();
   const currentYear = new Date().getFullYear();
+  const [shareStatus, setShareStatus] = useState<string>('');
     // Function to handle LinkedIn navigation
   const handleLinkedInNavigation = () => {
     window.open('https://www.linkedin.com/in/jirads/', '_blank', 'noopener noreferrer');
   };
-  
+
   // Function to handle GitHub navigation
   const handleGitHubNavigation = () => {
     window.open('https://github.com/HydrogenB/mydebugger', '_blank', 'noopener noreferrer');
+  };
+
+  const handleShare = async () => {
+    const shareData = {
+      title: t('footer.shareTitle', 'MyDebugger'),
+      text: t(
+        'footer.shareText',
+        'A platform for debugging, encoding, decoding & demonstrating your technical work.',
+      ),
+      url: typeof window !== 'undefined' ? window.location.href : '',
+    };
+
+    if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+      try {
+        await navigator.share(shareData);
+        return;
+      } catch (err) {
+        if ((err as DOMException)?.name === 'AbortError') {
+          return;
+        }
+        // fall through to clipboard fallback
+      }
+    }
+
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(shareData.url);
+        setShareStatus(t('footer.shareCopied', 'Link copied!'));
+        window.setTimeout(() => setShareStatus(''), 2000);
+      } catch {
+        setShareStatus(t('footer.shareFailed', 'Unable to share'));
+        window.setTimeout(() => setShareStatus(''), 2000);
+      }
+    }
   };
 
   return (
@@ -65,7 +109,26 @@ const Footer: React.FC = () => {
               >
                 {getIconHelper('linkedin')}
               </button>
+              <button
+                type="button"
+                onClick={handleShare}
+                aria-label={t('footer.share', 'Share')}
+                className="text-gray-500 hover:text-gray-900 dark:hover:text-white transition"
+                data-analytics-event="cta_share"
+                data-analytics-label="Footer Share"
+              >
+                {getIconHelper('share')}
+              </button>
             </div>
+            {shareStatus && (
+              <p
+                role="status"
+                aria-live="polite"
+                className="mt-2 text-xs text-gray-500 dark:text-gray-400"
+              >
+                {shareStatus}
+              </p>
+            )}
           </div>
           
           


### PR DESCRIPTION
## Summary
- Adds a share icon button to the footer's social-icon row in `src/layout/Footer.tsx`, alongside the existing GitHub and LinkedIn buttons.
- On supported devices, clicking it opens the native share sheet via `navigator.share` (the iOS / Android system sheet shown in the reference screenshots).
- Falls back to `navigator.clipboard.writeText(window.location.href)` with a brief inline "Link copied!" status when Web Share is unavailable.
- User-cancelled shares (`AbortError`) are treated as a no-op so they don't trigger the clipboard fallback.

## Test plan
- [ ] On a mobile browser that supports the Web Share API, click the share button in the footer and confirm the native share sheet appears with the page title, description, and current URL.
- [ ] On a desktop browser without `navigator.share`, click the button and confirm the URL is copied to the clipboard and a transient "Link copied!" message appears.
- [ ] Trigger Web Share and dismiss the sheet; confirm no clipboard fallback runs and no error message is shown.
- [ ] Verify the share button is keyboard-focusable and exposes an accessible name ("Share").


---
_Generated by [Claude Code](https://claude.ai/code/session_01U8w7JKPsomerddN9meQ3C5)_