### PR TITLE
fix(qrscan): decode at native resolution, crop to reticle, add UX hints

### DIFF
--- a/src/tools/qrscan/components/ARScannerView.tsx
+++ b/src/tools/qrscan/components/ARScannerView.tsx
@@ -296,6 +296,7 @@ const ARScannerView: React.FC<Props> = ({
   clearResult,
   torch,
   performance: perf,
+  scanHint,
   scanHistory,
   removeHistoryEntry,
   clearHistory,
@@ -373,6 +374,14 @@ const ARScannerView: React.FC<Props> = ({
 
         {scanning && <Reticle scanning={scanning} />}
 
+        {scanning && scanHint && !result && (
+          <div className="pointer-events-none absolute inset-x-0 top-1/2 mt-[max(40vw,200px)] flex justify-center px-6">
+            <div className="max-w-xs rounded-2xl border border-white/15 bg-black/70 px-4 py-2 text-center text-xs text-white/90 backdrop-blur-md">
+              {scanHint}
+            </div>
+          </div>
+        )}
+
         {/* Top controls */}
         <div className="absolute inset-x-0 top-0 flex items-center justify-between gap-2 p-4 pt-[max(env(safe-area-inset-top),0.75rem)]">
           <TopButton label={scanning ? 'Stop camera' : 'Camera idle'} onClick={scanning ? stop : () => void start()}>
@@ -405,12 +414,14 @@ const ARScannerView: React.FC<Props> = ({
             {lastEngine ? (
               <span className="text-emerald-300">{lastEngine}</span>
             ) : (
-              <span className="text-white/60">scanning…</span>
+              <span className="text-white/60">searching…</span>
             )}
             <span className="mx-2 text-white/30">·</span>
             <span>{formatMs(lastDecodeMs)}</span>
             <span className="mx-2 text-white/30">·</span>
             <span>{perf.scansPerSecond ?? 0}/s</span>
+            <span className="mx-2 text-white/30">·</span>
+            <span>{formatCount(perf.attempts)} frames</span>
           </div>
         )}
 

--- a/src/tools/qrscan/hooks/useQrscan.ts
+++ b/src/tools/qrscan/hooks/useQrscan.ts
@@ -189,6 +189,7 @@ export interface UseQrscanReturn {
     set: (value: number) => Promise<void>;
   };
   performance: ScanPerformance;
+  scanHint: string | null;
   scanFromFile: (file: File) => Promise<void>;
   processManualText: (text: string) => void;
 }
@@ -323,6 +324,8 @@ const useQrscan = (): UseQrscanReturn => {
   const [zoomCapability, setZoomCapability] = useState<{ min: number; max: number; step: number } | null>(null);
   const [performance, setPerformance] = useState<ScanPerformance>(() => createEmptyPerformance());
   const attemptTimesRef = useRef<number[]>([]);
+  const scanStartedAtRef = useRef<number | null>(null);
+  const [scanHint, setScanHint] = useState<string | null>(null);
 
   const historyRef = useRef<ScanRecord[]>([]);
   useEffect(() => {
@@ -558,8 +561,44 @@ const useQrscan = (): UseQrscanReturn => {
 
   const resetPerformance = useCallback(() => {
     attemptTimesRef.current = [];
+    scanStartedAtRef.current = null;
+    setScanHint(null);
     setPerformance(createEmptyPerformance());
   }, []);
+
+  useEffect(() => {
+    if (!scanning) {
+      scanStartedAtRef.current = null;
+      setScanHint(null);
+      return undefined;
+    }
+    if (scanStartedAtRef.current === null) {
+      scanStartedAtRef.current = Date.now();
+    }
+    const interval = window.setInterval(() => {
+      if (performance.hits > 0) {
+        setScanHint(null);
+        return;
+      }
+      const startedAt = scanStartedAtRef.current;
+      if (startedAt === null) return;
+      const elapsed = Date.now() - startedAt;
+      if (elapsed < 4000) {
+        setScanHint(null);
+      } else if (elapsed < 9000) {
+        setScanHint('Centre the QR code inside the box and hold steady.');
+      } else {
+        setScanHint('No code yet — try moving closer or improving the lighting.');
+      }
+    }, 1000);
+    return () => window.clearInterval(interval);
+  }, [scanning, performance.hits]);
+
+  useEffect(() => {
+    if (performance.hits > 0) {
+      setScanHint(null);
+    }
+  }, [performance.hits]);
 
   const startInternal = useCallback(async (cameraOverride?: string) => {
     if (!isBrowser) return;
@@ -589,7 +628,11 @@ const useQrscan = (): UseQrscanReturn => {
       controlsRef.current = await startQrScan(
         video,
         (text, format) => handleCameraResult(text, format),
-        { deviceId: cameraId || undefined, onDecodeAttempt: handleDecodeAttempt },
+        {
+          deviceId: cameraId || undefined,
+          onDecodeAttempt: handleDecodeAttempt,
+          cropToCenterSquare: true,
+        },
       );
       setScanning(true);
       setCameraStatus('ready');
@@ -803,6 +846,7 @@ const useQrscan = (): UseQrscanReturn => {
     torch,
     zoom,
     performance,
+    scanHint,
     scanFromFile,
     processManualText,
   };

--- a/src/tools/qrscan/lib/qrscan.ts
+++ b/src/tools/qrscan/lib/qrscan.ts
@@ -57,6 +57,9 @@ export interface StartQrScanOptions {
   /** Fires after every worker reply (hit or miss) — use for a live HUD. */
   onDecodeAttempt?: (meta: DecodeAttemptMeta) => void;
   onError?: (error: Error) => void;
+  /** Crop the decode canvas to the centered square (matches the AR reticle).
+   * Speeds up decoding and focuses on what the user is aiming at. */
+  cropToCenterSquare?: boolean;
 }
 
 export const startQrScan = async (
@@ -76,6 +79,7 @@ export const startQrScan = async (
     deviceId: options.deviceId,
     onDecodeAttempt: options.onDecodeAttempt,
     onError: options.onError,
+    cropToCenterSquare: options.cropToCenterSquare,
     onResult: (text, engine, decodeMs) =>
       onResult(text, formatForEngine(engine), decodeMs),
   });

--- a/src/tools/qrscan/lib/scannerController.ts
+++ b/src/tools/qrscan/lib/scannerController.ts
@@ -51,6 +51,12 @@ export interface ScannerStartOptions {
   pauseWhenHidden?: boolean;
   runLevelPattern?: readonly RunLevel[];
   workerFactory?: () => Worker;
+  /** Crop the decode canvas to the centered square (matches the AR reticle).
+   * Decoding only the area the user is aiming at speeds up jsQR substantially
+   * and avoids wasted work on background pixels. Default false. */
+  cropToCenterSquare?: boolean;
+  /** Ideal camera height; pairs with initialWidth. Default 720. */
+  initialHeight?: number;
 }
 
 export interface ScannerHandle {
@@ -60,18 +66,24 @@ export interface ScannerHandle {
   getCanvasSize: () => { width: number; height: number };
 }
 
-const DEFAULT_INITIAL_WIDTH = 640;
-const DEFAULT_MIN_WIDTH = 320;
+const DEFAULT_INITIAL_WIDTH = 1280;
+const DEFAULT_INITIAL_HEIGHT = 720;
+const DEFAULT_MIN_WIDTH = 480;
 const DEFAULT_MAX_DECODE_MS = 30;
 const DEFAULT_DECODE_TIMEOUT_MS = 3000;
 
 const buildConstraints = (
   deviceId: string | undefined,
   idealWidth: number,
+  idealHeight: number,
 ): MediaStreamConstraints => {
+  const base: MediaTrackConstraints = {
+    width: { ideal: idealWidth },
+    height: { ideal: idealHeight },
+  };
   const videoConstraints: MediaTrackConstraints = deviceId
-    ? { deviceId: { exact: deviceId }, width: { ideal: idealWidth } }
-    : { facingMode: { ideal: 'environment' }, width: { ideal: idealWidth } };
+    ? { ...base, deviceId: { exact: deviceId } }
+    : { ...base, facingMode: { ideal: 'environment' } };
   return { audio: false, video: videoConstraints };
 };
 
@@ -85,12 +97,14 @@ export const startScanner = async (
     onDecodeAttempt,
     onError,
     initialWidth = DEFAULT_INITIAL_WIDTH,
+    initialHeight = DEFAULT_INITIAL_HEIGHT,
     minWidth = DEFAULT_MIN_WIDTH,
     maxDecodeMs = DEFAULT_MAX_DECODE_MS,
     decodeTimeoutMs = DEFAULT_DECODE_TIMEOUT_MS,
     pauseWhenHidden = true,
     runLevelPattern,
     workerFactory = createDefaultQrWorker,
+    cropToCenterSquare = false,
   } = options;
 
   if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
@@ -98,7 +112,7 @@ export const startScanner = async (
   }
 
   const stream = await navigator.mediaDevices.getUserMedia(
-    buildConstraints(deviceId, initialWidth),
+    buildConstraints(deviceId, initialWidth, initialHeight),
   );
 
   video.srcObject = stream;
@@ -273,9 +287,22 @@ export const startScanner = async (
       return;
     }
 
-    const aspect = video.videoHeight / video.videoWidth;
-    const targetWidth = Math.max(1, Math.min(currentWidth, video.videoWidth));
-    const targetHeight = Math.max(1, Math.round(targetWidth * aspect));
+    let sourceX = 0;
+    let sourceY = 0;
+    let sourceWidth = video.videoWidth;
+    let sourceHeight = video.videoHeight;
+
+    if (cropToCenterSquare) {
+      const side = Math.min(video.videoWidth, video.videoHeight);
+      sourceWidth = side;
+      sourceHeight = side;
+      sourceX = Math.round((video.videoWidth - side) / 2);
+      sourceY = Math.round((video.videoHeight - side) / 2);
+    }
+
+    const sourceAspect = sourceHeight / sourceWidth;
+    const targetWidth = Math.max(1, Math.min(currentWidth, sourceWidth));
+    const targetHeight = Math.max(1, Math.round(targetWidth * sourceAspect));
 
     if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
       canvas.width = targetWidth;
@@ -283,7 +310,17 @@ export const startScanner = async (
     }
 
     try {
-      ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+      ctx.drawImage(
+        video,
+        sourceX,
+        sourceY,
+        sourceWidth,
+        sourceHeight,
+        0,
+        0,
+        canvas.width,
+        canvas.height,
+      );
     } catch (drawError) {
       // drawImage can throw if the video frame is not decodable yet. Skip frame.
       reportError(drawError, 'Unable to draw video frame');


### PR DESCRIPTION
The decode pipeline was capping every frame at 640px wide, so a QR that filled ~1/6 of the camera view ended up around 80px in the canvas — right at the reliability cliff for jsQR/BarcodeDetector. The HUD recorded 22 attempts/sec, every one a miss.

- Bump default decode width 640 → 1280 and request a 1280×720 camera stream so the canvas has detail to read; the existing auto-downscale loop still kicks in if a device can't keep up.
- Add cropToCenterSquare option that decodes only the centred square matching the on-screen reticle. Roughly 4× fewer pixels per frame and focuses on what the user is aiming at.
- Surface a contextual hint after a few seconds without hits ("centre the code", "move closer / improve lighting") and replace the ambiguous "scanning…" HUD label with a frame counter so the user can see the pipeline is working.